### PR TITLE
Phase 1.5: Clerk Organizations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,11 @@ DATABASE_URL="postgresql://shearsimp:shearsimp_dev@localhost:5432/shearsimp?sche
 REDIS_URL="redis://localhost:6379"
 
 # --- Auth provider ---
-# "dev" uses DevAuthProvider (cookie-based fixed identity for local dev).
-# "clerk" uses ClerkAuthProvider (not yet implemented in Phase 1).
+# "dev"   = DevAuthProvider — signed cookie, fixed identity from DEV_* vars below.
+# "clerk" = ClerkAuthProvider — verifies Clerk session, mirrors orgs/users via webhook.
 AUTH_PROVIDER="dev"
 
+# --- Dev auth (used when AUTH_PROVIDER=dev) ---
 # Secret used to sign the dev session cookie. Change in any non-local environment.
 DEV_AUTH_SECRET="dev-secret-change-me"
 
@@ -18,10 +19,15 @@ DEV_USER_EMAIL="dev@shearsimp.local"
 DEV_SALON_ID="00000000-0000-0000-0000-0000000000a1"
 DEV_SALON_SLUG="dev-salon"
 
-# --- Clerk (Phase 1.5+) ---
-# CLERK_SECRET_KEY=
-# CLERK_PUBLISHABLE_KEY=
-# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+# --- Clerk (required when AUTH_PROVIDER=clerk) ---
+# Get these from https://dashboard.clerk.com → your app → API Keys.
+# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ships to the browser; CLERK_SECRET_KEY stays server-side.
+# CLERK_WEBHOOK_SECRET comes from dashboard → Webhooks → your endpoint → Signing Secret.
+# See README "Clerk setup" section for the full walkthrough.
+# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
+# CLERK_PUBLISHABLE_KEY="pk_test_..."
+# CLERK_SECRET_KEY="sk_test_..."
+# CLERK_WEBHOOK_SECRET="whsec_..."
 
 # --- Stripe (Phase 5+) ---
 # STRIPE_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,10 @@ DEV_SALON_SLUG="dev-salon"
 # --- Clerk (required when AUTH_PROVIDER=clerk) ---
 # Get these from https://dashboard.clerk.com → your app → API Keys.
 # NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ships to the browser; CLERK_SECRET_KEY stays server-side.
+# Both apps read the same publishable key — there is only one per Clerk app.
 # CLERK_WEBHOOK_SECRET comes from dashboard → Webhooks → your endpoint → Signing Secret.
 # See README "Clerk setup" section for the full walkthrough.
 # NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
-# CLERK_PUBLISHABLE_KEY="pk_test_..."
 # CLERK_SECRET_KEY="sk_test_..."
 # CLERK_WEBHOOK_SECRET="whsec_..."
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ First-time Clerk users — every step is clickable.
      ```
 
 4. **Wire the webhook (so orgs/users mirror into your DB)**
-   - In dev, expose your local API to Clerk via either:
-     - **Clerk CLI** — `npx @clerk/cli webhooks tunnel --port 3001` (recommended), or
-     - **ngrok** — `ngrok http 3001` and use the forwarded HTTPS URL.
+   - Clerk needs a public HTTPS URL to reach your local API. Pick one:
+     - **ngrok** — `ngrok http 3001` (free tier is fine; sign up once at
+       <https://ngrok.com> for a stable subdomain).
+     - **cloudflared** — `cloudflared tunnel --url http://localhost:3001`.
+     - **localtunnel** — `npx localtunnel --port 3001`.
    - Dashboard → **Webhooks** → **Add endpoint**.
    - Endpoint URL: `<tunnel-url>/webhooks/clerk`.
    - Subscribe to:

--- a/README.md
+++ b/README.md
@@ -54,8 +54,52 @@ pnpm dev
 `__shearsimp_dev_session` cookie. The Nest API reads the same cookie to
 resolve a fixed user + salon identity that matches the seeded fixture.
 
-To swap to Clerk later: set `AUTH_PROVIDER=clerk`, supply Clerk keys, and the
-`ClerkAuthProvider` (Phase 1.5) takes over without any controller changes.
+## Clerk setup (Phase 1.5)
+
+Switch from the dev provider to real authentication via Clerk Organizations.
+First-time Clerk users — every step is clickable.
+
+1. **Create the Clerk app**
+   - Sign in at <https://dashboard.clerk.com> and click **Create application**.
+   - Give it a name (e.g. *ShearSimplicity Dev*), pick the sign-in methods you
+     want (email + Google is a good default), then **Create application**.
+
+2. **Enable Organizations**
+   - In the dashboard sidebar: **Organizations Management** → toggle
+     **Enable organizations**.
+   - Under **Organization settings**, allow members to create their own
+     organizations (so dev sign-up creates a salon for you).
+
+3. **Copy API keys into `.env`**
+   - Dashboard → **API Keys**. Copy the **Publishable key** and **Secret key**
+     into your `.env`:
+     ```
+     AUTH_PROVIDER="clerk"
+     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
+     CLERK_PUBLISHABLE_KEY="pk_test_..."
+     CLERK_SECRET_KEY="sk_test_..."
+     ```
+
+4. **Wire the webhook (so orgs/users mirror into your DB)**
+   - In dev, expose your local API to Clerk via either:
+     - **Clerk CLI** — `npx @clerk/cli webhooks tunnel --port 3001` (recommended), or
+     - **ngrok** — `ngrok http 3001` and use the forwarded HTTPS URL.
+   - Dashboard → **Webhooks** → **Add endpoint**.
+   - Endpoint URL: `<tunnel-url>/webhooks/clerk`.
+   - Subscribe to:
+     `user.created`, `user.updated`, `user.deleted`,
+     `organization.created`, `organization.updated`, `organization.deleted`,
+     `organizationMembership.created`, `organizationMembership.updated`, `organizationMembership.deleted`,
+     `organizationInvitation.created`, `organizationInvitation.accepted`, `organizationInvitation.revoked`.
+   - After creation, copy the **Signing Secret** into `.env` as
+     `CLERK_WEBHOOK_SECRET="whsec_..."`.
+
+5. **Restart `pnpm dev`**, sign up at <http://localhost:3000/sign-up>, create
+   an organization, and the Topbar's **OrganizationSwitcher** lights up. The
+   webhook will mirror your Clerk org into the `salons` table; if it lags, the
+   `ClerkAuthProvider` self-heals on first request and logs a warning.
+
+To swap back: set `AUTH_PROVIDER=dev` and restart — no other change needed.
 
 ## Tenant isolation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ First-time Clerk users — every step is clickable.
      ```
      AUTH_PROVIDER="clerk"
      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
-     CLERK_PUBLISHABLE_KEY="pk_test_..."
      CLERK_SECRET_KEY="sk_test_..."
      ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,17 +53,22 @@ PR: [#1](https://github.com/jnoecker/ShearSimplicity/pull/1)
 - Enum parity test between `@shearsimp/shared` and Prisma
 - `dotenv-cli` so Prisma scripts pick up the root `.env`
 
-## Phase 1.5 — Clerk Organizations 🟡
+## Phase 1.5 — Clerk Organizations 🚧
 
 Replace `DevAuthProvider` with a real auth flow without changing controllers.
 
-- `@clerk/nextjs` middleware + `<ClerkProvider>` in `apps/web`
-- Implement `ClerkAuthProvider` in `apps/api` using `@clerk/backend`'s `authenticateRequest` / `verifyToken`
-- Org switcher topbar wired to `useOrganizationList()`
-- Clerk webhook → mirror `User` and `Salon` rows (idempotent on Clerk event ID); link `clerkOrgId` and `clerkUserId` for lookup
-- Invite flow → `SalonMembership` row with `MembershipStatus.INVITED`
-- Sign-out + session expiry parity with the web cookie behavior
-- E2E: dev mode and Clerk mode both pass the same test suite (toggle via `AUTH_PROVIDER`)
+- `@clerk/nextjs` middleware + conditional `<ClerkProvider>` in `apps/web`
+- `ClerkAuthProvider` in `apps/api` via `@clerk/backend`'s `authenticateRequest`,
+  with self-heal `User` / `Salon` mirroring on first sign-in
+- Topbar wired to Clerk `<OrganizationSwitcher />` + `<UserButton />` in clerk mode
+- Clerk webhook → mirrors `User` / `Salon` / `SalonMembership` (idempotent on
+  Clerk event ID via shared `processed_webhook_events` table)
+- Invitations → `SalonMembership` row with `MembershipStatus.INVITED`,
+  flipped to `ACTIVE` on `organizationInvitation.accepted`
+- Sign-in/sign-up routes catchall under `[[...sign-in]]` so Clerk owns its
+  multi-step flow; dev mode still serves the cookie form at the same path
+- Vitest parity test: both providers produce equivalent `AuthIdentity` shapes
+  *(narrower than a full Playwright e2e — that's worth a future phase)*
 
 **Risks:** Clerk's Next SDK is intrusive; treat its boundary carefully so swap-back to dev mode stays cheap. Don't leak Clerk types into shared packages.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,9 +9,10 @@
     "start:prod": "node dist/main.js",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'lint: noop'",
-    "test": "echo 'test: noop'"
+    "test": "vitest run"
   },
   "dependencies": {
+    "@clerk/backend": "1",
     "@nestjs/common": "^10.4.7",
     "@nestjs/core": "^10.4.7",
     "@nestjs/platform-express": "^10.4.7",
@@ -21,6 +22,7 @@
     "cookie-parser": "^1.4.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "svix": "1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -33,6 +35,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "2"
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,12 +7,19 @@ import { TenantModule } from "./tenant/tenant.module";
 import { TenantGuard } from "./tenant/tenant.guard";
 import { HealthController } from "./health/health.controller";
 import { SalonsModule } from "./salons/salons.module";
+import { WebhooksModule } from "./webhooks/webhooks.module";
 
 // AuthGuard runs first; TenantGuard depends on the identity it attaches to
 // the request. Order matters: Nest evaluates global guards in registration
 // order.
 @Module({
-  imports: [PrismaModule, AuthModule, TenantModule, SalonsModule],
+  imports: [
+    PrismaModule,
+    AuthModule,
+    TenantModule,
+    SalonsModule,
+    WebhooksModule,
+  ],
   controllers: [HealthController],
   providers: [
     { provide: APP_GUARD, useClass: AuthGuard },

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,4 +1,6 @@
 import { Global, Module, type Provider } from "@nestjs/common";
+import { PrismaModule } from "../prisma/prisma.module";
+import { PrismaService } from "../prisma/prisma.service";
 import { env } from "../env";
 import { AUTH_PROVIDER } from "./auth-provider.interface";
 import { DevAuthProvider } from "./dev-auth.provider";
@@ -6,18 +8,20 @@ import { ClerkAuthProvider } from "./clerk-auth.provider";
 
 const authProviderFactory: Provider = {
   provide: AUTH_PROVIDER,
-  useFactory: () => {
+  inject: [PrismaService],
+  useFactory: (prisma: PrismaService) => {
     switch (env.AUTH_PROVIDER) {
       case "dev":
         return new DevAuthProvider();
       case "clerk":
-        return new ClerkAuthProvider();
+        return new ClerkAuthProvider(prisma);
     }
   },
 };
 
 @Global()
 @Module({
+  imports: [PrismaModule],
   providers: [authProviderFactory, DevAuthProvider, ClerkAuthProvider],
   exports: [AUTH_PROVIDER],
 })

--- a/apps/api/src/auth/clerk-auth.provider.ts
+++ b/apps/api/src/auth/clerk-auth.provider.ts
@@ -96,6 +96,23 @@ export class ClerkAuthProvider implements AuthProvider {
         .filter((p): p is string => Boolean(p))
         .join(" ") || null;
 
+    // organizationInvitation.created may have written a placeholder row
+    // keyed only on email (no clerkUserId yet). Adopt it instead of inserting
+    // a duplicate that would collide on the email unique index.
+    if (email) {
+      const placeholder = await this.prisma.user.findUnique({
+        where: { email },
+        select: { id: true, clerkUserId: true },
+      });
+      if (placeholder && placeholder.clerkUserId === null) {
+        return this.prisma.user.update({
+          where: { id: placeholder.id },
+          data: { clerkUserId, displayName },
+          select: { id: true, email: true },
+        });
+      }
+    }
+
     return this.prisma.user.upsert({
       where: { clerkUserId },
       create: { clerkUserId, email, displayName },

--- a/apps/api/src/auth/clerk-auth.provider.ts
+++ b/apps/api/src/auth/clerk-auth.provider.ts
@@ -35,7 +35,7 @@ export class ClerkAuthProvider implements AuthProvider {
       env.AUTH_PROVIDER === "clerk" && env.CLERK_SECRET_KEY
         ? createClerkClient({
             secretKey: env.CLERK_SECRET_KEY,
-            publishableKey: env.CLERK_PUBLISHABLE_KEY,
+            publishableKey: env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
           })
         : null;
   }

--- a/apps/api/src/auth/clerk-auth.provider.ts
+++ b/apps/api/src/auth/clerk-auth.provider.ts
@@ -1,22 +1,198 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
+import {
+  createClerkClient,
+  type AuthObject,
+  type ClerkClient,
+} from "@clerk/backend";
 import type { Request } from "express";
+import { MembershipStatus, Role } from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service";
+import { env } from "../env";
 import type { AuthIdentity } from "../context/request-context";
 import type { AuthProvider } from "./auth-provider.interface";
 
 /**
- * Phase 1.5 placeholder. The real implementation will verify the Clerk
- * session via `@clerk/backend`'s `authenticateRequest` / `verifyToken`,
- * and translate `clerkUserId` + `clerkOrgId` into an AuthIdentity by
- * looking them up in the `users` and `salons` tables.
+ * Verifies a Clerk session and translates `(clerkUserId, clerkOrgId)` into our
+ * domain `AuthIdentity` by looking up — and, when missing, mirroring — the
+ * corresponding `User` / `Salon` / `SalonMembership` rows.
  *
- * Selected when AUTH_PROVIDER=clerk; throws on first request to make the
- * gap obvious until implemented.
+ * The Clerk webhook (Phase 1.5) is the canonical sync path for these rows.
+ * The self-heal here is a backstop so first-sign-in or webhook lag never
+ * surfaces as a 401: we log a warning and create the missing rows on the fly.
+ *
+ * Active org selection: when the Clerk session has no `orgId` (user hasn't
+ * picked an org, or signed in to a personal account), `salonHint` is null —
+ * `@SkipTenant()` routes still work, tenant-scoped routes return 403 via
+ * the TenantGuard. That's the correct behavior.
  */
 @Injectable()
 export class ClerkAuthProvider implements AuthProvider {
-  async authenticate(_req: Request): Promise<AuthIdentity | null> {
-    throw new Error(
-      "ClerkAuthProvider is not implemented yet. Set AUTH_PROVIDER=dev or implement Phase 1.5.",
+  private readonly logger = new Logger(ClerkAuthProvider.name);
+  private readonly clerk: ClerkClient | null;
+
+  constructor(private readonly prisma: PrismaService) {
+    this.clerk =
+      env.AUTH_PROVIDER === "clerk" && env.CLERK_SECRET_KEY
+        ? createClerkClient({
+            secretKey: env.CLERK_SECRET_KEY,
+            publishableKey: env.CLERK_PUBLISHABLE_KEY,
+          })
+        : null;
+  }
+
+  async authenticate(req: Request): Promise<AuthIdentity | null> {
+    if (!this.clerk) {
+      throw new Error(
+        "ClerkAuthProvider selected but Clerk client is not configured",
+      );
+    }
+
+    const fetchReq = expressToFetchRequest(req);
+    const requestState = await this.clerk.authenticateRequest(fetchReq, {
+      authorizedParties: [env.WEB_ORIGIN],
+    });
+
+    if (!requestState.isSignedIn) {
+      return null;
+    }
+
+    const auth = requestState.toAuth();
+    if (!auth.userId) {
+      // toAuth() can still return a signed-out shape (e.g., pending session)
+      // even when the request state was signed-in. Treat as unauthenticated.
+      return null;
+    }
+
+    const user = await this.resolveUser(auth.userId);
+    const salonHint = auth.orgId
+      ? await this.resolveSalon(auth.orgId, user.id, auth.orgRole)
+      : null;
+
+    return {
+      userId: user.id,
+      email: user.email,
+      salonHint: salonHint
+        ? { salonId: salonHint.salonId, slug: salonHint.slug }
+        : null,
+    };
+  }
+
+  private async resolveUser(
+    clerkUserId: string,
+  ): Promise<{ id: string; email: string | null }> {
+    const existing = await this.prisma.user.findUnique({
+      where: { clerkUserId },
+      select: { id: true, email: true },
+    });
+    if (existing) return existing;
+
+    this.logger.warn(
+      `Mirroring Clerk user ${clerkUserId} on demand — webhook may be lagging`,
     );
+    const clerkUser = await this.clerk!.users.getUser(clerkUserId);
+    const email = clerkUser.primaryEmailAddress?.emailAddress ?? null;
+    const displayName =
+      [clerkUser.firstName, clerkUser.lastName]
+        .filter((p): p is string => Boolean(p))
+        .join(" ") || null;
+
+    return this.prisma.user.upsert({
+      where: { clerkUserId },
+      create: { clerkUserId, email, displayName },
+      update: {},
+      select: { id: true, email: true },
+    });
+  }
+
+  private async resolveSalon(
+    clerkOrgId: string,
+    userId: string,
+    orgRole: AuthObject["orgRole"],
+  ): Promise<{ salonId: string; slug: string } | null> {
+    let salon = await this.prisma.salon.findUnique({
+      where: { clerkOrgId },
+      select: { id: true, slug: true, isActive: true },
+    });
+
+    if (!salon) {
+      this.logger.warn(
+        `Mirroring Clerk org ${clerkOrgId} on demand — webhook may be lagging`,
+      );
+      const org = await this.clerk!.organizations.getOrganization({
+        organizationId: clerkOrgId,
+      });
+      const slug = await this.uniqueSalonSlug(org.slug ?? clerkOrgId);
+      salon = await this.prisma.salon.upsert({
+        where: { clerkOrgId },
+        create: { clerkOrgId, name: org.name, slug },
+        update: {},
+        select: { id: true, slug: true, isActive: true },
+      });
+    }
+
+    if (!salon.isActive) return null;
+
+    await this.prisma.salonMembership.upsert({
+      where: { salonId_userId: { salonId: salon.id, userId } },
+      create: {
+        salonId: salon.id,
+        userId,
+        role: clerkRoleToRole(orgRole),
+        status: MembershipStatus.ACTIVE,
+      },
+      update: {},
+    });
+
+    return { salonId: salon.id, slug: salon.slug };
+  }
+
+  // Salon slugs are globally unique in our schema; Clerk org slugs are unique
+  // within Clerk but might collide with existing rows. Append a short suffix
+  // until we find a free one.
+  private async uniqueSalonSlug(base: string): Promise<string> {
+    const candidate = base.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
+    for (let i = 0; i < 5; i++) {
+      const slug = i === 0 ? candidate : `${candidate}-${i + 1}`;
+      const taken = await this.prisma.salon.findUnique({
+        where: { slug },
+        select: { id: true },
+      });
+      if (!taken) return slug;
+    }
+    return `${candidate}-${Date.now()}`;
   }
 }
+
+// Clerk's default org roles are `org:admin` and `org:member`. Custom roles can
+// be defined in the Clerk dashboard; map them in this function as they appear.
+export function clerkRoleToRole(orgRole: string | null | undefined): Role {
+  switch (orgRole) {
+    case "org:admin":
+      return Role.OWNER;
+    case "org:member":
+      return Role.STYLIST;
+    default:
+      return Role.STYLIST;
+  }
+}
+
+// Convert an Express request to a Fetch API Request so @clerk/backend can
+// read the headers/cookies it needs. We don't forward the body (Clerk doesn't
+// look at it for session verification).
+export function expressToFetchRequest(req: Request): Request_ {
+  const protocol = (req.headers["x-forwarded-proto"] as string) ?? req.protocol;
+  const host = req.get("host") ?? "localhost";
+  const url = `${protocol}://${host}${req.originalUrl}`;
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(name, v);
+    } else if (typeof value === "string") {
+      headers.set(name, value);
+    }
+  }
+  return new Request(url, { method: req.method, headers });
+}
+
+// Local alias to avoid colliding with the Express Request import.
+type Request_ = globalThis.Request;

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,20 +1,39 @@
 import { z } from "zod";
 
-const schema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  API_PORT: z.coerce.number().int().positive().default(3001),
-  WEB_ORIGIN: z.string().url().default("http://localhost:3000"),
-  DATABASE_URL: z.string().min(1),
+const schema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+    API_PORT: z.coerce.number().int().positive().default(3001),
+    WEB_ORIGIN: z.string().url().default("http://localhost:3000"),
+    DATABASE_URL: z.string().min(1),
 
-  AUTH_PROVIDER: z.enum(["dev", "clerk"]).default("dev"),
-  DEV_AUTH_SECRET: z.string().min(8).default("dev-secret-change-me"),
-  DEV_USER_ID: z.string().uuid(),
-  DEV_USER_EMAIL: z.string().email(),
-  DEV_SALON_ID: z.string().uuid(),
-  DEV_SALON_SLUG: z.string().min(1),
+    AUTH_PROVIDER: z.enum(["dev", "clerk"]).default("dev"),
+    DEV_AUTH_SECRET: z.string().min(8).default("dev-secret-change-me"),
+    DEV_USER_ID: z.string().uuid(),
+    DEV_USER_EMAIL: z.string().email(),
+    DEV_SALON_ID: z.string().uuid(),
+    DEV_SALON_SLUG: z.string().min(1),
 
-  CLERK_SECRET_KEY: z.string().optional(),
-});
+    CLERK_SECRET_KEY: z.string().optional(),
+    CLERK_PUBLISHABLE_KEY: z.string().optional(),
+    CLERK_WEBHOOK_SECRET: z.string().optional(),
+  })
+  .superRefine((env, ctx) => {
+    if (env.AUTH_PROVIDER !== "clerk") return;
+    for (const key of [
+      "CLERK_SECRET_KEY",
+      "CLERK_PUBLISHABLE_KEY",
+      "CLERK_WEBHOOK_SECRET",
+    ] as const) {
+      if (!env[key]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} is required when AUTH_PROVIDER=clerk`,
+        });
+      }
+    }
+  });
 
 export type Env = z.infer<typeof schema>;
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -15,14 +15,17 @@ const schema = z
     DEV_SALON_SLUG: z.string().min(1),
 
     CLERK_SECRET_KEY: z.string().optional(),
-    CLERK_PUBLISHABLE_KEY: z.string().optional(),
+    // Clerk issues a single publishable key per app. The web side reads it
+    // from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (the prefix is required for
+    // Next.js to expose it to the browser); the API reads the same value.
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().optional(),
     CLERK_WEBHOOK_SECRET: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     if (env.AUTH_PROVIDER !== "clerk") return;
     for (const key of [
       "CLERK_SECRET_KEY",
-      "CLERK_PUBLISHABLE_KEY",
+      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
       "CLERK_WEBHOOK_SECRET",
     ] as const) {
       if (!env[key]) {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,6 +8,10 @@ import { env } from "./env";
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule, {
     logger: ["error", "warn", "log"],
+    // Required for the Clerk webhook controller to access the unparsed body
+    // for svix signature verification. Body parsing still happens for other
+    // routes — `rawBody` is just kept alongside the parsed body.
+    rawBody: true,
   });
 
   app.use(cookieParser(env.DEV_AUTH_SECRET));

--- a/apps/api/src/webhooks/clerk-webhook.controller.ts
+++ b/apps/api/src/webhooks/clerk-webhook.controller.ts
@@ -1,0 +1,67 @@
+import {
+  BadRequestException,
+  Controller,
+  HttpCode,
+  Post,
+  Req,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { Webhook, WebhookVerificationError } from "svix";
+import { Public } from "../auth/public.decorator";
+import { SkipTenant } from "../tenant/skip-tenant.decorator";
+import { env } from "../env";
+import {
+  ClerkWebhookService,
+  type ClerkWebhookEvent,
+} from "./clerk-webhook.service";
+
+/**
+ * Clerk → ShearSimplicity sync. Configured in the Clerk dashboard
+ * (Webhooks → add endpoint, point at `<api>/webhooks/clerk`, copy the
+ * signing secret into `CLERK_WEBHOOK_SECRET`).
+ *
+ * Public + SkipTenant: the request carries no session — its trust is
+ * established entirely by the svix signature.
+ */
+@Controller("webhooks/clerk")
+export class ClerkWebhookController {
+  constructor(private readonly service: ClerkWebhookService) {}
+
+  @Public()
+  @SkipTenant()
+  @Post()
+  @HttpCode(200)
+  async handle(@Req() req: Request): Promise<{ received: true }> {
+    if (!env.CLERK_WEBHOOK_SECRET) {
+      throw new BadRequestException("Clerk webhook secret not configured");
+    }
+
+    const raw = (req as Request & { rawBody?: Buffer }).rawBody;
+    if (!raw) {
+      throw new BadRequestException("Raw body unavailable for signature check");
+    }
+
+    const headers = {
+      "svix-id": req.header("svix-id") ?? "",
+      "svix-timestamp": req.header("svix-timestamp") ?? "",
+      "svix-signature": req.header("svix-signature") ?? "",
+    };
+
+    let event: ClerkWebhookEvent;
+    try {
+      event = new Webhook(env.CLERK_WEBHOOK_SECRET).verify(
+        raw.toString("utf8"),
+        headers,
+      ) as ClerkWebhookEvent;
+    } catch (err) {
+      if (err instanceof WebhookVerificationError) {
+        throw new BadRequestException("Invalid Clerk webhook signature");
+      }
+      throw err;
+    }
+
+    const eventId = headers["svix-id"];
+    await this.service.process(eventId, event);
+    return { received: true };
+  }
+}

--- a/apps/api/src/webhooks/clerk-webhook.service.ts
+++ b/apps/api/src/webhooks/clerk-webhook.service.ts
@@ -1,0 +1,320 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Prisma, MembershipStatus } from "@prisma/client";
+import { PrismaService } from "../prisma/prisma.service";
+import { clerkRoleToRole } from "../auth/clerk-auth.provider";
+
+const SOURCE = "clerk";
+
+// Minimal subset of the Clerk webhook event shapes we care about. Clerk's
+// schema is large; typing only what we read keeps this file legible.
+export type ClerkWebhookEvent =
+  | {
+      type: "user.created" | "user.updated";
+      data: {
+        id: string;
+        email_addresses?: Array<{ id: string; email_address: string }>;
+        primary_email_address_id?: string | null;
+        first_name?: string | null;
+        last_name?: string | null;
+      };
+    }
+  | { type: "user.deleted"; data: { id: string; deleted?: boolean } }
+  | {
+      type: "organization.created" | "organization.updated";
+      data: { id: string; name: string; slug: string | null };
+    }
+  | { type: "organization.deleted"; data: { id: string; deleted?: boolean } }
+  | {
+      type:
+        | "organizationMembership.created"
+        | "organizationMembership.updated";
+      data: {
+        organization: { id: string };
+        public_user_data: { user_id: string };
+        role: string;
+      };
+    }
+  | {
+      type: "organizationMembership.deleted";
+      data: {
+        organization: { id: string };
+        public_user_data: { user_id: string };
+      };
+    }
+  | {
+      type: "organizationInvitation.created";
+      data: {
+        id: string;
+        organization_id: string;
+        email_address: string;
+        role: string;
+      };
+    }
+  | {
+      type:
+        | "organizationInvitation.accepted"
+        | "organizationInvitation.revoked";
+      data: { id: string; organization_id: string; email_address: string };
+    };
+
+/**
+ * Mirrors Clerk state into our `users`, `salons`, and `salon_memberships`
+ * tables. Each call is wrapped in a transaction that:
+ *   1. Inserts a `processed_webhook_events` row keyed on (source, eventId).
+ *   2. Performs the side effect.
+ *
+ * The unique constraint on (source, externalEventId) makes Clerk re-deliveries
+ * a no-op — if the insert fails with P2002, we've already processed it.
+ */
+@Injectable()
+export class ClerkWebhookService {
+  private readonly logger = new Logger(ClerkWebhookService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async process(eventId: string, event: ClerkWebhookEvent): Promise<void> {
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.processedWebhookEvent.create({
+          data: {
+            source: SOURCE,
+            externalEventId: eventId,
+            eventType: event.type,
+          },
+        });
+        await this.apply(tx, event);
+      });
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002"
+      ) {
+        this.logger.log(`Clerk event ${eventId} already processed; skipping`);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async apply(
+    tx: Prisma.TransactionClient,
+    event: ClerkWebhookEvent,
+  ): Promise<void> {
+    switch (event.type) {
+      case "user.created":
+      case "user.updated": {
+        const { id, first_name, last_name } = event.data;
+        const email = primaryEmail(event.data);
+        const displayName =
+          [first_name, last_name].filter((p): p is string => Boolean(p)).join(
+            " ",
+          ) || null;
+        await tx.user.upsert({
+          where: { clerkUserId: id },
+          create: { clerkUserId: id, email, displayName },
+          update: { email, displayName },
+        });
+        return;
+      }
+
+      case "user.deleted": {
+        // We don't hard-delete users — rows may be referenced by historical
+        // appointments. Strip the Clerk linkage so a re-created Clerk user
+        // doesn't collide on the unique index.
+        await tx.user.updateMany({
+          where: { clerkUserId: event.data.id },
+          data: { clerkUserId: null },
+        });
+        return;
+      }
+
+      case "organization.created":
+      case "organization.updated": {
+        const { id, name, slug } = event.data;
+        const finalSlug = await uniqueSlug(tx, slug ?? id, id);
+        await tx.salon.upsert({
+          where: { clerkOrgId: id },
+          create: { clerkOrgId: id, name, slug: finalSlug },
+          update: { name, slug: finalSlug },
+        });
+        return;
+      }
+
+      case "organization.deleted": {
+        // Soft-deactivate. Same reasoning as user.deleted — appointments,
+        // payments, etc. depend on the salonId.
+        await tx.salon.updateMany({
+          where: { clerkOrgId: event.data.id },
+          data: { isActive: false, clerkOrgId: null },
+        });
+        return;
+      }
+
+      case "organizationMembership.created":
+      case "organizationMembership.updated": {
+        const link = await resolveOrgUser(
+          tx,
+          event.data.organization.id,
+          event.data.public_user_data.user_id,
+        );
+        if (!link) return;
+        await tx.salonMembership.upsert({
+          where: {
+            salonId_userId: { salonId: link.salonId, userId: link.userId },
+          },
+          create: {
+            salonId: link.salonId,
+            userId: link.userId,
+            role: clerkRoleToRole(event.data.role),
+            status: MembershipStatus.ACTIVE,
+          },
+          update: {
+            role: clerkRoleToRole(event.data.role),
+            status: MembershipStatus.ACTIVE,
+          },
+        });
+        return;
+      }
+
+      case "organizationMembership.deleted": {
+        const link = await resolveOrgUser(
+          tx,
+          event.data.organization.id,
+          event.data.public_user_data.user_id,
+        );
+        if (!link) return;
+        await tx.salonMembership.updateMany({
+          where: { salonId: link.salonId, userId: link.userId },
+          data: { status: MembershipStatus.REMOVED },
+        });
+        return;
+      }
+
+      case "organizationInvitation.created": {
+        const salon = await tx.salon.findUnique({
+          where: { clerkOrgId: event.data.organization_id },
+          select: { id: true },
+        });
+        if (!salon) return;
+        // The invited user may not have a Clerk account yet, so we have no
+        // Clerk user id to link on. Create a placeholder User keyed on email
+        // and a SalonMembership in INVITED state. organization.membership.*
+        // reconciles when the invite is accepted.
+        const user = await tx.user.upsert({
+          where: { email: event.data.email_address },
+          create: { email: event.data.email_address },
+          update: {},
+        });
+        await tx.salonMembership.upsert({
+          where: { salonId_userId: { salonId: salon.id, userId: user.id } },
+          create: {
+            salonId: salon.id,
+            userId: user.id,
+            role: clerkRoleToRole(event.data.role),
+            status: MembershipStatus.INVITED,
+            invitedAt: new Date(),
+          },
+          update: {
+            role: clerkRoleToRole(event.data.role),
+            status: MembershipStatus.INVITED,
+            invitedAt: new Date(),
+          },
+        });
+        return;
+      }
+
+      case "organizationInvitation.accepted": {
+        const salon = await tx.salon.findUnique({
+          where: { clerkOrgId: event.data.organization_id },
+          select: { id: true },
+        });
+        const user = await tx.user.findUnique({
+          where: { email: event.data.email_address },
+          select: { id: true },
+        });
+        if (!salon || !user) return;
+        await tx.salonMembership.updateMany({
+          where: { salonId: salon.id, userId: user.id },
+          data: { status: MembershipStatus.ACTIVE },
+        });
+        return;
+      }
+
+      case "organizationInvitation.revoked": {
+        const salon = await tx.salon.findUnique({
+          where: { clerkOrgId: event.data.organization_id },
+          select: { id: true },
+        });
+        const user = await tx.user.findUnique({
+          where: { email: event.data.email_address },
+          select: { id: true },
+        });
+        if (!salon || !user) return;
+        await tx.salonMembership.updateMany({
+          where: { salonId: salon.id, userId: user.id },
+          data: { status: MembershipStatus.REMOVED },
+        });
+        return;
+      }
+
+      default: {
+        const _exhaustive: never = event;
+        this.logger.warn(
+          `Unhandled Clerk event type: ${(_exhaustive as { type: string }).type}`,
+        );
+      }
+    }
+  }
+}
+
+function primaryEmail(data: {
+  email_addresses?: Array<{ id: string; email_address: string }>;
+  primary_email_address_id?: string | null;
+}): string | null {
+  if (!data.email_addresses?.length) return null;
+  const primary = data.email_addresses.find(
+    (e) => e.id === data.primary_email_address_id,
+  );
+  return (primary ?? data.email_addresses[0])?.email_address ?? null;
+}
+
+// Resolves a Clerk (orgId, userId) pair to our internal (salonId, userId).
+// Returns null if either side hasn't been mirrored yet — the corresponding
+// `organization.created` or `user.created` event will arrive shortly and the
+// membership event will be redelivered.
+async function resolveOrgUser(
+  tx: Prisma.TransactionClient,
+  clerkOrgId: string,
+  clerkUserId: string,
+): Promise<{ salonId: string; userId: string } | null> {
+  const [salon, user] = await Promise.all([
+    tx.salon.findUnique({
+      where: { clerkOrgId },
+      select: { id: true },
+    }),
+    tx.user.findUnique({
+      where: { clerkUserId },
+      select: { id: true },
+    }),
+  ]);
+  if (!salon || !user) return null;
+  return { salonId: salon.id, userId: user.id };
+}
+
+async function uniqueSlug(
+  tx: Prisma.TransactionClient,
+  base: string,
+  clerkOrgId: string,
+): Promise<string> {
+  const candidate = base.toLowerCase().replace(/[^a-z0-9-]+/g, "-") || "salon";
+  for (let i = 0; i < 5; i++) {
+    const slug = i === 0 ? candidate : `${candidate}-${i + 1}`;
+    const taken = await tx.salon.findUnique({
+      where: { slug },
+      select: { clerkOrgId: true },
+    });
+    if (!taken || taken.clerkOrgId === clerkOrgId) return slug;
+  }
+  return `${candidate}-${Date.now()}`;
+}
+

--- a/apps/api/src/webhooks/clerk-webhook.service.ts
+++ b/apps/api/src/webhooks/clerk-webhook.service.ts
@@ -85,10 +85,10 @@ export class ClerkWebhookService {
         await this.apply(tx, event);
       });
     } catch (err) {
-      if (
-        err instanceof Prisma.PrismaClientKnownRequestError &&
-        err.code === "P2002"
-      ) {
+      // Narrow to the idempotency-key uniqueness violation. A P2002 from
+      // anywhere else inside `apply` is a real error and must propagate so
+      // svix retries it — otherwise we'd silently drop genuine failures.
+      if (isProcessedWebhookEventDuplicate(err)) {
         this.logger.log(`Clerk event ${eventId} already processed; skipping`);
         return;
       }
@@ -265,6 +265,22 @@ export class ClerkWebhookService {
       }
     }
   }
+}
+
+function isProcessedWebhookEventDuplicate(err: unknown): boolean {
+  if (!(err instanceof Prisma.PrismaClientKnownRequestError)) return false;
+  if (err.code !== "P2002") return false;
+  // Prisma reports `target` as either an array of column names or the
+  // constraint name string, depending on adapter version. Match either shape
+  // against our (source, externalEventId) unique index.
+  const target = (err.meta as { target?: unknown } | undefined)?.target;
+  if (Array.isArray(target)) {
+    return target.includes("source") && target.includes("externalEventId");
+  }
+  if (typeof target === "string") {
+    return target.includes("source") && target.includes("externalEventId");
+  }
+  return false;
 }
 
 function primaryEmail(data: {

--- a/apps/api/src/webhooks/clerk-webhook.service.ts
+++ b/apps/api/src/webhooks/clerk-webhook.service.ts
@@ -109,6 +109,22 @@ export class ClerkWebhookService {
           [first_name, last_name].filter((p): p is string => Boolean(p)).join(
             " ",
           ) || null;
+        // If an invitation already created a placeholder row keyed on email
+        // (clerkUserId still null), adopt it. Without this, user.created for
+        // an invited user collides on the email unique index.
+        if (email) {
+          const placeholder = await tx.user.findUnique({
+            where: { email },
+            select: { id: true, clerkUserId: true },
+          });
+          if (placeholder && placeholder.clerkUserId === null) {
+            await tx.user.update({
+              where: { id: placeholder.id },
+              data: { clerkUserId: id, email, displayName },
+            });
+            return;
+          }
+        }
         await tx.user.upsert({
           where: { clerkUserId: id },
           create: { clerkUserId: id, email, displayName },

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { ClerkWebhookController } from "./clerk-webhook.controller";
+import { ClerkWebhookService } from "./clerk-webhook.service";
+
+@Module({
+  controllers: [ClerkWebhookController],
+  providers: [ClerkWebhookService],
+})
+export class WebhooksModule {}

--- a/apps/api/test/auth-provider-parity.test.ts
+++ b/apps/api/test/auth-provider-parity.test.ts
@@ -84,7 +84,7 @@ describe("AuthProvider parity", () => {
     // constructor branch that initialises the Clerk client.
     process.env.AUTH_PROVIDER = "clerk";
     process.env.CLERK_SECRET_KEY = "sk_test_fake";
-    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_fake";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_fake";
     process.env.CLERK_WEBHOOK_SECRET = "whsec_fake";
 
     const { createClerkClient } = await import("@clerk/backend");
@@ -159,7 +159,7 @@ describe("AuthProvider parity", () => {
   it("ClerkAuthProvider returns null when the request is not signed in", async () => {
     process.env.AUTH_PROVIDER = "clerk";
     process.env.CLERK_SECRET_KEY = "sk_test_fake";
-    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_fake";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_fake";
     process.env.CLERK_WEBHOOK_SECRET = "whsec_fake";
 
     const { createClerkClient } = await import("@clerk/backend");

--- a/apps/api/test/auth-provider-parity.test.ts
+++ b/apps/api/test/auth-provider-parity.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request } from "express";
+
+import {
+  DEV_SESSION_COOKIE,
+  DevAuthProvider,
+  signDevSession,
+} from "../src/auth/dev-auth.provider";
+import { env } from "../src/env";
+
+// Clerk's createClerkClient is mocked at the module boundary so the test
+// never reaches the network. We test the provider's translation logic only.
+vi.mock("@clerk/backend", () => {
+  return {
+    createClerkClient: vi.fn(),
+  };
+});
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const SALON_ID = "22222222-2222-2222-2222-222222222222";
+
+function fakeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    cookies: {},
+    headers: { host: "localhost:3001" },
+    method: "GET",
+    originalUrl: "/health",
+    protocol: "http",
+    get: (h: string) => (h.toLowerCase() === "host" ? "localhost:3001" : undefined),
+    header: (h: string) =>
+      (h.toLowerCase() === "host" ? "localhost:3001" : undefined),
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe("AuthProvider parity", () => {
+  it("DevAuthProvider returns an AuthIdentity from a valid signed cookie", async () => {
+    const provider = new DevAuthProvider();
+    const cookie = signDevSession(
+      {
+        userId: USER_ID,
+        email: "owner@example.com",
+        salonId: SALON_ID,
+        salonSlug: "test-salon",
+      },
+      env.DEV_AUTH_SECRET,
+    );
+    const req = fakeRequest({ cookies: { [DEV_SESSION_COOKIE]: cookie } });
+
+    const identity = await provider.authenticate(req);
+
+    expect(identity).toEqual({
+      userId: USER_ID,
+      email: "owner@example.com",
+      salonHint: { salonId: SALON_ID, slug: "test-salon" },
+    });
+  });
+
+  it("DevAuthProvider returns null when the cookie is missing", async () => {
+    const provider = new DevAuthProvider();
+    const identity = await provider.authenticate(fakeRequest());
+    expect(identity).toBeNull();
+  });
+
+  it("DevAuthProvider rejects a tampered cookie", async () => {
+    const provider = new DevAuthProvider();
+    const cookie = signDevSession(
+      {
+        userId: USER_ID,
+        email: "owner@example.com",
+        salonId: SALON_ID,
+        salonSlug: "test-salon",
+      },
+      "wrong-secret",
+    );
+    const req = fakeRequest({ cookies: { [DEV_SESSION_COOKIE]: cookie } });
+    const identity = await provider.authenticate(req);
+    expect(identity).toBeNull();
+  });
+
+  it("ClerkAuthProvider produces an AuthIdentity with the same shape as DevAuthProvider", async () => {
+    // We import lazily so the mocked createClerkClient is in place before
+    // the provider constructs its client. Force AUTH_PROVIDER=clerk for the
+    // constructor branch that initialises the Clerk client.
+    process.env.AUTH_PROVIDER = "clerk";
+    process.env.CLERK_SECRET_KEY = "sk_test_fake";
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_fake";
+    process.env.CLERK_WEBHOOK_SECRET = "whsec_fake";
+
+    const { createClerkClient } = await import("@clerk/backend");
+    const authenticateRequest = vi.fn().mockResolvedValue({
+      isSignedIn: true,
+      toAuth: () => ({
+        userId: "user_clerk_abc",
+        orgId: "org_clerk_xyz",
+        orgRole: "org:admin",
+      }),
+    });
+    (createClerkClient as ReturnType<typeof vi.fn>).mockReturnValue({
+      authenticateRequest,
+      users: {
+        getUser: vi.fn().mockResolvedValue({
+          primaryEmailAddress: { emailAddress: "owner@example.com" },
+          firstName: "Owner",
+          lastName: "Example",
+        }),
+      },
+      organizations: {
+        getOrganization: vi.fn().mockResolvedValue({
+          name: "Acme",
+          slug: "acme",
+        }),
+      },
+    });
+
+    // Re-import after AUTH_PROVIDER flip so the constructor takes the
+    // clerk branch.
+    vi.resetModules();
+    const { ClerkAuthProvider } = await import(
+      "../src/auth/clerk-auth.provider"
+    );
+
+    const prismaMock = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: USER_ID,
+          email: "owner@example.com",
+        }),
+      },
+      salon: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: SALON_ID,
+          slug: "acme",
+          isActive: true,
+        }),
+      },
+      salonMembership: {
+        upsert: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    const provider = new ClerkAuthProvider(prismaMock as never);
+    const identity = await provider.authenticate(fakeRequest());
+
+    expect(identity).toEqual({
+      userId: USER_ID,
+      email: "owner@example.com",
+      salonHint: { salonId: SALON_ID, slug: "acme" },
+    });
+
+    // Both providers produce values that satisfy the same AuthIdentity
+    // contract — the AuthGuard and TenantGuard don't need to know which
+    // one ran.
+    expect(Object.keys(identity!).sort()).toEqual(
+      ["email", "salonHint", "userId"].sort(),
+    );
+  });
+
+  it("ClerkAuthProvider returns null when the request is not signed in", async () => {
+    process.env.AUTH_PROVIDER = "clerk";
+    process.env.CLERK_SECRET_KEY = "sk_test_fake";
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_fake";
+    process.env.CLERK_WEBHOOK_SECRET = "whsec_fake";
+
+    const { createClerkClient } = await import("@clerk/backend");
+    (createClerkClient as ReturnType<typeof vi.fn>).mockReturnValue({
+      authenticateRequest: vi
+        .fn()
+        .mockResolvedValue({ isSignedIn: false, toAuth: () => ({}) }),
+    });
+
+    vi.resetModules();
+    const { ClerkAuthProvider } = await import(
+      "../src/auth/clerk-auth.provider"
+    );
+    const provider = new ClerkAuthProvider({} as never);
+    const identity = await provider.authenticate(fakeRequest());
+    expect(identity).toBeNull();
+  });
+});

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -1,0 +1,11 @@
+// Vitest setup: ensure required env vars are present before any test file
+// imports `env.ts` (which validates at module load).
+process.env.NODE_ENV = "test";
+process.env.DATABASE_URL ??=
+  "postgresql://shearsimp:shearsimp_dev@localhost:5432/shearsimp?schema=public";
+process.env.AUTH_PROVIDER ??= "dev";
+process.env.DEV_AUTH_SECRET ??= "test-secret-12345";
+process.env.DEV_USER_ID ??= "00000000-0000-0000-0000-000000000001";
+process.env.DEV_USER_EMAIL ??= "dev@shearsimp.test";
+process.env.DEV_SALON_ID ??= "00000000-0000-0000-0000-0000000000a1";
+process.env.DEV_SALON_SLUG ??= "test-salon";

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+    setupFiles: ["./test/setup.ts"],
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "echo 'test: noop'"
   },
   "dependencies": {
+    "@clerk/nextjs": "6",
     "@shearsimp/shared": "workspace:*",
     "next": "^15.1.0",
     "react": "^19.0.0",

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { Sidebar } from "@/components/sidebar";
 import { Topbar } from "@/components/topbar";
 import { getServerSession } from "@/lib/session";
+import { serverEnv } from "@/lib/env";
 
 export default async function AppLayout({
   children,
@@ -24,7 +25,9 @@ export default async function AppLayout({
       <Sidebar activeHref={activeHref} />
       <div className="pl-56">
         <Topbar
-          salonName={`Acme Salon (${session.salonSlug})`}
+          mode={serverEnv.authProvider}
+          salonName={session.salonName}
+          salonSlug={session.salonSlug}
           userEmail={session.email}
         />
         <main className="mx-auto max-w-6xl px-6 py-8">{children}</main>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { ClerkProvider } from "@clerk/nextjs";
+import { serverEnv } from "@/lib/env";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -11,9 +13,16 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
+  const body = (
     <html lang="en">
       <body>{children}</body>
     </html>
+  );
+  // ClerkProvider is a no-op in dev mode but pulls in Clerk's runtime —
+  // keep it conditional so the dev bundle stays free of Clerk weight.
+  return serverEnv.authProvider === "clerk" ? (
+    <ClerkProvider>{body}</ClerkProvider>
+  ) : (
+    body
   );
 }

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,10 +1,22 @@
 import { redirect } from "next/navigation";
+import { SignIn } from "@clerk/nextjs";
 import { getServerSession } from "@/lib/session";
 import { serverEnv } from "@/lib/env";
 
+// Catchall so Clerk's <SignIn routing="path"> can own /sign-in/* substates
+// (factor-one, sso-callback, verify, etc.). In dev mode we render the
+// signed-cookie form here directly.
 export default async function SignInPage() {
   const session = await getServerSession();
   if (session) redirect("/");
+
+  if (serverEnv.authProvider === "clerk") {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-zinc-50 p-6">
+        <SignIn routing="path" path="/sign-in" />
+      </main>
+    );
+  }
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-zinc-50 p-6">
@@ -13,8 +25,8 @@ export default async function SignInPage() {
           Sign in
         </h1>
         <p className="mt-2 text-sm text-zinc-500">
-          Phase 1 ships with a development identity provider. Clerk
-          Organizations replaces this in Phase 1.5.
+          Development identity provider. Set <code>AUTH_PROVIDER=clerk</code> to
+          use Clerk Organizations.
         </p>
         <form action="/api/dev-sign-in" method="post" className="mt-6">
           <div className="rounded-md bg-zinc-50 px-4 py-3 text-xs leading-relaxed text-zinc-600 ring-1 ring-zinc-200">

--- a/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { SignUp } from "@clerk/nextjs";
+import { getServerSession } from "@/lib/session";
+import { serverEnv } from "@/lib/env";
+
+// Sign-up only exists in Clerk mode. Dev mode has a single fixed identity,
+// so we redirect to /sign-in.
+export default async function SignUpPage() {
+  if (serverEnv.authProvider !== "clerk") {
+    redirect("/sign-in");
+  }
+  const session = await getServerSession();
+  if (session) redirect("/");
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-zinc-50 p-6">
+      <SignUp routing="path" path="/sign-up" />
+    </main>
+  );
+}

--- a/apps/web/src/components/topbar-clerk.tsx
+++ b/apps/web/src/components/topbar-clerk.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { OrganizationSwitcher, UserButton } from "@clerk/nextjs";
+
+// Client-only Clerk widgets used by the topbar in Clerk mode. Splitting
+// these out keeps Topbar itself a server component.
+export function TopbarOrgSwitcher() {
+  return (
+    <OrganizationSwitcher
+      hidePersonal
+      appearance={{
+        elements: {
+          rootBox: "flex items-center",
+          organizationSwitcherTrigger:
+            "rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 shadow-sm hover:bg-zinc-50",
+        },
+      }}
+    />
+  );
+}
+
+export function TopbarUserButton() {
+  return <UserButton afterSignOutUrl="/sign-in" />;
+}

--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -1,44 +1,44 @@
+import { TopbarOrgSwitcher, TopbarUserButton } from "./topbar-clerk";
+
 export function Topbar({
+  mode,
   salonName,
+  salonSlug,
   userEmail,
 }: {
-  salonName: string;
+  mode: "dev" | "clerk";
+  salonName: string | null;
+  salonSlug: string | null;
   userEmail: string;
 }) {
   return (
     <header className="sticky top-0 z-10 flex h-14 items-center justify-between border-b border-zinc-200 bg-white/80 px-6 backdrop-blur">
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 shadow-sm hover:bg-zinc-50"
-          disabled
-          title="Org switcher — Phase 1.5 (Clerk Organizations)"
-        >
-          {salonName}
-          <svg
-            viewBox="0 0 20 20"
-            className="h-3.5 w-3.5 text-zinc-400"
-            fill="currentColor"
-            aria-hidden
-          >
-            <path
-              fillRule="evenodd"
-              d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 011.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </button>
+        {mode === "clerk" ? (
+          <TopbarOrgSwitcher />
+        ) : (
+          <span className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 shadow-sm">
+            {salonName ?? "—"}
+            {salonSlug ? (
+              <span className="text-zinc-400">({salonSlug})</span>
+            ) : null}
+          </span>
+        )}
       </div>
       <div className="flex items-center gap-3">
         <span className="text-sm text-zinc-500">{userEmail}</span>
-        <form action="/api/dev-sign-out" method="post">
-          <button
-            type="submit"
-            className="rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
-          >
-            Sign out
-          </button>
-        </form>
+        {mode === "clerk" ? (
+          <TopbarUserButton />
+        ) : (
+          <form action="/api/dev-sign-out" method="post">
+            <button
+              type="submit"
+              className="rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
+            >
+              Sign out
+            </button>
+          </form>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -9,15 +9,30 @@ function required(name: string): string {
   return value;
 }
 
+const authProvider = (process.env.AUTH_PROVIDER ?? "dev") as "dev" | "clerk";
+
+function devValue(name: string, fallback: string): string {
+  // Dev-only env vars aren't required when running in Clerk mode. We still
+  // surface them as fixed strings so callers don't deal with optional types.
+  return authProvider === "dev" ? required(name) : (process.env[name] ?? fallback);
+}
+
 export const serverEnv = {
-  authProvider: (process.env.AUTH_PROVIDER ?? "dev") as "dev" | "clerk",
-  devAuthSecret: required("DEV_AUTH_SECRET"),
-  devUserId: required("DEV_USER_ID"),
-  devUserEmail: required("DEV_USER_EMAIL"),
-  devSalonId: required("DEV_SALON_ID"),
-  devSalonSlug: required("DEV_SALON_SLUG"),
-  apiInternalUrl:
-    process.env.API_INTERNAL_URL ?? "http://localhost:3001",
+  authProvider,
+  devAuthSecret: devValue("DEV_AUTH_SECRET", "unused-in-clerk-mode"),
+  devUserId: devValue("DEV_USER_ID", ""),
+  devUserEmail: devValue("DEV_USER_EMAIL", ""),
+  devSalonId: devValue("DEV_SALON_ID", ""),
+  devSalonSlug: devValue("DEV_SALON_SLUG", ""),
+  apiInternalUrl: process.env.API_INTERNAL_URL ?? "http://localhost:3001",
+  // Required at boot when AUTH_PROVIDER=clerk; @clerk/nextjs reads them
+  // directly from process.env so we mainly re-export for visibility.
+  clerkPublishableKey:
+    authProvider === "clerk"
+      ? required("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY")
+      : undefined,
+  clerkSecretKey:
+    authProvider === "clerk" ? required("CLERK_SECRET_KEY") : undefined,
 };
 
 export const publicEnv = {

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 // Server-side env access. Throws on first access if a required value is
 // missing — surfaces config errors at boot rather than at request time.
 

--- a/apps/web/src/lib/session.ts
+++ b/apps/web/src/lib/session.ts
@@ -1,23 +1,60 @@
 import "server-only";
 import { cookies } from "next/headers";
+import { auth, currentUser } from "@clerk/nextjs/server";
 import { serverEnv } from "./env";
-import {
-  DEV_SESSION_COOKIE,
-  type DevSessionPayload,
-  verifyDevSession,
-} from "./dev-session";
+import { DEV_SESSION_COOKIE, verifyDevSession } from "./dev-session";
 
 /**
- * Read the current dev session, if any. Returns null when the cookie is
- * missing or its signature doesn't verify.
+ * Display-shaped session for the app shell. Both providers normalize to
+ * this shape so the (app) layout doesn't branch on auth mode.
  *
- * In Phase 1.5 this gets a sibling that reads the Clerk session and the
- * caller picks based on serverEnv.authProvider.
+ * `salonSlug`/`salonName` are null when the user is signed in but hasn't
+ * picked an organization yet — the layout can show an org picker in that
+ * case.
  */
-export async function getServerSession(): Promise<DevSessionPayload | null> {
-  if (serverEnv.authProvider !== "dev") return null;
+export interface AppSession {
+  userId: string;
+  email: string;
+  salonName: string | null;
+  salonSlug: string | null;
+}
+
+export async function getServerSession(): Promise<AppSession | null> {
+  if (serverEnv.authProvider === "clerk") {
+    return getClerkSession();
+  }
+  return getDevSession();
+}
+
+async function getDevSession(): Promise<AppSession | null> {
   const store = await cookies();
   const raw = store.get(DEV_SESSION_COOKIE)?.value;
   if (!raw) return null;
-  return verifyDevSession(raw, serverEnv.devAuthSecret);
+  const payload = verifyDevSession(raw, serverEnv.devAuthSecret);
+  if (!payload) return null;
+  return {
+    userId: payload.userId,
+    email: payload.email,
+    salonName: "Acme Salon",
+    salonSlug: payload.salonSlug,
+  };
+}
+
+async function getClerkSession(): Promise<AppSession | null> {
+  const { userId, orgSlug } = await auth();
+  if (!userId) return null;
+  // currentUser() round-trips to Clerk for the user record. Cheap enough
+  // for the layout (cached per request); revisit if the dashboard takes
+  // many auth-aware reads per page.
+  // The Topbar renders Clerk's <OrganizationSwitcher /> in clerk mode,
+  // which displays the active org name itself — we leave salonName null
+  // and let the switcher handle it.
+  const user = await currentUser();
+  const email = user?.primaryEmailAddress?.emailAddress ?? "";
+  return {
+    userId,
+    email,
+    salonName: null,
+    salonSlug: orgSlug ?? null,
+  };
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,11 +1,27 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse, type NextRequest, type NextFetchEvent } from "next/server";
+import { clerkMiddleware } from "@clerk/nextjs/server";
+
+const authProvider = process.env.AUTH_PROVIDER ?? "dev";
 
 // Stamps the current pathname into a request header so server components
 // can read it (Next 15 still doesn't surface the active pathname directly).
-export function middleware(req: NextRequest) {
+function stampPathname(req: NextRequest): NextResponse {
   const headers = new Headers(req.headers);
   headers.set("x-pathname", req.nextUrl.pathname);
   return NextResponse.next({ request: { headers } });
+}
+
+// In Clerk mode we wrap our pathname-stamping logic in clerkMiddleware so
+// `auth()` inside server components has session context. clerkMiddleware
+// doesn't enforce protection by default — the (app) layout already gates
+// access via getServerSession, so we don't restate route protection here.
+const clerkComposed = clerkMiddleware((_auth, req) => stampPathname(req));
+
+export default function middleware(req: NextRequest, event: NextFetchEvent) {
+  if (authProvider === "clerk") {
+    return clerkComposed(req, event);
+  }
+  return stampPathname(req);
 }
 
 export const config = {

--- a/packages/db/prisma/migrations/20260429031045_processed_webhook_events/migration.sql
+++ b/packages/db/prisma/migrations/20260429031045_processed_webhook_events/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "processed_webhook_events" (
+    "id" UUID NOT NULL,
+    "source" TEXT NOT NULL,
+    "externalEventId" TEXT NOT NULL,
+    "eventType" TEXT,
+    "processedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "processed_webhook_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "processed_webhook_events_source_processedAt_idx" ON "processed_webhook_events"("source", "processedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "processed_webhook_events_source_externalEventId_key" ON "processed_webhook_events"("source", "externalEventId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -527,3 +527,22 @@ model DurationPrediction {
   @@index([modelVersion, createdAt])
   @@map("duration_predictions")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// External webhook idempotency — one row per (source, externalEventId) we've
+// already processed. Shared by every integration: Clerk (Phase 1.5),
+// Stripe (Phase 5), Twilio (Phase 4). Insert inside the same transaction
+// as the side effect; the unique constraint turns retries into no-ops.
+// ─────────────────────────────────────────────────────────────────────────────
+
+model ProcessedWebhookEvent {
+  id              String   @id @default(uuid()) @db.Uuid
+  source          String
+  externalEventId String
+  eventType       String?
+  processedAt     DateTime @default(now())
+
+  @@unique([source, externalEventId])
+  @@index([source, processedAt])
+  @@map("processed_webhook_events")
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@clerk/backend':
+        specifier: '1'
+        version: 1.34.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svix@1.92.2)
       '@nestjs/common':
         specifier: ^10.4.7
         version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -41,6 +44,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      svix:
+        specifier: '1'
+        version: 1.92.2
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -75,9 +81,15 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: '2'
+        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
 
   apps/web:
     dependencies:
+      '@clerk/nextjs':
+        specifier: '6'
+        version: 6.39.3(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@shearsimp/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -188,6 +200,55 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@clerk/backend@1.34.0':
+    resolution: {integrity: sha512-9rZ8hQJVpX5KX2bEpiuVXfpjhojQCiqCWADJDdCI0PCeKxn58Ep0JPYiIcczg4VKUc3a7jve9vXylykG2XajLQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      svix: ^1.62.0
+    peerDependenciesMeta:
+      svix:
+        optional: true
+
+  '@clerk/backend@2.33.3':
+    resolution: {integrity: sha512-cgkFVEYFG2nZn4QDuYBhiAwPtMdo8Yj7DAtq/SBQ5C/ainh3uxNRDgUj4bFn52qJkWLiCkraYJIw1b8dEUbUBg==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/clerk-react@5.61.6':
+    resolution: {integrity: sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/nextjs@6.39.3':
+    resolution: {integrity: sha512-a64lJ1IlV1uA7eEe8DOx+v2bkNOhnTsNlB5THP/xkHvynHqZhc74Yt05sm1vTniWwhJpJspAZ95pCWUX/RVZ2Q==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      next: ^13.5.7 || ^14.2.25 || ^15.2.3 || ^16
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@3.47.5':
+    resolution: {integrity: sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@4.101.20':
+    resolution: {integrity: sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==}
+    engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
+
+  '@clerk/types@4.101.23':
+    resolution: {integrity: sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA==}
+    engines: {node: '>=18.17.0'}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -205,16 +266,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -223,16 +302,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -241,10 +338,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -253,10 +362,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -265,10 +386,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -277,10 +410,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -289,16 +434,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.7':
@@ -313,6 +476,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
@@ -323,6 +492,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -337,11 +512,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
@@ -349,10 +536,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -756,11 +955,139 @@ packages:
   '@prisma/get-platform@6.19.3':
     resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1090,6 +1417,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1265,6 +1621,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1351,6 +1711,10 @@ packages:
       magicast:
         optional: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1370,6 +1734,10 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1380,6 +1748,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1483,6 +1855,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -1505,6 +1881,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1549,6 +1928,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1578,6 +1961,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1596,6 +1983,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dotenv-cli@7.4.4:
     resolution: {integrity: sha512-XkBYCG0tPIes+YZr4SpfFv76SQrV/LeCE8CI7JSEMi3VR9MvTihCGTOtbIexD6i2mXF+6px7trb1imVCXSNMDw==}
@@ -1680,6 +2070,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1830,6 +2225,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1841,6 +2239,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -1872,6 +2274,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -2245,6 +2650,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2398,6 +2807,12 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2410,6 +2825,10 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2537,6 +2956,9 @@ packages:
         optional: true
       sass:
         optional: true
+
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -2679,8 +3101,15 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -2828,6 +3257,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -2891,6 +3325,9 @@ packages:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2934,12 +3371,22 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  snakecase-keys@8.0.1:
+    resolution: {integrity: sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw==}
+    engines: {node: '>=18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2959,9 +3406,18 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3050,6 +3506,14 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -3085,6 +3549,12 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -3092,6 +3562,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -3163,6 +3645,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -3231,6 +3717,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3244,6 +3735,67 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
@@ -3295,6 +3847,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3378,6 +3935,74 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@clerk/backend@1.34.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svix@1.92.2)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/types': 4.101.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      cookie: 1.0.2
+      snakecase-keys: 8.0.1
+      tslib: 2.8.1
+    optionalDependencies:
+      svix: 1.92.2
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/backend@2.33.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/types': 4.101.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/clerk-react@5.61.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@clerk/nextjs@6.39.3(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/backend': 2.33.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/clerk-react': 5.61.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@clerk/types': 4.101.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      server-only: 0.0.1
+      tslib: 2.8.1
+
+  '@clerk/shared@3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.5)
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@clerk/types@4.101.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/types@4.101.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -3401,52 +4026,103 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
@@ -3455,10 +4131,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -3467,13 +4149,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -3866,9 +4560,86 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.19.3
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4187,6 +4958,46 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -4420,6 +5231,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4518,6 +5331,8 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 2.1.2
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4539,6 +5354,14 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4547,6 +5370,8 @@ snapshots:
   chalk@5.6.2: {}
 
   chardet@0.7.0: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -4642,6 +5467,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.0.2: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
@@ -4665,6 +5492,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -4700,6 +5529,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge-ts@7.1.5: {}
@@ -4726,6 +5557,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   destroy@1.2.0: {}
@@ -4737,6 +5570,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
 
   dotenv-cli@7.4.4:
     dependencies:
@@ -4885,6 +5723,32 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -5128,11 +5992,17 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
   events@3.3.0: {}
+
+  expect-type@1.3.0: {}
 
   express@4.22.1:
     dependencies:
@@ -5197,6 +6067,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -5626,6 +6498,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-cookie@3.0.5: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -5750,6 +6624,12 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
@@ -5761,6 +6641,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   make-error@1.3.6: {}
+
+  map-obj@4.3.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -5863,6 +6745,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
 
   node-abort-controller@3.1.1: {}
 
@@ -6014,7 +6901,11 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -6161,6 +7052,37 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
   run-async@2.4.1: {}
 
   run-async@3.0.0: {}
@@ -6245,6 +7167,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -6336,9 +7260,22 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  snakecase-keys@8.0.1:
+    dependencies:
+      map-obj: 4.3.0
+      snake-case: 3.0.4
+      type-fest: 4.41.0
 
   source-map-js@1.2.1: {}
 
@@ -6353,7 +7290,16 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6459,6 +7405,16 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
+
+  swr@2.3.4(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   symbol-observable@4.0.0: {}
 
   tailwindcss@4.2.4: {}
@@ -6482,12 +7438,22 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.0.33:
     dependencies:
@@ -6565,6 +7531,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.21.3: {}
+
+  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -6663,6 +7631,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -6670,6 +7642,70 @@ snapshots:
   v8-compile-cache-lib@3.0.1: {}
 
   vary@1.1.2: {}
+
+  vite-node@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.12
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.46.2
+
+  vitest@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
+      vite-node: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   watchpack@2.5.1:
     dependencies:
@@ -6765,6 +7801,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

Replaces `DevAuthProvider` with a real Clerk-backed auth flow without changing controllers — the pluggable `AuthProvider` seam from Phase 1 holds. Toggle behaviour with `AUTH_PROVIDER=dev|clerk`.

- **Backend**: `ClerkAuthProvider` verifies Clerk sessions via `@clerk/backend` and translates `(clerkUserId, clerkOrgId)` into our `User` / `Salon` rows. Self-heals by mirroring missing rows on demand (with a warning log) so first-sign-in or webhook lag never surfaces as a 401. `POST /webhooks/clerk` verifies svix signatures and mirrors user / org / membership / invitation events. Idempotent on Clerk event ID via a new `processed_webhook_events` table — same pattern is reusable for Stripe (Phase 5) and Twilio (Phase 4) webhooks.
- **Frontend**: Conditional `<ClerkProvider>` keeps Clerk's runtime out of the dev bundle. Middleware composes `clerkMiddleware` with the existing pathname-stamping logic. `/sign-in` becomes a `[[...sign-in]]` catchall that renders Clerk's `<SignIn />` in clerk mode and the dev cookie form otherwise. Topbar swaps in `<OrganizationSwitcher />` + `<UserButton />` when in clerk mode.
- **Tests + docs**: Vitest parity test asserts both providers produce equivalent `AuthIdentity` shapes (Clerk mocked at the module boundary). README walks first-time Clerk users through dashboard setup, key placement, and webhook tunneling.

## Notes for reviewers

- Tenant isolation guarantees from Phase 1 are unchanged — `TenantGuard` still resolves the salon from `req.identity.salonHint` and verifies an `ACTIVE` `SalonMembership` row before exposing `req.salon`.
- The parity test is intentionally narrower than a full Playwright e2e; ROADMAP carries that as a future phase.
- Self-heal in `ClerkAuthProvider.resolveUser/resolveSalon` is a backstop, not the canonical sync path — webhooks remain authoritative.

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r test` clean (Vitest parity suite passes)
- [ ] `pnpm --filter @shearsimp/db prisma:validate` clean and migration applies
- [ ] Dev mode (`AUTH_PROVIDER=dev`): sign in via the dev form, app shell renders with seeded fixture
- [ ] Clerk mode (`AUTH_PROVIDER=clerk`): with keys + webhook configured per README, sign up, create an organization, see OrganizationSwitcher render, verify `salons` row mirrored via webhook