### PR TITLE
Phase 2: core salon data CRUD + admin UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,7 +72,7 @@ Replace `DevAuthProvider` with a real auth flow without changing controllers.
 
 **Risks:** Clerk's Next SDK is intrusive; treat its boundary carefully so swap-back to dev mode stays cheap. Don't leak Clerk types into shared packages.
 
-## Phase 2 — Core salon data ⬜
+## Phase 2 — Core salon data 🚧
 
 CRUD UIs and APIs for the entities the rest of the product depends on.
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,10 @@ import { TenantModule } from "./tenant/tenant.module";
 import { TenantGuard } from "./tenant/tenant.guard";
 import { HealthController } from "./health/health.controller";
 import { SalonsModule } from "./salons/salons.module";
+import { StaffModule } from "./staff/staff.module";
+import { ServicesModule } from "./services/services.module";
+import { ClientsModule } from "./clients/clients.module";
+import { SettingsModule } from "./settings/settings.module";
 import { WebhooksModule } from "./webhooks/webhooks.module";
 
 // AuthGuard runs first; TenantGuard depends on the identity it attaches to
@@ -18,6 +22,10 @@ import { WebhooksModule } from "./webhooks/webhooks.module";
     AuthModule,
     TenantModule,
     SalonsModule,
+    StaffModule,
+    ServicesModule,
+    ClientsModule,
+    SettingsModule,
     WebhooksModule,
   ],
   controllers: [HealthController],

--- a/apps/api/src/clients/clients.controller.ts
+++ b/apps/api/src/clients/clients.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from "@nestjs/common";
+import { clientCreateSchema, clientUpdateSchema } from "@shearsimp/shared";
+import type {
+  ClientCreateInput,
+  ClientUpdateInput,
+} from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { ClientsService } from "./clients.service";
+
+@Controller("clients")
+export class ClientsController {
+  constructor(private readonly clients: ClientsService) {}
+
+  @Get()
+  list(
+    @CurrentSalon() salon: ActiveSalon,
+    @Query("q") q?: string,
+  ) {
+    return this.clients.list(salon.salonId, q);
+  }
+
+  @Get(":id")
+  get(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+  ) {
+    return this.clients.get(salon.salonId, id);
+  }
+
+  @Post()
+  create(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(clientCreateSchema)) input: ClientCreateInput,
+  ) {
+    return this.clients.create(salon.salonId, user.userId, input);
+  }
+
+  @Patch(":id")
+  update(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(clientUpdateSchema)) input: ClientUpdateInput,
+  ) {
+    return this.clients.update(salon.salonId, user.userId, id, input);
+  }
+}

--- a/apps/api/src/clients/clients.module.ts
+++ b/apps/api/src/clients/clients.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { ClientsController } from "./clients.controller";
+import { ClientsService } from "./clients.service";
+
+@Module({
+  controllers: [ClientsController],
+  providers: [ClientsService],
+})
+export class ClientsModule {}

--- a/apps/api/src/clients/clients.service.ts
+++ b/apps/api/src/clients/clients.service.ts
@@ -1,0 +1,179 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type {
+  ClientCreateInput,
+  ClientUpdateInput,
+} from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import { appendDomainEvent } from "../common/domain-events";
+
+const APPOINTMENT_HISTORY_LIMIT = 50;
+
+@Injectable()
+export class ClientsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Search is case-insensitive across displayName/phone/email so receptionists
+  // can paste in any of the three. When `q` is empty we list everything sorted
+  // by display name.
+  list(salonId: string, q: string | undefined) {
+    const where: Prisma.ClientWhereInput = { salonId };
+    if (q && q.trim().length > 0) {
+      const term = q.trim();
+      where.OR = [
+        { displayName: { contains: term, mode: "insensitive" } },
+        { firstName: { contains: term, mode: "insensitive" } },
+        { lastName: { contains: term, mode: "insensitive" } },
+        { phone: { contains: term } },
+        { email: { contains: term, mode: "insensitive" } },
+      ];
+    }
+    return this.prisma.client.findMany({
+      where,
+      orderBy: [{ displayName: "asc" }],
+      take: 200,
+    });
+  }
+
+  async get(salonId: string, id: string) {
+    const client = await this.prisma.client.findFirst({
+      where: { id, salonId },
+    });
+    if (!client) throw new NotFoundException("Client not found");
+
+    // Appointment history rolls up here read-only. Phase 3 will populate it
+    // for real; the query is correct now and just returns an empty list.
+    const appointments = await this.prisma.appointment.findMany({
+      where: { salonId, clientId: id },
+      orderBy: [{ startAt: "desc" }],
+      take: APPOINTMENT_HISTORY_LIMIT,
+      select: {
+        id: true,
+        startAt: true,
+        endAt: true,
+        status: true,
+        staffMember: { select: { id: true, displayName: true } },
+        services: {
+          select: {
+            serviceNameSnapshot: true,
+            priceSnapshotCents: true,
+            currencySnapshot: true,
+          },
+        },
+      },
+    });
+
+    return { ...client, appointments };
+  }
+
+  async create(salonId: string, actorUserId: string, input: ClientCreateInput) {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const client = await tx.client.create({
+          data: {
+            salonId,
+            firstName: input.firstName,
+            lastName: input.lastName ?? null,
+            displayName: input.displayName,
+            email: input.email ?? null,
+            phone: input.phone ?? null,
+            notes: input.notes ?? null,
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "CLIENT",
+          aggregateId: client.id,
+          eventType: EventType.CLIENT_CREATED,
+          payload: clientSnapshot(client),
+          actorUserId,
+        });
+        return client;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Client");
+    }
+  }
+
+  async update(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: ClientUpdateInput,
+  ) {
+    const existing = await this.prisma.client.findFirst({
+      where: { id, salonId },
+      select: { id: true },
+    });
+    if (!existing) throw new NotFoundException("Client not found");
+
+    const data: Prisma.ClientUpdateInput = {};
+    if (input.firstName !== undefined) data.firstName = input.firstName;
+    if (input.lastName !== undefined) data.lastName = input.lastName;
+    if (input.displayName !== undefined) data.displayName = input.displayName;
+    if (input.email !== undefined) data.email = input.email;
+    if (input.phone !== undefined) data.phone = input.phone;
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const client = await tx.client.update({ where: { id }, data });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "CLIENT",
+          aggregateId: client.id,
+          eventType: EventType.CLIENT_UPDATED,
+          payload: { changes: input, after: clientSnapshot(client) },
+          actorUserId,
+        });
+        return client;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Client");
+    }
+  }
+}
+
+function clientSnapshot(c: {
+  id: string;
+  firstName: string;
+  lastName: string | null;
+  displayName: string;
+  email: string | null;
+  phone: string | null;
+}) {
+  return {
+    id: c.id,
+    firstName: c.firstName,
+    lastName: c.lastName,
+    displayName: c.displayName,
+    email: c.email,
+    phone: c.phone,
+  };
+}
+
+function mapKnownErrors(e: unknown, label: string): Error {
+  if (e instanceof Prisma.PrismaClientKnownRequestError) {
+    if (e.code === "P2002") {
+      const target = (e.meta as { target?: string[] | string } | undefined)
+        ?.target;
+      const field = Array.isArray(target)
+        ? target.find((t) => t !== "salonId")
+        : target;
+      return new ConflictException(
+        field
+          ? `Another ${label.toLowerCase()} in this salon already uses that ${field}`
+          : `${label} already exists for this salon`,
+      );
+    }
+    if (e.code === "P2025") {
+      return new NotFoundException(`${label} not found`);
+    }
+  }
+  return e as Error;
+}

--- a/apps/api/src/common/domain-events.ts
+++ b/apps/api/src/common/domain-events.ts
@@ -1,0 +1,44 @@
+import {
+  type AggregateType as AggregateTypeEnum,
+  ActorType,
+  type Prisma,
+} from "@prisma/client";
+
+interface AppendDomainEventArgs {
+  salonId: string | null;
+  aggregateType: AggregateTypeEnum;
+  aggregateId: string;
+  eventType: string;
+  payload: Prisma.InputJsonValue;
+  actorUserId?: string | null;
+}
+
+/**
+ * Append a `domain_events` row inside an active Prisma transaction. Always
+ * invoke this from within `prisma.$transaction(async (tx) => …)` so the row
+ * commits atomically with the business write that produced it — that's the
+ * append-only contract Phase 1 set up.
+ */
+export async function appendDomainEvent(
+  tx: Prisma.TransactionClient,
+  {
+    salonId,
+    aggregateType,
+    aggregateId,
+    eventType,
+    payload,
+    actorUserId,
+  }: AppendDomainEventArgs,
+): Promise<void> {
+  await tx.domainEvent.create({
+    data: {
+      salonId,
+      aggregateType,
+      aggregateId,
+      eventType,
+      payload,
+      actorType: actorUserId ? ActorType.USER : ActorType.SYSTEM,
+      actorId: actorUserId ?? null,
+    },
+  });
+}

--- a/apps/api/src/common/zod-validation.pipe.ts
+++ b/apps/api/src/common/zod-validation.pipe.ts
@@ -1,0 +1,31 @@
+import { BadRequestException, PipeTransform } from "@nestjs/common";
+import type { ZodTypeAny, infer as zInfer } from "zod";
+
+/**
+ * Validates and transforms request payloads with a Zod schema. Schema parse
+ * errors surface as a 400 with a flattened issue list.
+ *
+ * Pair with the global Nest ValidationPipe by listing this one explicitly on
+ * the parameter — the global pipe still runs for non-Zod bodies (e.g. plain
+ * primitives) and remains the place class-validator decorators are honored.
+ */
+export class ZodValidationPipe<S extends ZodTypeAny>
+  implements PipeTransform<unknown, zInfer<S>>
+{
+  constructor(private readonly schema: S) {}
+
+  transform(value: unknown): zInfer<S> {
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new BadRequestException({
+        message: "Validation failed",
+        issues: result.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+          code: i.code,
+        })),
+      });
+    }
+    return result.data;
+  }
+}

--- a/apps/api/src/services/services.controller.ts
+++ b/apps/api/src/services/services.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from "@nestjs/common";
+import {
+  serviceCategoryCreateSchema,
+  serviceCategoryUpdateSchema,
+  serviceCreateSchema,
+  serviceUpdateSchema,
+} from "@shearsimp/shared";
+import type {
+  ServiceCategoryCreateInput,
+  ServiceCategoryUpdateInput,
+  ServiceCreateInput,
+  ServiceUpdateInput,
+} from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { ServicesService } from "./services.service";
+
+@Controller()
+export class ServicesController {
+  constructor(private readonly services: ServicesService) {}
+
+  // ─── Categories ────────────────────────────────────────────────────────────
+
+  @Get("service-categories")
+  listCategories(@CurrentSalon() salon: ActiveSalon) {
+    return this.services.listCategories(salon.salonId);
+  }
+
+  @Post("service-categories")
+  createCategory(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(serviceCategoryCreateSchema))
+    input: ServiceCategoryCreateInput,
+  ) {
+    return this.services.createCategory(salon.salonId, user.userId, input);
+  }
+
+  @Patch("service-categories/:id")
+  updateCategory(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(serviceCategoryUpdateSchema))
+    input: ServiceCategoryUpdateInput,
+  ) {
+    return this.services.updateCategory(
+      salon.salonId,
+      user.userId,
+      id,
+      input,
+    );
+  }
+
+  // ─── Services ──────────────────────────────────────────────────────────────
+
+  @Get("services")
+  list(@CurrentSalon() salon: ActiveSalon) {
+    return this.services.list(salon.salonId);
+  }
+
+  @Get("services/:id")
+  get(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+  ) {
+    return this.services.get(salon.salonId, id);
+  }
+
+  @Post("services")
+  create(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(serviceCreateSchema)) input: ServiceCreateInput,
+  ) {
+    return this.services.create(salon.salonId, user.userId, input);
+  }
+
+  @Patch("services/:id")
+  update(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(serviceUpdateSchema)) input: ServiceUpdateInput,
+  ) {
+    return this.services.update(salon.salonId, user.userId, id, input);
+  }
+}

--- a/apps/api/src/services/services.module.ts
+++ b/apps/api/src/services/services.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { ServicesController } from "./services.controller";
+import { ServicesService } from "./services.service";
+
+@Module({
+  controllers: [ServicesController],
+  providers: [ServicesService],
+})
+export class ServicesModule {}

--- a/apps/api/src/services/services.service.ts
+++ b/apps/api/src/services/services.service.ts
@@ -1,0 +1,251 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type {
+  ServiceCategoryCreateInput,
+  ServiceCategoryUpdateInput,
+  ServiceCreateInput,
+  ServiceUpdateInput,
+} from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import { appendDomainEvent } from "../common/domain-events";
+
+@Injectable()
+export class ServicesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─── Categories ────────────────────────────────────────────────────────────
+
+  listCategories(salonId: string) {
+    return this.prisma.serviceCategory.findMany({
+      where: { salonId },
+      orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+    });
+  }
+
+  async createCategory(
+    salonId: string,
+    actorUserId: string,
+    input: ServiceCategoryCreateInput,
+  ) {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const category = await tx.serviceCategory.create({
+          data: {
+            salonId,
+            name: input.name,
+            sortOrder: input.sortOrder ?? 0,
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "SERVICE",
+          aggregateId: category.id,
+          eventType: EventType.SERVICE_CATEGORY_CREATED,
+          payload: { id: category.id, name: category.name },
+          actorUserId,
+        });
+        return category;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Service category");
+    }
+  }
+
+  async updateCategory(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: ServiceCategoryUpdateInput,
+  ) {
+    const existing = await this.prisma.serviceCategory.findFirst({
+      where: { id, salonId },
+    });
+    if (!existing) throw new NotFoundException("Service category not found");
+
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const category = await tx.serviceCategory.update({
+          where: { id },
+          data: {
+            name: input.name,
+            sortOrder: input.sortOrder,
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "SERVICE",
+          aggregateId: category.id,
+          eventType: EventType.SERVICE_CATEGORY_UPDATED,
+          payload: { changes: input },
+          actorUserId,
+        });
+        return category;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Service category");
+    }
+  }
+
+  // ─── Services ──────────────────────────────────────────────────────────────
+
+  list(salonId: string) {
+    return this.prisma.service.findMany({
+      where: { salonId },
+      include: { category: { select: { id: true, name: true } } },
+      orderBy: [{ isActive: "desc" }, { name: "asc" }],
+    });
+  }
+
+  async get(salonId: string, id: string) {
+    const service = await this.prisma.service.findFirst({
+      where: { id, salonId },
+      include: { category: { select: { id: true, name: true } } },
+    });
+    if (!service) throw new NotFoundException("Service not found");
+    return service;
+  }
+
+  async create(
+    salonId: string,
+    actorUserId: string,
+    input: ServiceCreateInput,
+  ) {
+    if (input.categoryId) {
+      await this.assertCategoryBelongsToSalon(salonId, input.categoryId);
+    }
+
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const service = await tx.service.create({
+          data: {
+            salonId,
+            name: input.name,
+            slug: input.slug,
+            categoryId: input.categoryId ?? null,
+            description: input.description ?? null,
+            defaultDurationMinutes: input.defaultDurationMinutes,
+            defaultPriceCents: input.defaultPriceCents,
+            currency: input.currency ?? "USD",
+            isActive: input.isActive ?? true,
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "SERVICE",
+          aggregateId: service.id,
+          eventType: EventType.SERVICE_CREATED,
+          payload: serviceSnapshot(service),
+          actorUserId,
+        });
+        return service;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Service");
+    }
+  }
+
+  async update(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: ServiceUpdateInput,
+  ) {
+    await this.get(salonId, id);
+    if (input.categoryId) {
+      await this.assertCategoryBelongsToSalon(salonId, input.categoryId);
+    }
+
+    const data: Prisma.ServiceUpdateInput = {};
+    if (input.name !== undefined) data.name = input.name;
+    if (input.slug !== undefined) data.slug = input.slug;
+    if (input.description !== undefined) data.description = input.description;
+    if (input.defaultDurationMinutes !== undefined)
+      data.defaultDurationMinutes = input.defaultDurationMinutes;
+    if (input.defaultPriceCents !== undefined)
+      data.defaultPriceCents = input.defaultPriceCents;
+    if (input.currency !== undefined) data.currency = input.currency;
+    if (input.isActive !== undefined) data.isActive = input.isActive;
+    if (input.categoryId !== undefined) {
+      // The Service.category relation uses a composite FK (categoryId, salonId)
+      // so Prisma exposes the connect target via the named composite-unique
+      // key, not the scalar `categoryId`. The presalon-check above plus this
+      // composite key make a cross-tenant id impossible.
+      data.category = input.categoryId
+        ? {
+            connect: {
+              service_categories_id_salonId_key: {
+                id: input.categoryId,
+                salonId,
+              },
+            },
+          }
+        : { disconnect: true };
+    }
+
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const service = await tx.service.update({ where: { id }, data });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "SERVICE",
+          aggregateId: service.id,
+          eventType: EventType.SERVICE_UPDATED,
+          payload: { changes: input, after: serviceSnapshot(service) },
+          actorUserId,
+        });
+        return service;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Service");
+    }
+  }
+
+  private async assertCategoryBelongsToSalon(salonId: string, categoryId: string) {
+    const exists = await this.prisma.serviceCategory.findFirst({
+      where: { id: categoryId, salonId },
+      select: { id: true },
+    });
+    if (!exists) {
+      throw new NotFoundException("Service category not found in this salon");
+    }
+  }
+}
+
+function serviceSnapshot(s: {
+  id: string;
+  name: string;
+  slug: string;
+  defaultDurationMinutes: number;
+  defaultPriceCents: number;
+  currency: string;
+  isActive: boolean;
+  categoryId: string | null;
+}) {
+  return {
+    id: s.id,
+    name: s.name,
+    slug: s.slug,
+    defaultDurationMinutes: s.defaultDurationMinutes,
+    defaultPriceCents: s.defaultPriceCents,
+    currency: s.currency,
+    isActive: s.isActive,
+    categoryId: s.categoryId,
+  };
+}
+
+function mapKnownErrors(e: unknown, label: string): Error {
+  if (e instanceof Prisma.PrismaClientKnownRequestError) {
+    if (e.code === "P2002") {
+      return new ConflictException(`${label} already exists for this salon`);
+    }
+    if (e.code === "P2025") {
+      return new NotFoundException(`${label} not found`);
+    }
+  }
+  return e as Error;
+}

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Patch } from "@nestjs/common";
+import { salonSettingsUpdateSchema } from "@shearsimp/shared";
+import type { SalonSettingsUpdateInput } from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { SettingsService } from "./settings.service";
+
+@Controller("settings")
+export class SettingsController {
+  constructor(private readonly settings: SettingsService) {}
+
+  @Get()
+  get(@CurrentSalon() salon: ActiveSalon) {
+    return this.settings.get(salon.salonId);
+  }
+
+  @Patch()
+  update(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(salonSettingsUpdateSchema))
+    input: SalonSettingsUpdateInput,
+  ) {
+    return this.settings.update(salon.salonId, user.userId, input);
+  }
+}

--- a/apps/api/src/settings/settings.module.ts
+++ b/apps/api/src/settings/settings.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { SettingsController } from "./settings.controller";
+import { SettingsService } from "./settings.service";
+
+@Module({
+  controllers: [SettingsController],
+  providers: [SettingsService],
+})
+export class SettingsModule {}

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type { SalonSettingsUpdateInput } from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import { appendDomainEvent } from "../common/domain-events";
+
+@Injectable()
+export class SettingsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async get(salonId: string) {
+    const salon = await this.prisma.salon.findUnique({
+      where: { id: salonId },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        timezone: true,
+        isActive: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    if (!salon) throw new NotFoundException("Salon not found");
+    return salon;
+  }
+
+  async update(
+    salonId: string,
+    actorUserId: string,
+    input: SalonSettingsUpdateInput,
+  ) {
+    const data: Prisma.SalonUpdateInput = {};
+    if (input.name !== undefined) data.name = input.name;
+    if (input.timezone !== undefined) data.timezone = input.timezone;
+
+    return this.prisma.$transaction(async (tx) => {
+      const salon = await tx.salon.update({
+        where: { id: salonId },
+        data,
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          timezone: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "SALON",
+        aggregateId: salonId,
+        eventType: EventType.SALON_UPDATED,
+        payload: {
+          changes: input,
+          after: { name: salon.name, timezone: salon.timezone },
+        },
+        actorUserId,
+      });
+      return salon;
+    });
+  }
+}

--- a/apps/api/src/staff/staff.controller.ts
+++ b/apps/api/src/staff/staff.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+} from "@nestjs/common";
+import {
+  staffCreateSchema,
+  staffUpdateSchema,
+  workingHoursReplaceSchema,
+} from "@shearsimp/shared";
+import type {
+  StaffCreateInput,
+  StaffUpdateInput,
+  WorkingHoursReplaceInput,
+} from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { StaffService } from "./staff.service";
+
+@Controller("staff")
+export class StaffController {
+  constructor(private readonly staff: StaffService) {}
+
+  @Get()
+  list(@CurrentSalon() salon: ActiveSalon) {
+    return this.staff.list(salon.salonId);
+  }
+
+  @Get(":id")
+  get(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+  ) {
+    return this.staff.get(salon.salonId, id);
+  }
+
+  @Post()
+  create(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(staffCreateSchema)) input: StaffCreateInput,
+  ) {
+    return this.staff.create(salon.salonId, user.userId, input);
+  }
+
+  @Patch(":id")
+  update(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(staffUpdateSchema)) input: StaffUpdateInput,
+  ) {
+    return this.staff.update(salon.salonId, user.userId, id, input);
+  }
+
+  @Put(":id/working-hours")
+  replaceWorkingHours(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(workingHoursReplaceSchema))
+    input: WorkingHoursReplaceInput,
+  ) {
+    return this.staff.replaceWorkingHours(
+      salon.salonId,
+      user.userId,
+      id,
+      input,
+    );
+  }
+}

--- a/apps/api/src/staff/staff.module.ts
+++ b/apps/api/src/staff/staff.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { StaffController } from "./staff.controller";
+import { StaffService } from "./staff.service";
+
+@Module({
+  controllers: [StaffController],
+  providers: [StaffService],
+})
+export class StaffModule {}

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -85,6 +85,11 @@ export class StaffService {
     if (input.color !== undefined) data.color = input.color;
     if (input.bio !== undefined) data.bio = input.bio;
     if (input.isActive !== undefined) data.isActive = input.isActive;
+    if (input.userId !== undefined) {
+      data.user = input.userId
+        ? { connect: { id: input.userId } }
+        : { disconnect: true };
+    }
 
     try {
       return await this.prisma.$transaction(async (tx) => {

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -1,0 +1,182 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type {
+  StaffCreateInput,
+  StaffUpdateInput,
+  WorkingHoursReplaceInput,
+} from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import { appendDomainEvent } from "../common/domain-events";
+
+@Injectable()
+export class StaffService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  list(salonId: string) {
+    return this.prisma.staffMember.findMany({
+      where: { salonId },
+      orderBy: [{ isActive: "desc" }, { displayName: "asc" }],
+    });
+  }
+
+  async get(salonId: string, id: string) {
+    const staff = await this.prisma.staffMember.findFirst({
+      where: { id, salonId },
+      include: {
+        workingHours: {
+          orderBy: [
+            { dayOfWeek: "asc" },
+            { startMinutesFromMidnight: "asc" },
+          ],
+        },
+      },
+    });
+    if (!staff) throw new NotFoundException("Staff member not found");
+    return staff;
+  }
+
+  async create(salonId: string, actorUserId: string, input: StaffCreateInput) {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const staff = await tx.staffMember.create({
+          data: {
+            salonId,
+            displayName: input.displayName,
+            title: input.title ?? null,
+            color: input.color ?? null,
+            bio: input.bio ?? null,
+            isActive: input.isActive ?? true,
+            userId: input.userId ?? null,
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "STAFF_MEMBER",
+          aggregateId: staff.id,
+          eventType: EventType.STAFF_CREATED,
+          payload: snapshot(staff),
+          actorUserId,
+        });
+        return staff;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Staff member");
+    }
+  }
+
+  async update(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: StaffUpdateInput,
+  ) {
+    // Verify ownership before update so a cross-tenant id surfaces as 404
+    // rather than a generic Prisma "record not found".
+    await this.get(salonId, id);
+
+    const data: Prisma.StaffMemberUpdateInput = {};
+    if (input.displayName !== undefined) data.displayName = input.displayName;
+    if (input.title !== undefined) data.title = input.title;
+    if (input.color !== undefined) data.color = input.color;
+    if (input.bio !== undefined) data.bio = input.bio;
+    if (input.isActive !== undefined) data.isActive = input.isActive;
+
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const staff = await tx.staffMember.update({
+          where: { id },
+          data,
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "STAFF_MEMBER",
+          aggregateId: staff.id,
+          eventType: EventType.STAFF_UPDATED,
+          payload: { changes: input, after: snapshot(staff) },
+          actorUserId,
+        });
+        return staff;
+      });
+    } catch (e) {
+      throw mapKnownErrors(e, "Staff member");
+    }
+  }
+
+  async replaceWorkingHours(
+    salonId: string,
+    actorUserId: string,
+    staffId: string,
+    input: WorkingHoursReplaceInput,
+  ) {
+    await this.get(salonId, staffId);
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.workingHours.deleteMany({
+        where: { salonId, staffMemberId: staffId },
+      });
+      if (input.windows.length > 0) {
+        await tx.workingHours.createMany({
+          data: input.windows.map((w) => ({
+            salonId,
+            staffMemberId: staffId,
+            dayOfWeek: w.dayOfWeek,
+            startMinutesFromMidnight: w.startMinutesFromMidnight,
+            endMinutesFromMidnight: w.endMinutesFromMidnight,
+          })),
+        });
+      }
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "STAFF_MEMBER",
+        aggregateId: staffId,
+        eventType: EventType.WORKING_HOURS_UPDATED,
+        payload: { windows: input.windows },
+        actorUserId,
+      });
+      return tx.workingHours.findMany({
+        where: { salonId, staffMemberId: staffId },
+        orderBy: [
+          { dayOfWeek: "asc" },
+          { startMinutesFromMidnight: "asc" },
+        ],
+      });
+    });
+  }
+}
+
+function snapshot(staff: {
+  id: string;
+  displayName: string;
+  title: string | null;
+  color: string | null;
+  isActive: boolean;
+  userId: string | null;
+}) {
+  return {
+    id: staff.id,
+    displayName: staff.displayName,
+    title: staff.title,
+    color: staff.color,
+    isActive: staff.isActive,
+    userId: staff.userId,
+  };
+}
+
+// Translate Prisma's known errors into HTTP-shaped exceptions the controller
+// can return verbatim.
+function mapKnownErrors(e: unknown, label: string): Error {
+  if (e instanceof Prisma.PrismaClientKnownRequestError) {
+    if (e.code === "P2002") {
+      return new ConflictException(`${label} already exists for this salon`);
+    }
+    if (e.code === "P2025") {
+      return new NotFoundException(`${label} not found`);
+    }
+  }
+  return e as Error;
+}

--- a/apps/web/src/app/(app)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(app)/clients/[id]/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Card, PageHeader } from "@/components/form";
+import { ClientForm } from "../_components/client-form";
+import { updateClientAction, type FormState } from "../_actions";
+
+interface AppointmentRow {
+  id: string;
+  startAt: string;
+  endAt: string;
+  status: string;
+  staffMember: { id: string; displayName: string };
+  services: Array<{
+    serviceNameSnapshot: string;
+    priceSnapshotCents: number;
+    currencySnapshot: string;
+  }>;
+}
+
+interface ClientDetail {
+  id: string;
+  firstName: string;
+  lastName: string | null;
+  displayName: string;
+  email: string | null;
+  phone: string | null;
+  notes: string | null;
+  appointments: AppointmentRow[];
+}
+
+export default async function ClientDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const client = await apiFetch<ClientDetail>(`/clients/${id}`);
+
+  const action = async (
+    state: FormState,
+    formData: FormData,
+  ): Promise<FormState> => {
+    "use server";
+    return updateClientAction(id, state, formData);
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={client.displayName} description="Client profile" />
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
+          Profile
+        </h2>
+        <Card>
+          <ClientForm
+            action={action}
+            submitLabel="Save changes"
+            defaults={{
+              firstName: client.firstName,
+              lastName: client.lastName,
+              displayName: client.displayName,
+              email: client.email,
+              phone: client.phone,
+              notes: client.notes,
+            }}
+          />
+        </Card>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
+          Appointment history
+        </h2>
+        <Card className={client.appointments.length === 0 ? undefined : "p-0"}>
+          {client.appointments.length === 0 ? (
+            <p className="text-sm text-zinc-500">
+              No appointments yet. Booking lands in Phase 3.
+            </p>
+          ) : (
+            <ul className="divide-y divide-zinc-200">
+              {client.appointments.map((a) => (
+                <li key={a.id} className="px-6 py-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-sm font-medium text-zinc-900">
+                        {new Date(a.startAt).toLocaleString()}
+                      </div>
+                      <div className="text-xs text-zinc-500">
+                        With {a.staffMember.displayName} ·{" "}
+                        {a.services
+                          .map((s) => s.serviceNameSnapshot)
+                          .join(", ") || "No services"}
+                      </div>
+                    </div>
+                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
+                      {a.status}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      </section>
+
+      <div>
+        <Link
+          href="/clients"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to clients
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/clients/_actions.ts
+++ b/apps/web/src/app/(app)/clients/_actions.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { clientCreateSchema, clientUpdateSchema } from "@shearsimp/shared";
+import { apiFetch, ApiError } from "@/lib/api";
+
+export interface FormState {
+  errors?: Record<string, string>;
+  message?: string;
+}
+
+function toFormErrors(parsed: { error: { issues: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }> } }): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const i of parsed.error.issues) {
+    const k = i.path.join(".") || "_";
+    if (!(k in out)) out[k] = i.message;
+  }
+  return out;
+}
+
+function readClient(formData: FormData) {
+  return {
+    firstName: String(formData.get("firstName") ?? ""),
+    lastName: optional(formData.get("lastName")),
+    displayName: optional(formData.get("displayName")),
+    email: optional(formData.get("email")),
+    phone: optional(formData.get("phone")),
+    notes: optional(formData.get("notes")),
+  };
+}
+
+function optional(v: FormDataEntryValue | null): string | undefined {
+  if (v === null) return undefined;
+  const s = String(v);
+  return s.length === 0 ? undefined : s;
+}
+
+export async function createClientAction(
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = clientCreateSchema.safeParse(readClient(formData));
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  let created: { id: string };
+  try {
+    created = await apiFetch<{ id: string }>("/clients", {
+      method: "POST",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/clients");
+  redirect(`/clients/${created.id}`);
+}
+
+export async function updateClientAction(
+  id: string,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = clientUpdateSchema.safeParse(readClient(formData));
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch(`/clients/${id}`, { method: "PATCH", data: parsed.data });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/clients");
+  revalidatePath(`/clients/${id}`);
+  return { message: "Saved." };
+}

--- a/apps/web/src/app/(app)/clients/_actions.ts
+++ b/apps/web/src/app/(app)/clients/_actions.ts
@@ -22,15 +22,25 @@ function toFormErrors(parsed: { error: { issues: ReadonlyArray<{ path: ReadonlyA
 function readClient(formData: FormData) {
   return {
     firstName: String(formData.get("firstName") ?? ""),
-    lastName: optional(formData.get("lastName")),
-    displayName: optional(formData.get("displayName")),
-    email: optional(formData.get("email")),
-    phone: optional(formData.get("phone")),
-    notes: optional(formData.get("notes")),
+    // For nullable model fields we pass the empty string through so the shared
+    // schema's transforms collapse it to null — that's how a user clears a
+    // previously-saved value. Treating empty as undefined would silently drop
+    // the change on update.
+    lastName: passthrough(formData.get("lastName")),
+    email: passthrough(formData.get("email")),
+    phone: passthrough(formData.get("phone")),
+    notes: passthrough(formData.get("notes")),
+    // displayName is non-null in the model; empty means "no change" rather
+    // than "clear" (clientCreateSchema's First-Last fallback handles new rows).
+    displayName: omitIfBlank(formData.get("displayName")),
   };
 }
 
-function optional(v: FormDataEntryValue | null): string | undefined {
+function passthrough(v: FormDataEntryValue | null): string | undefined {
+  return v === null ? undefined : String(v);
+}
+
+function omitIfBlank(v: FormDataEntryValue | null): string | undefined {
   if (v === null) return undefined;
   const s = String(v);
   return s.length === 0 ? undefined : s;

--- a/apps/web/src/app/(app)/clients/_components/client-form.tsx
+++ b/apps/web/src/app/(app)/clients/_components/client-form.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  Button,
+  Field,
+  FormError,
+  Input,
+  Textarea,
+} from "@/components/form";
+import type { FormState } from "../_actions";
+
+export interface ClientDefaults {
+  firstName?: string;
+  lastName?: string | null;
+  displayName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  notes?: string | null;
+}
+
+export function ClientForm({
+  action,
+  defaults,
+  submitLabel,
+}: {
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+  defaults?: ClientDefaults;
+  submitLabel: string;
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    action,
+    {},
+  );
+  const errors = state?.errors ?? {};
+  return (
+    <form action={formAction} className="space-y-5">
+      <FormError message={state?.message} />
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="First name" name="firstName" error={errors.firstName}>
+          <Input
+            id="firstName"
+            name="firstName"
+            required
+            defaultValue={defaults?.firstName ?? ""}
+            maxLength={80}
+          />
+        </Field>
+        <Field label="Last name" name="lastName" error={errors.lastName}>
+          <Input
+            id="lastName"
+            name="lastName"
+            defaultValue={defaults?.lastName ?? ""}
+            maxLength={80}
+          />
+        </Field>
+      </div>
+      <Field
+        label="Display name"
+        name="displayName"
+        error={errors.displayName}
+        hint="Defaults to First Last when blank."
+      >
+        <Input
+          id="displayName"
+          name="displayName"
+          defaultValue={defaults?.displayName ?? ""}
+          maxLength={160}
+        />
+      </Field>
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Phone" name="phone" error={errors.phone}>
+          <Input
+            id="phone"
+            name="phone"
+            type="tel"
+            defaultValue={defaults?.phone ?? ""}
+            maxLength={32}
+          />
+        </Field>
+        <Field label="Email" name="email" error={errors.email}>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            defaultValue={defaults?.email ?? ""}
+            maxLength={254}
+          />
+        </Field>
+      </div>
+      <Field label="Notes" name="notes" error={errors.notes}>
+        <Textarea
+          id="notes"
+          name="notes"
+          rows={4}
+          defaultValue={defaults?.notes ?? ""}
+          maxLength={4000}
+        />
+      </Field>
+      <div>
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/clients/new/page.tsx
+++ b/apps/web/src/app/(app)/clients/new/page.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { Card, PageHeader } from "@/components/form";
+import { ClientForm } from "../_components/client-form";
+import { createClientAction } from "../_actions";
+
+export default function NewClientPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader title="New client" description="Add a client profile." />
+      <Card>
+        <ClientForm action={createClientAction} submitLabel="Create client" />
+      </Card>
+      <div>
+        <Link
+          href="/clients"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to clients
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/clients/page.tsx
+++ b/apps/web/src/app/(app)/clients/page.tsx
@@ -1,21 +1,81 @@
-import { EmptyState } from "@/components/empty-state";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Button, Card, Input, PageHeader } from "@/components/form";
 
-export default function ClientsPage() {
+interface Client {
+  id: string;
+  displayName: string;
+  firstName: string;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+export default async function ClientsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const params = await searchParams;
+  const q = params.q ?? "";
+  const clients = await apiFetch<Client[]>("/clients", {
+    query: { q: q || undefined },
+  });
+
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Clients
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Client profiles, contact info, and appointment history.
-        </p>
-      </header>
-      <EmptyState
-        title="Client list coming in Phase 2"
-        body="Search, profiles, and appointment history will live here."
-        phase="Phase 2"
+      <PageHeader
+        title="Clients"
+        description="Search by name, phone, or email."
+        action={
+          <Link href="/clients/new">
+            <Button>New client</Button>
+          </Link>
+        }
       />
+      <Card>
+        <form className="flex gap-2" action="/clients">
+          <Input
+            name="q"
+            defaultValue={q}
+            placeholder="Search clients…"
+            className="flex-1"
+          />
+          <Button type="submit" variant="secondary">
+            Search
+          </Button>
+        </form>
+      </Card>
+      {clients.length === 0 ? (
+        <Card>
+          <p className="text-sm text-zinc-500">
+            {q ? `No clients match "${q}".` : "No clients yet."}
+          </p>
+        </Card>
+      ) : (
+        <Card className="p-0">
+          <ul className="divide-y divide-zinc-200">
+            {clients.map((c) => (
+              <li key={c.id}>
+                <Link
+                  href={`/clients/${c.id}`}
+                  className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-zinc-50"
+                >
+                  <div>
+                    <div className="text-sm font-medium text-zinc-900">
+                      {c.displayName}
+                    </div>
+                    <div className="text-xs text-zinc-500">
+                      {[c.phone, c.email].filter(Boolean).join(" · ") ||
+                        "No contact info"}
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/services/[id]/page.tsx
+++ b/apps/web/src/app/(app)/services/[id]/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Card, PageHeader } from "@/components/form";
+import {
+  ServiceForm,
+  type CategoryOption,
+  type ServiceDefaults,
+} from "../_components/service-form";
+import { updateServiceAction, type FormState } from "../_actions";
+
+interface ServiceDetail extends ServiceDefaults {
+  id: string;
+  name: string;
+  slug: string;
+  defaultDurationMinutes: number;
+  defaultPriceCents: number;
+  currency: string;
+  isActive: boolean;
+}
+
+export default async function ServiceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [service, categories] = await Promise.all([
+    apiFetch<ServiceDetail>(`/services/${id}`),
+    apiFetch<CategoryOption[]>("/service-categories"),
+  ]);
+
+  const action = async (
+    state: FormState,
+    formData: FormData,
+  ): Promise<FormState> => {
+    "use server";
+    return updateServiceAction(id, state, formData);
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={service.name} description={service.slug} />
+      <Card>
+        <ServiceForm
+          action={action}
+          categories={categories}
+          submitLabel="Save changes"
+          defaults={{
+            name: service.name,
+            slug: service.slug,
+            categoryId: service.categoryId,
+            description: service.description,
+            defaultDurationMinutes: service.defaultDurationMinutes,
+            defaultPriceCents: service.defaultPriceCents,
+            currency: service.currency,
+            isActive: service.isActive,
+          }}
+        />
+      </Card>
+      <div>
+        <Link
+          href="/services"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to services
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/services/_actions.ts
+++ b/apps/web/src/app/(app)/services/_actions.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  serviceCategoryCreateSchema,
+  serviceCategoryUpdateSchema,
+  serviceCreateSchema,
+  serviceUpdateSchema,
+} from "@shearsimp/shared";
+import { apiFetch, ApiError } from "@/lib/api";
+
+export interface FormState {
+  errors?: Record<string, string>;
+  message?: string;
+}
+
+function toFormErrors(parsed: { error: { issues: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }> } }): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const i of parsed.error.issues) {
+    const k = i.path.join(".") || "_";
+    if (!(k in out)) out[k] = i.message;
+  }
+  return out;
+}
+
+function readService(formData: FormData) {
+  const categoryRaw = formData.get("categoryId");
+  const categoryId =
+    categoryRaw === null || categoryRaw === "" ? null : String(categoryRaw);
+  return {
+    name: String(formData.get("name") ?? ""),
+    slug: String(formData.get("slug") ?? ""),
+    categoryId,
+    description: optional(formData.get("description")),
+    defaultDurationMinutes: parseInt(
+      String(formData.get("defaultDurationMinutes") ?? ""),
+      10,
+    ),
+    // Form collects dollars; convert to integer cents at the boundary.
+    defaultPriceCents: dollarsToCents(formData.get("defaultPriceDollars")),
+    currency: String(formData.get("currency") ?? "USD"),
+    isActive: formData.get("isActive") === "on",
+  };
+}
+
+function optional(v: FormDataEntryValue | null): string | undefined {
+  if (v === null) return undefined;
+  const s = String(v);
+  return s.length === 0 ? undefined : s;
+}
+
+function dollarsToCents(v: FormDataEntryValue | null): number {
+  if (v === null) return Number.NaN;
+  const dollars = parseFloat(String(v));
+  if (!Number.isFinite(dollars)) return Number.NaN;
+  return Math.round(dollars * 100);
+}
+
+export async function createServiceAction(
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = serviceCreateSchema.safeParse(readService(formData));
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  let created: { id: string };
+  try {
+    created = await apiFetch<{ id: string }>("/services", {
+      method: "POST",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/services");
+  redirect(`/services/${created.id}`);
+}
+
+export async function updateServiceAction(
+  id: string,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = serviceUpdateSchema.safeParse(readService(formData));
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch(`/services/${id}`, { method: "PATCH", data: parsed.data });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/services");
+  revalidatePath(`/services/${id}`);
+  return { message: "Saved." };
+}
+
+// ─── Categories ─────────────────────────────────────────────────────────────
+
+export async function createCategoryAction(
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = serviceCategoryCreateSchema.safeParse({
+    name: String(formData.get("name") ?? ""),
+    sortOrder: parseInt(String(formData.get("sortOrder") ?? "0"), 10),
+  });
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch("/service-categories", {
+      method: "POST",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/services");
+  revalidatePath("/services/categories");
+  return { message: "Category created." };
+}
+
+export async function updateCategoryAction(
+  id: string,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = serviceCategoryUpdateSchema.safeParse({
+    name: String(formData.get("name") ?? ""),
+    sortOrder: parseInt(String(formData.get("sortOrder") ?? "0"), 10),
+  });
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch(`/service-categories/${id}`, {
+      method: "PATCH",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/services");
+  revalidatePath("/services/categories");
+  return { message: "Saved." };
+}

--- a/apps/web/src/app/(app)/services/_components/category-form.tsx
+++ b/apps/web/src/app/(app)/services/_components/category-form.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useActionState } from "react";
+import { Button, Field, FormError, Input } from "@/components/form";
+import type { FormState } from "../_actions";
+
+export function CategoryCreateForm({
+  action,
+}: {
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    action,
+    {},
+  );
+  const errors = state?.errors ?? {};
+  return (
+    <form action={formAction} className="flex items-end gap-3">
+      <div className="flex-1">
+        <Field label="Category name" name="name" error={errors.name}>
+          <Input
+            id="name"
+            name="name"
+            required
+            placeholder="Color, Cut, Treatment…"
+            maxLength={80}
+          />
+        </Field>
+      </div>
+      <div className="w-28">
+        <Field label="Order" name="sortOrder" error={errors.sortOrder}>
+          <Input
+            id="sortOrder"
+            name="sortOrder"
+            type="number"
+            min={0}
+            defaultValue={0}
+          />
+        </Field>
+      </div>
+      <Button type="submit" disabled={pending}>
+        {pending ? "Adding…" : "Add"}
+      </Button>
+      {state?.message && !errors._ && (
+        <span className="text-xs text-emerald-700">{state.message}</span>
+      )}
+      <FormError message={errors._} />
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/services/_components/service-form.tsx
+++ b/apps/web/src/app/(app)/services/_components/service-form.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  Button,
+  Checkbox,
+  Field,
+  FormError,
+  Input,
+  Select,
+  Textarea,
+} from "@/components/form";
+import type { FormState } from "../_actions";
+
+export interface ServiceDefaults {
+  name?: string;
+  slug?: string;
+  categoryId?: string | null;
+  description?: string | null;
+  defaultDurationMinutes?: number;
+  defaultPriceCents?: number;
+  currency?: string;
+  isActive?: boolean;
+}
+
+export interface CategoryOption {
+  id: string;
+  name: string;
+}
+
+export function ServiceForm({
+  action,
+  defaults,
+  categories,
+  submitLabel,
+}: {
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+  defaults?: ServiceDefaults;
+  categories: CategoryOption[];
+  submitLabel: string;
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    action,
+    {},
+  );
+  const errors = state?.errors ?? {};
+  const dollars =
+    defaults?.defaultPriceCents !== undefined
+      ? (defaults.defaultPriceCents / 100).toFixed(2)
+      : "";
+  return (
+    <form action={formAction} className="space-y-5">
+      <FormError message={state?.message} />
+      <Field label="Name" name="name" error={errors.name}>
+        <Input
+          id="name"
+          name="name"
+          required
+          defaultValue={defaults?.name ?? ""}
+          maxLength={120}
+        />
+      </Field>
+      <Field
+        label="Slug"
+        name="slug"
+        error={errors.slug}
+        hint="Lowercase letters, numbers, and dashes. Used in URLs and reports."
+      >
+        <Input
+          id="slug"
+          name="slug"
+          required
+          defaultValue={defaults?.slug ?? ""}
+          maxLength={80}
+          placeholder="balayage-premium"
+        />
+      </Field>
+      <Field label="Category" name="categoryId" error={errors.categoryId}>
+        <Select
+          id="categoryId"
+          name="categoryId"
+          defaultValue={defaults?.categoryId ?? ""}
+        >
+          <option value="">Uncategorized</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid grid-cols-2 gap-4">
+        <Field
+          label="Default duration"
+          name="defaultDurationMinutes"
+          error={errors.defaultDurationMinutes}
+          hint="Minutes"
+        >
+          <Input
+            id="defaultDurationMinutes"
+            name="defaultDurationMinutes"
+            type="number"
+            required
+            min={5}
+            max={1440}
+            defaultValue={defaults?.defaultDurationMinutes ?? 60}
+          />
+        </Field>
+        <Field
+          label="Default price"
+          name="defaultPriceDollars"
+          error={errors.defaultPriceCents}
+          hint="Stored as cents on the server"
+        >
+          <Input
+            id="defaultPriceDollars"
+            name="defaultPriceDollars"
+            type="number"
+            step="0.01"
+            min={0}
+            required
+            defaultValue={dollars}
+          />
+        </Field>
+      </div>
+      <Field label="Description" name="description" error={errors.description}>
+        <Textarea
+          id="description"
+          name="description"
+          rows={3}
+          defaultValue={defaults?.description ?? ""}
+          maxLength={2000}
+        />
+      </Field>
+      <input type="hidden" name="currency" value={defaults?.currency ?? "USD"} />
+      <Checkbox
+        name="isActive"
+        label="Active (bookable)"
+        defaultChecked={defaults?.isActive ?? true}
+      />
+      <div>
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/services/categories/page.tsx
+++ b/apps/web/src/app/(app)/services/categories/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Card, PageHeader } from "@/components/form";
+import { CategoryCreateForm } from "../_components/category-form";
+import { createCategoryAction } from "../_actions";
+
+interface Category {
+  id: string;
+  name: string;
+  sortOrder: number;
+}
+
+export default async function ServiceCategoriesPage() {
+  const categories = await apiFetch<Category[]>("/service-categories");
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Service categories"
+        description="Group services for the booking screen and reports."
+      />
+      <Card>
+        <CategoryCreateForm action={createCategoryAction} />
+      </Card>
+      {categories.length === 0 ? (
+        <Card>
+          <p className="text-sm text-zinc-500">No categories yet.</p>
+        </Card>
+      ) : (
+        <Card className="p-0">
+          <ul className="divide-y divide-zinc-200">
+            {categories.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center justify-between px-6 py-3"
+              >
+                <span className="text-sm font-medium text-zinc-900">
+                  {c.name}
+                </span>
+                <span className="text-xs text-zinc-500">
+                  Order {c.sortOrder}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+      <div>
+        <Link
+          href="/services"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to services
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/services/new/page.tsx
+++ b/apps/web/src/app/(app)/services/new/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Card, PageHeader } from "@/components/form";
+import { ServiceForm, type CategoryOption } from "../_components/service-form";
+import { createServiceAction } from "../_actions";
+
+export default async function NewServicePage() {
+  const categories = await apiFetch<CategoryOption[]>("/service-categories");
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="New service"
+        description="Add a service to the catalog."
+      />
+      <Card>
+        <ServiceForm
+          action={createServiceAction}
+          categories={categories}
+          submitLabel="Create service"
+        />
+      </Card>
+      <div>
+        <Link
+          href="/services"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to services
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/services/page.tsx
+++ b/apps/web/src/app/(app)/services/page.tsx
@@ -1,21 +1,132 @@
-import { EmptyState } from "@/components/empty-state";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Button, Card, PageHeader } from "@/components/form";
 
-export default function ServicesPage() {
+interface Category {
+  id: string;
+  name: string;
+}
+
+interface ServiceRow {
+  id: string;
+  name: string;
+  slug: string;
+  isActive: boolean;
+  defaultDurationMinutes: number;
+  defaultPriceCents: number;
+  currency: string;
+  category: Category | null;
+}
+
+export default async function ServicesPage() {
+  const services = await apiFetch<ServiceRow[]>("/services");
+
+  // Group by category for the list view; uncategorized lands at the bottom.
+  const groups = new Map<string, { name: string; services: ServiceRow[] }>();
+  const uncat: ServiceRow[] = [];
+  for (const s of services) {
+    if (s.category) {
+      const g = groups.get(s.category.id) ?? {
+        name: s.category.name,
+        services: [],
+      };
+      g.services.push(s);
+      groups.set(s.category.id, g);
+    } else {
+      uncat.push(s);
+    }
+  }
+
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Services
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Service catalog with categories, default duration, and pricing.
-        </p>
-      </header>
-      <EmptyState
-        title="Service catalog coming in Phase 2"
-        body="Categories, default durations, and prices live here. Bookings snapshot these values so historical records stay accurate."
-        phase="Phase 2"
+      <PageHeader
+        title="Services"
+        description="The catalog of bookable services."
+        action={
+          <div className="flex gap-2">
+            <Link href="/services/categories">
+              <Button variant="secondary">Categories</Button>
+            </Link>
+            <Link href="/services/new">
+              <Button>New service</Button>
+            </Link>
+          </div>
+        }
       />
+      {services.length === 0 ? (
+        <Card>
+          <p className="text-sm text-zinc-500">
+            No services yet. Add one to start booking appointments.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {[...groups.values()]
+            .map((g) => ({ ...g, sortKey: g.name.toLowerCase() }))
+            .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
+            .map((g) => (
+              <ServiceGroup
+                key={g.name}
+                title={g.name}
+                services={g.services}
+              />
+            ))}
+          {uncat.length > 0 && (
+            <ServiceGroup title="Uncategorized" services={uncat} />
+          )}
+        </div>
+      )}
     </div>
   );
+}
+
+function ServiceGroup({
+  title,
+  services,
+}: {
+  title: string;
+  services: ServiceRow[];
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
+        {title}
+      </h2>
+      <Card className="p-0">
+        <ul className="divide-y divide-zinc-200">
+          {services.map((s) => (
+            <li key={s.id}>
+              <Link
+                href={`/services/${s.id}`}
+                className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-zinc-50"
+              >
+                <div>
+                  <div className="text-sm font-medium text-zinc-900">
+                    {s.name}
+                  </div>
+                  <div className="text-xs text-zinc-500">{s.slug}</div>
+                </div>
+                <div className="flex items-center gap-4 text-sm text-zinc-600">
+                  <span>{s.defaultDurationMinutes} min</span>
+                  <span>{formatPrice(s.defaultPriceCents, s.currency)}</span>
+                  {!s.isActive && (
+                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
+                      Inactive
+                    </span>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    </section>
+  );
+}
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(cents / 100);
 }

--- a/apps/web/src/app/(app)/settings/_actions.ts
+++ b/apps/web/src/app/(app)/settings/_actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { salonSettingsUpdateSchema } from "@shearsimp/shared";
+import { apiFetch, ApiError } from "@/lib/api";
+
+export interface FormState {
+  errors?: Record<string, string>;
+  message?: string;
+}
+
+function toFormErrors(parsed: { error: { issues: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }> } }): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const i of parsed.error.issues) {
+    const k = i.path.join(".") || "_";
+    if (!(k in out)) out[k] = i.message;
+  }
+  return out;
+}
+
+export async function updateSettingsAction(
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const raw = {
+    name: optional(formData.get("name")),
+    timezone: optional(formData.get("timezone")),
+  };
+  const parsed = salonSettingsUpdateSchema.safeParse(raw);
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch("/settings", { method: "PATCH", data: parsed.data });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/settings");
+  return { message: "Saved." };
+}
+
+function optional(v: FormDataEntryValue | null): string | undefined {
+  if (v === null) return undefined;
+  const s = String(v);
+  return s.length === 0 ? undefined : s;
+}

--- a/apps/web/src/app/(app)/settings/_components/settings-form.tsx
+++ b/apps/web/src/app/(app)/settings/_components/settings-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useActionState } from "react";
+import { Button, Field, FormError, Input, Select } from "@/components/form";
+import { updateSettingsAction, type FormState } from "../_actions";
+
+// A short whitelist for the picker — can grow later. Users with a salon in an
+// unusual TZ can still PATCH directly via API.
+const TIMEZONE_OPTIONS = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Phoenix",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+  "Europe/London",
+];
+
+export function SettingsForm({
+  defaults,
+}: {
+  defaults: { name: string; timezone: string; slug: string };
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    updateSettingsAction,
+    {},
+  );
+  const errors = state?.errors ?? {};
+  return (
+    <form action={formAction} className="space-y-5">
+      <FormError message={state?.message} />
+      {state?.message && !state.errors && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+          {state.message}
+        </div>
+      )}
+      <Field label="Salon name" name="name" error={errors.name}>
+        <Input
+          id="name"
+          name="name"
+          defaultValue={defaults.name}
+          maxLength={120}
+        />
+      </Field>
+      <Field
+        label="Salon URL slug"
+        name="slug"
+        hint="Edit slugs from the org switcher (Phase 1.5). Read-only here."
+      >
+        <Input id="slug" defaultValue={defaults.slug} disabled />
+      </Field>
+      <Field
+        label="Timezone"
+        name="timezone"
+        error={errors.timezone}
+        hint="Times on the schedule render in this zone."
+      >
+        <Select id="timezone" name="timezone" defaultValue={defaults.timezone}>
+          {!TIMEZONE_OPTIONS.includes(defaults.timezone) && (
+            <option value={defaults.timezone}>{defaults.timezone}</option>
+          )}
+          {TIMEZONE_OPTIONS.map((tz) => (
+            <option key={tz} value={tz}>
+              {tz}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div>
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : "Save settings"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,21 +1,31 @@
-import { EmptyState } from "@/components/empty-state";
+import { apiFetch } from "@/lib/api";
+import { Card, PageHeader } from "@/components/form";
+import { SettingsForm } from "./_components/settings-form";
 
-export default function SettingsPage() {
+interface SalonSettings {
+  id: string;
+  slug: string;
+  name: string;
+  timezone: string;
+}
+
+export default async function SettingsPage() {
+  const settings = await apiFetch<SalonSettings>("/settings");
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Settings
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Salon details, branding, business hours, and integrations.
-        </p>
-      </header>
-      <EmptyState
-        title="Settings coming in Phase 2"
-        body="Salon profile, business hours, payment provider, and SMS sender configuration."
-        phase="Phase 2"
+      <PageHeader
+        title="Settings"
+        description="Salon profile and timezone. Business hours, branding, and integrations land later."
       />
+      <Card>
+        <SettingsForm
+          defaults={{
+            name: settings.name,
+            timezone: settings.timezone,
+            slug: settings.slug,
+          }}
+        />
+      </Card>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/staff/[id]/page.tsx
+++ b/apps/web/src/app/(app)/staff/[id]/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Card, PageHeader } from "@/components/form";
+import { StaffForm } from "../_components/staff-form";
+import { WorkingHoursForm } from "../_components/working-hours-form";
+import {
+  replaceWorkingHoursAction,
+  updateStaffAction,
+  type FormState,
+} from "../_actions";
+
+interface WorkingHoursRow {
+  dayOfWeek: number;
+  startMinutesFromMidnight: number;
+  endMinutesFromMidnight: number;
+}
+
+interface StaffDetail {
+  id: string;
+  displayName: string;
+  title: string | null;
+  color: string | null;
+  bio: string | null;
+  isActive: boolean;
+  workingHours: WorkingHoursRow[];
+}
+
+export default async function StaffDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const staff = await apiFetch<StaffDetail>(`/staff/${id}`);
+
+  // Bind the staff id into the action so the client form doesn't need to
+  // smuggle it via a hidden field.
+  const updateAction = async (
+    state: FormState,
+    formData: FormData,
+  ): Promise<FormState> => {
+    "use server";
+    return updateStaffAction(id, state, formData);
+  };
+  const hoursAction = async (
+    state: FormState,
+    formData: FormData,
+  ): Promise<FormState> => {
+    "use server";
+    return replaceWorkingHoursAction(id, state, formData);
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={staff.displayName}
+        description={staff.title ?? "Stylist"}
+      />
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
+          Profile
+        </h2>
+        <Card>
+          <StaffForm
+            action={updateAction}
+            submitLabel="Save changes"
+            defaults={{
+              displayName: staff.displayName,
+              title: staff.title,
+              color: staff.color,
+              bio: staff.bio,
+              isActive: staff.isActive,
+            }}
+          />
+        </Card>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
+          Working hours
+        </h2>
+        <Card>
+          <WorkingHoursForm action={hoursAction} initial={staff.workingHours} />
+        </Card>
+      </section>
+
+      <div>
+        <Link
+          href="/staff"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to staff
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/staff/_actions.ts
+++ b/apps/web/src/app/(app)/staff/_actions.ts
@@ -1,0 +1,120 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import {
+  staffCreateSchema,
+  staffUpdateSchema,
+  workingHoursReplaceSchema,
+} from "@shearsimp/shared";
+import { apiFetch, ApiError } from "@/lib/api";
+
+export interface FormState {
+  errors?: Record<string, string>;
+  message?: string;
+}
+
+interface StaffRow {
+  id: string;
+}
+
+function toFormErrors(parsed: { error: { issues: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }> } }): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const issue of parsed.error.issues) {
+    const key = issue.path.join(".") || "_";
+    if (!(key in out)) out[key] = issue.message;
+  }
+  return out;
+}
+
+function readStaffForm(formData: FormData) {
+  return {
+    displayName: String(formData.get("displayName") ?? ""),
+    title: optionalString(formData.get("title")),
+    color: optionalString(formData.get("color")),
+    bio: optionalString(formData.get("bio")),
+    isActive: formData.get("isActive") === "on",
+  };
+}
+
+function optionalString(v: FormDataEntryValue | null): string | undefined {
+  if (v === null) return undefined;
+  const s = String(v);
+  return s.length === 0 ? undefined : s;
+}
+
+export async function createStaffAction(
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = staffCreateSchema.safeParse(readStaffForm(formData));
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  let created: StaffRow;
+  try {
+    created = await apiFetch<StaffRow>("/staff", {
+      method: "POST",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/staff");
+  redirect(`/staff/${created.id}`);
+}
+
+export async function updateStaffAction(
+  id: string,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  const parsed = staffUpdateSchema.safeParse(readStaffForm(formData));
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch(`/staff/${id}`, { method: "PATCH", data: parsed.data });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath("/staff");
+  revalidatePath(`/staff/${id}`);
+  return { message: "Saved." };
+}
+
+// Working-hours form posts a list of windows as JSON in a hidden input —
+// simpler than reconstructing a 7-day grid out of FormData entries here, and
+// keeps client-side serialization explicit.
+export async function replaceWorkingHoursAction(
+  id: string,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  let windows: unknown;
+  try {
+    windows = JSON.parse(String(formData.get("windows") ?? "[]"));
+  } catch {
+    return { errors: { _: "Could not parse working hours" } };
+  }
+  const parsed = workingHoursReplaceSchema.safeParse({ windows });
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch(`/staff/${id}/working-hours`, {
+      method: "PUT",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath(`/staff/${id}`);
+  return { message: "Working hours saved." };
+}

--- a/apps/web/src/app/(app)/staff/_components/staff-form.tsx
+++ b/apps/web/src/app/(app)/staff/_components/staff-form.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  Button,
+  Field,
+  FormError,
+  Input,
+  Textarea,
+  Checkbox,
+} from "@/components/form";
+import type { FormState } from "../_actions";
+
+export interface StaffDefaults {
+  displayName?: string;
+  title?: string | null;
+  color?: string | null;
+  bio?: string | null;
+  isActive?: boolean;
+}
+
+export function StaffForm({
+  action,
+  defaults,
+  submitLabel,
+}: {
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+  defaults?: StaffDefaults;
+  submitLabel: string;
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    action,
+    {},
+  );
+  const errors = state?.errors ?? {};
+  return (
+    <form action={formAction} className="space-y-5">
+      <FormError message={state?.message} />
+      <Field label="Display name" name="displayName" error={errors.displayName}>
+        <Input
+          id="displayName"
+          name="displayName"
+          required
+          defaultValue={defaults?.displayName ?? ""}
+          maxLength={120}
+          autoComplete="off"
+        />
+      </Field>
+      <Field label="Title" name="title" error={errors.title} hint="e.g. Senior Stylist">
+        <Input
+          id="title"
+          name="title"
+          defaultValue={defaults?.title ?? ""}
+          maxLength={80}
+        />
+      </Field>
+      <Field
+        label="Calendar color"
+        name="color"
+        error={errors.color}
+        hint="6-digit hex, like #6c8eef"
+      >
+        <Input
+          id="color"
+          name="color"
+          defaultValue={defaults?.color ?? ""}
+          placeholder="#6c8eef"
+          maxLength={7}
+        />
+      </Field>
+      <Field label="Bio" name="bio" error={errors.bio}>
+        <Textarea
+          id="bio"
+          name="bio"
+          rows={3}
+          defaultValue={defaults?.bio ?? ""}
+          maxLength={2000}
+        />
+      </Field>
+      <Checkbox
+        name="isActive"
+        label="Active (shows on the schedule)"
+        defaultChecked={defaults?.isActive ?? true}
+      />
+      <div>
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/staff/_components/working-hours-form.tsx
+++ b/apps/web/src/app/(app)/staff/_components/working-hours-form.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useActionState, useMemo, useState } from "react";
+import { Button, FormError } from "@/components/form";
+import type { FormState } from "../_actions";
+
+interface Window {
+  dayOfWeek: number;
+  startMinutesFromMidnight: number;
+  endMinutesFromMidnight: number;
+}
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export function WorkingHoursForm({
+  action,
+  initial,
+}: {
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+  initial: Window[];
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    action,
+    {},
+  );
+
+  // Group by day so the editor is row-per-day.
+  const initialByDay = useMemo(() => groupByDay(initial), [initial]);
+  const [byDay, setByDay] = useState<Record<number, Window[]>>(initialByDay);
+
+  const allWindows = useMemo<Window[]>(
+    () => Object.values(byDay).flat(),
+    [byDay],
+  );
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <FormError message={state?.errors?._ ?? state?.errors?.windows} />
+      {state?.message && !state.errors && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+          {state.message}
+        </div>
+      )}
+      <input type="hidden" name="windows" value={JSON.stringify(allWindows)} />
+      <div className="space-y-2">
+        {DAY_LABELS.map((label, day) => (
+          <DayRow
+            key={day}
+            label={label}
+            day={day}
+            windows={byDay[day] ?? []}
+            onAdd={() =>
+              setByDay((prev) => ({
+                ...prev,
+                [day]: [
+                  ...(prev[day] ?? []),
+                  // 9:00 → 17:00 default — receptionist-friendly placeholder.
+                  {
+                    dayOfWeek: day,
+                    startMinutesFromMidnight: 9 * 60,
+                    endMinutesFromMidnight: 17 * 60,
+                  },
+                ],
+              }))
+            }
+            onChange={(idx, w) =>
+              setByDay((prev) => ({
+                ...prev,
+                [day]: (prev[day] ?? []).map((existing, i) =>
+                  i === idx ? w : existing,
+                ),
+              }))
+            }
+            onRemove={(idx) =>
+              setByDay((prev) => ({
+                ...prev,
+                [day]: (prev[day] ?? []).filter((_, i) => i !== idx),
+              }))
+            }
+          />
+        ))}
+      </div>
+      <Button type="submit" disabled={pending}>
+        {pending ? "Saving…" : "Save working hours"}
+      </Button>
+    </form>
+  );
+}
+
+function DayRow({
+  label,
+  day,
+  windows,
+  onAdd,
+  onChange,
+  onRemove,
+}: {
+  label: string;
+  day: number;
+  windows: Window[];
+  onAdd: () => void;
+  onChange: (idx: number, w: Window) => void;
+  onRemove: (idx: number) => void;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-zinc-200 bg-white p-3">
+      <div className="w-12 pt-2 text-sm font-medium text-zinc-700">{label}</div>
+      <div className="flex-1 space-y-2">
+        {windows.length === 0 && (
+          <div className="text-sm text-zinc-400">Closed</div>
+        )}
+        {windows.map((w, idx) => (
+          <div key={idx} className="flex items-center gap-2">
+            <input
+              type="time"
+              value={minutesToHHMM(w.startMinutesFromMidnight)}
+              onChange={(e) =>
+                onChange(idx, {
+                  ...w,
+                  dayOfWeek: day,
+                  startMinutesFromMidnight: hhmmToMinutes(e.target.value),
+                })
+              }
+              className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm"
+            />
+            <span className="text-sm text-zinc-400">to</span>
+            <input
+              type="time"
+              value={minutesToHHMM(w.endMinutesFromMidnight)}
+              onChange={(e) =>
+                onChange(idx, {
+                  ...w,
+                  dayOfWeek: day,
+                  endMinutesFromMidnight: hhmmToMinutes(e.target.value),
+                })
+              }
+              className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm"
+            />
+            <button
+              type="button"
+              onClick={() => onRemove(idx)}
+              className="ml-2 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-50"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={onAdd}
+        className="rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50"
+      >
+        + window
+      </button>
+    </div>
+  );
+}
+
+function groupByDay(windows: Window[]): Record<number, Window[]> {
+  const out: Record<number, Window[]> = {};
+  for (const w of windows) {
+    (out[w.dayOfWeek] ??= []).push(w);
+  }
+  return out;
+}
+
+function minutesToHHMM(m: number): string {
+  const h = Math.floor(m / 60).toString().padStart(2, "0");
+  const min = (m % 60).toString().padStart(2, "0");
+  return `${h}:${min}`;
+}
+
+function hhmmToMinutes(s: string): number {
+  const [h, m] = s.split(":").map((p) => parseInt(p, 10));
+  return (h ?? 0) * 60 + (m ?? 0);
+}

--- a/apps/web/src/app/(app)/staff/new/page.tsx
+++ b/apps/web/src/app/(app)/staff/new/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { Card, PageHeader } from "@/components/form";
+import { StaffForm } from "../_components/staff-form";
+import { createStaffAction } from "../_actions";
+
+export default function NewStaffPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="New stylist"
+        description="Add a stylist to the schedule."
+      />
+      <Card>
+        <StaffForm action={createStaffAction} submitLabel="Create stylist" />
+      </Card>
+      <div>
+        <Link
+          href="/staff"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
+          ← Back to staff
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/staff/page.tsx
+++ b/apps/web/src/app/(app)/staff/page.tsx
@@ -1,21 +1,69 @@
-import { EmptyState } from "@/components/empty-state";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { Button, Card, PageHeader } from "@/components/form";
 
-export default function StaffPage() {
+interface StaffRow {
+  id: string;
+  displayName: string;
+  title: string | null;
+  color: string | null;
+  isActive: boolean;
+}
+
+export default async function StaffPage() {
+  const staff = await apiFetch<StaffRow[]>("/staff");
+
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Staff
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Stylists, working hours, and roles.
-        </p>
-      </header>
-      <EmptyState
-        title="Staff management coming in Phase 2"
-        body="Profiles, working hours, color tags, and role assignment land here."
-        phase="Phase 2"
+      <PageHeader
+        title="Staff"
+        description="Stylists, working hours, and roles."
+        action={
+          <Link href="/staff/new">
+            <Button>New stylist</Button>
+          </Link>
+        }
       />
+      {staff.length === 0 ? (
+        <Card>
+          <p className="text-sm text-zinc-500">
+            No staff yet. Add your first stylist to start scheduling.
+          </p>
+        </Card>
+      ) : (
+        <Card className="p-0">
+          <ul className="divide-y divide-zinc-200">
+            {staff.map((s) => (
+              <li key={s.id}>
+                <Link
+                  href={`/staff/${s.id}`}
+                  className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-zinc-50"
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="h-3 w-3 rounded-full border border-zinc-200"
+                      style={{ backgroundColor: s.color ?? "#e5e7eb" }}
+                    />
+                    <div>
+                      <div className="text-sm font-medium text-zinc-900">
+                        {s.displayName}
+                      </div>
+                      {s.title && (
+                        <div className="text-xs text-zinc-500">{s.title}</div>
+                      )}
+                    </div>
+                  </div>
+                  {!s.isActive && (
+                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
+                      Inactive
+                    </span>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/form.tsx
+++ b/apps/web/src/components/form.tsx
@@ -1,0 +1,161 @@
+// Lightweight form primitives. Tailwind classes inline to keep the component
+// surface obvious — when there are 5 of these the styling is the value.
+
+interface FieldProps {
+  label: string;
+  name: string;
+  hint?: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+export function Field({ label, name, hint, error, children }: FieldProps) {
+  return (
+    <div className="space-y-1.5">
+      <label
+        htmlFor={name}
+        className="block text-sm font-medium text-zinc-800"
+      >
+        {label}
+      </label>
+      {children}
+      {hint && !error && (
+        <p className="text-xs text-zinc-500">{hint}</p>
+      )}
+      {error && <p className="text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}
+
+export function Input(
+  props: React.InputHTMLAttributes<HTMLInputElement>,
+) {
+  return (
+    <input
+      {...props}
+      className={
+        "block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 " +
+        (props.className ?? "")
+      }
+    />
+  );
+}
+
+export function Textarea(
+  props: React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+) {
+  return (
+    <textarea
+      {...props}
+      className={
+        "block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 " +
+        (props.className ?? "")
+      }
+    />
+  );
+}
+
+export function Select(
+  props: React.SelectHTMLAttributes<HTMLSelectElement>,
+) {
+  return (
+    <select
+      {...props}
+      className={
+        "block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 " +
+        (props.className ?? "")
+      }
+    />
+  );
+}
+
+export function Checkbox({
+  label,
+  ...props
+}: { label: string } & React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <label className="inline-flex items-center gap-2 text-sm text-zinc-800">
+      <input
+        type="checkbox"
+        {...props}
+        className="h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-500"
+      />
+      {label}
+    </label>
+  );
+}
+
+export function Button(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: "primary" | "secondary";
+  },
+) {
+  const { variant = "primary", className, ...rest } = props;
+  const palette =
+    variant === "primary"
+      ? "bg-zinc-900 text-white hover:bg-zinc-800"
+      : "bg-white text-zinc-800 border border-zinc-300 hover:bg-zinc-50";
+  return (
+    <button
+      {...rest}
+      className={
+        "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed " +
+        palette +
+        " " +
+        (className ?? "")
+      }
+    />
+  );
+}
+
+export function FormError({ message }: { message: string | null | undefined }) {
+  if (!message) return null;
+  return (
+    <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+      {message}
+    </div>
+  );
+}
+
+export function PageHeader({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <header className="flex items-start justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
+          {title}
+        </h1>
+        {description && (
+          <p className="mt-1 text-sm text-zinc-500">{description}</p>
+        )}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </header>
+  );
+}
+
+export function Card({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={
+        "rounded-xl border border-zinc-200 bg-white p-6 shadow-sm " +
+        (className ?? "")
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -52,7 +52,7 @@ export function Sidebar({ activeHref }: { activeHref: string }) {
         </ul>
       </nav>
       <div className="border-t border-zinc-200 px-4 py-3 text-xs text-zinc-400">
-        Phase 1 · Foundation
+        Phase 2 · Core data
       </div>
     </aside>
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,97 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { serverEnv } from "./env";
+
+/**
+ * Server-side fetch helper for the API. Forwards browser cookies so both auth
+ * providers work without branching here:
+ *  - Dev mode: the signed `__shearsimp_dev_session` cookie reaches the api,
+ *    where DevAuthProvider verifies it.
+ *  - Clerk mode: the `__session` cookie reaches the api, where
+ *    ClerkAuthProvider passes it to `@clerk/backend`'s authenticateRequest.
+ *
+ * Pass `data` to send a JSON body. Throws ApiError on non-2xx so callers can
+ * surface validation issues to the form. Server-only — never bundle this into
+ * a client component.
+ */
+export async function apiFetch<T>(
+  path: string,
+  init: { method?: string; data?: unknown; query?: Record<string, string | undefined> } = {},
+): Promise<T> {
+  const url = new URL(path, serverEnv.apiInternalUrl);
+  if (init.query) {
+    for (const [k, v] of Object.entries(init.query)) {
+      if (v !== undefined && v !== "") url.searchParams.set(k, v);
+    }
+  }
+
+  const cookieHeader = await buildCookieHeader();
+  const headers: Record<string, string> = { cookie: cookieHeader };
+  let body: string | undefined;
+  if (init.data !== undefined) {
+    headers["content-type"] = "application/json";
+    body = JSON.stringify(init.data);
+  }
+
+  const res = await fetch(url, {
+    method: init.method ?? "GET",
+    headers,
+    body,
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    let payload: unknown;
+    try {
+      payload = await res.json();
+    } catch {
+      payload = await res.text();
+    }
+    throw new ApiError(res.status, payload);
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}
+
+async function buildCookieHeader(): Promise<string> {
+  const store = await cookies();
+  return store
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ");
+}
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly payload: unknown;
+  constructor(status: number, payload: unknown) {
+    super(`API ${status}`);
+    this.status = status;
+    this.payload = payload;
+  }
+
+  // Helper for surfacing Zod-style validation errors back to a form.
+  fieldMessages(): Record<string, string> | null {
+    const p = this.payload as
+      | { issues?: Array<{ path?: string; message?: string }> }
+      | undefined;
+    if (!p?.issues) return null;
+    const map: Record<string, string> = {};
+    for (const issue of p.issues) {
+      if (issue.path && issue.message) {
+        map[issue.path] = issue.message;
+      }
+    }
+    return map;
+  }
+
+  topMessage(): string {
+    const p = this.payload as
+      | { message?: string; error?: string }
+      | undefined;
+    return p?.message ?? p?.error ?? `Request failed (${this.status})`;
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,9 +11,13 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc",
     "lint": "echo 'lint: noop'",
-    "test": "echo 'test: noop'"
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -93,6 +93,17 @@ export const EventType = {
   CLIENT_CREATED: "client.created",
   CLIENT_UPDATED: "client.updated",
 
+  STAFF_CREATED: "staff.created",
+  STAFF_UPDATED: "staff.updated",
+  WORKING_HOURS_UPDATED: "staff.working_hours_updated",
+
+  SERVICE_CATEGORY_CREATED: "service_category.created",
+  SERVICE_CATEGORY_UPDATED: "service_category.updated",
+  SERVICE_CREATED: "service.created",
+  SERVICE_UPDATED: "service.updated",
+
+  SALON_UPDATED: "salon.updated",
+
   AI_DURATION_ESTIMATE_GENERATED: "ai.duration_estimate_generated",
   AI_RECOMMENDATION_SHOWN: "ai.recommendation_shown",
   AI_RECOMMENDATION_ACCEPTED: "ai.recommendation_accepted",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./enums.js";
 export * from "./types.js";
+export * from "./schemas.js";

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -42,13 +42,18 @@ const phoneSchema = z
   .transform((s) => (s === undefined || s === "" ? null : s))
   .nullable();
 
-const emailSchema = z
-  .string()
-  .transform((s) => s.trim().toLowerCase())
-  .pipe(z.string().email().max(254))
-  .optional()
-  .transform((s) => (s === undefined || s === "" ? null : s))
-  .nullable();
+// Empty strings come from cleared form fields and must round-trip to null on
+// update so the user can actually remove a saved address. Preprocess collapses
+// blank/undefined to null up front so the inner email validator never sees an
+// empty string (which it would otherwise reject as malformed).
+const emailSchema = z.preprocess(
+  (v) => {
+    if (typeof v !== "string") return v ?? null;
+    const t = v.trim().toLowerCase();
+    return t === "" ? null : t;
+  },
+  z.string().email().max(254).nullable(),
+);
 
 const slugSchema = z
   .string()

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,0 +1,225 @@
+import { z } from "zod";
+import { Role } from "./enums.js";
+
+// Field-level building blocks — reused across create/update shapes so the
+// same trim/length/format rules apply everywhere.
+
+const trimmedString = (max: number) =>
+  z
+    .string()
+    .transform((s) => s.trim())
+    .pipe(z.string().min(1, "Required").max(max));
+
+const optionalTrimmed = (max: number) =>
+  z
+    .string()
+    .transform((s) => s.trim())
+    .pipe(z.string().max(max))
+    .optional()
+    .transform((s) => (s === undefined || s === "" ? null : s))
+    .nullable();
+
+// 7-char hex color including the leading "#". Frontend renders these as
+// stylist column tints; we don't need full CSS color support.
+const hexColor = z
+  .string()
+  .regex(/^#[0-9a-fA-F]{6}$/, "Use a #RRGGBB hex color")
+  .optional()
+  .nullable();
+
+// Phone numbers stored as the user typed them (we display, not dial).
+// Validation only enforces an upper bound and that there's at least one digit.
+const phoneSchema = z
+  .string()
+  .transform((s) => s.trim())
+  .pipe(
+    z
+      .string()
+      .max(32)
+      .refine((s) => s === "" || /\d/.test(s), "Phone must contain digits"),
+  )
+  .optional()
+  .transform((s) => (s === undefined || s === "" ? null : s))
+  .nullable();
+
+const emailSchema = z
+  .string()
+  .transform((s) => s.trim().toLowerCase())
+  .pipe(z.string().email().max(254))
+  .optional()
+  .transform((s) => (s === undefined || s === "" ? null : s))
+  .nullable();
+
+const slugSchema = z
+  .string()
+  .transform((s) => s.trim().toLowerCase())
+  .pipe(
+    z
+      .string()
+      .min(1)
+      .max(80)
+      .regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/, "Use lowercase letters, numbers, and dashes"),
+  );
+
+const uuidSchema = z.string().uuid();
+
+// IANA tz database identifiers are too varied to validate by regex; we lean on
+// Intl.DateTimeFormat at runtime instead. The schema keeps a sane upper bound
+// so a malformed value still fails fast.
+const timezoneSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .refine((tz) => isValidTimezone(tz), "Unknown IANA timezone");
+
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Staff
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const staffCreateSchema = z.object({
+  displayName: trimmedString(120),
+  title: optionalTrimmed(80),
+  color: hexColor,
+  bio: optionalTrimmed(2000),
+  isActive: z.boolean().default(true),
+  userId: uuidSchema.optional().nullable(),
+});
+
+export const staffUpdateSchema = staffCreateSchema.partial();
+
+export type StaffCreateInput = z.infer<typeof staffCreateSchema>;
+export type StaffUpdateInput = z.infer<typeof staffUpdateSchema>;
+
+// Working hours editor receives the full set per stylist as a replacement
+// (simpler than diffing rows). Each row is a single weekday window in the
+// salon's local time, expressed as minutes from midnight.
+export const workingHoursWindowSchema = z
+  .object({
+    dayOfWeek: z.number().int().min(0).max(6),
+    startMinutesFromMidnight: z.number().int().min(0).max(24 * 60),
+    endMinutesFromMidnight: z.number().int().min(0).max(24 * 60),
+  })
+  .refine(
+    (w) => w.endMinutesFromMidnight > w.startMinutesFromMidnight,
+    "End must be after start",
+  );
+
+export const workingHoursReplaceSchema = z.object({
+  windows: z.array(workingHoursWindowSchema).max(50),
+});
+
+export type WorkingHoursWindow = z.infer<typeof workingHoursWindowSchema>;
+export type WorkingHoursReplaceInput = z.infer<
+  typeof workingHoursReplaceSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Salon membership (used by staff page when linking a stylist to a user)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const roleSchema = z.nativeEnum(Role);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Services + categories
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const serviceCategoryCreateSchema = z.object({
+  name: trimmedString(80),
+  sortOrder: z.number().int().min(0).max(9999).default(0),
+});
+
+export const serviceCategoryUpdateSchema = serviceCategoryCreateSchema.partial();
+
+export type ServiceCategoryCreateInput = z.infer<
+  typeof serviceCategoryCreateSchema
+>;
+export type ServiceCategoryUpdateInput = z.infer<
+  typeof serviceCategoryUpdateSchema
+>;
+
+// Prices are integer cents to keep arithmetic exact. 24h × 60 min upper bound
+// on duration so a typo can't produce a year-long appointment block.
+export const serviceCreateSchema = z.object({
+  name: trimmedString(120),
+  slug: slugSchema,
+  categoryId: uuidSchema.optional().nullable(),
+  description: optionalTrimmed(2000),
+  defaultDurationMinutes: z.number().int().min(5).max(24 * 60),
+  defaultPriceCents: z.number().int().min(0).max(10_000_000),
+  currency: z
+    .string()
+    .length(3)
+    .transform((s) => s.toUpperCase())
+    .default("USD"),
+  isActive: z.boolean().default(true),
+});
+
+export const serviceUpdateSchema = serviceCreateSchema.partial();
+
+export type ServiceCreateInput = z.infer<typeof serviceCreateSchema>;
+export type ServiceUpdateInput = z.infer<typeof serviceUpdateSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clients
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const clientCreateSchema = z
+  .object({
+    firstName: trimmedString(80),
+    lastName: optionalTrimmed(80),
+    displayName: optionalTrimmed(160),
+    email: emailSchema,
+    phone: phoneSchema,
+    notes: optionalTrimmed(4000),
+  })
+  .transform((c) => ({
+    ...c,
+    // Default displayName to "First Last" so list views always have a label,
+    // without forcing the form to compute it client-side.
+    displayName:
+      c.displayName ??
+      [c.firstName, c.lastName].filter((p): p is string => Boolean(p)).join(" "),
+  }));
+
+export const clientUpdateSchema = z.object({
+  firstName: trimmedString(80).optional(),
+  lastName: optionalTrimmed(80).optional(),
+  // displayName is non-null in the model — allow editing the value but not
+  // clearing it. Use clientCreateSchema's derivation if you want the auto
+  // "First Last" fallback.
+  displayName: trimmedString(160).optional(),
+  email: emailSchema.optional(),
+  phone: phoneSchema.optional(),
+  notes: optionalTrimmed(4000).optional(),
+});
+
+export type ClientCreateInput = z.infer<typeof clientCreateSchema>;
+export type ClientUpdateInput = z.infer<typeof clientUpdateSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Salon settings (Phase 2 surface — name, timezone. Business hours and
+// branding land later.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const salonSettingsUpdateSchema = z
+  .object({
+    name: trimmedString(120).optional(),
+    timezone: timezoneSchema.optional(),
+  })
+  .refine(
+    (s) => s.name !== undefined || s.timezone !== undefined,
+    "Provide at least one field to update",
+  );
+
+export type SalonSettingsUpdateInput = z.infer<
+  typeof salonSettingsUpdateSchema
+>;

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -150,6 +150,19 @@ describe("clientUpdateSchema", () => {
   it("accepts an empty update (no-op)", () => {
     expect(clientUpdateSchema.parse({})).toEqual({});
   });
+
+  it("collapses blank optional fields to null so updates can clear them", () => {
+    const parsed = clientUpdateSchema.parse({
+      lastName: "",
+      email: "",
+      phone: "",
+      notes: "",
+    });
+    expect(parsed.lastName).toBeNull();
+    expect(parsed.email).toBeNull();
+    expect(parsed.phone).toBeNull();
+    expect(parsed.notes).toBeNull();
+  });
 });
 
 describe("salonSettingsUpdateSchema", () => {

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  clientCreateSchema,
+  clientUpdateSchema,
+  salonSettingsUpdateSchema,
+  serviceCategoryCreateSchema,
+  serviceCreateSchema,
+  serviceUpdateSchema,
+  staffCreateSchema,
+  workingHoursReplaceSchema,
+} from "../src/schemas.js";
+
+describe("staffCreateSchema", () => {
+  it("trims displayName and applies isActive default", () => {
+    const parsed = staffCreateSchema.parse({ displayName: "  Maya  " });
+    expect(parsed.displayName).toBe("Maya");
+    expect(parsed.isActive).toBe(true);
+    expect(parsed.title).toBeNull();
+  });
+
+  it("rejects an empty displayName after trim", () => {
+    expect(() => staffCreateSchema.parse({ displayName: "   " })).toThrow();
+  });
+
+  it("rejects a non-hex color", () => {
+    expect(() =>
+      staffCreateSchema.parse({ displayName: "Maya", color: "blue" }),
+    ).toThrow();
+  });
+
+  it("accepts a valid 6-digit hex color", () => {
+    const parsed = staffCreateSchema.parse({
+      displayName: "Maya",
+      color: "#a1b2c3",
+    });
+    expect(parsed.color).toBe("#a1b2c3");
+  });
+});
+
+describe("workingHoursReplaceSchema", () => {
+  it("rejects a window with end at or before start", () => {
+    expect(() =>
+      workingHoursReplaceSchema.parse({
+        windows: [
+          {
+            dayOfWeek: 1,
+            startMinutesFromMidnight: 600,
+            endMinutesFromMidnight: 600,
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts an empty replacement (closes the calendar)", () => {
+    expect(workingHoursReplaceSchema.parse({ windows: [] })).toEqual({
+      windows: [],
+    });
+  });
+});
+
+describe("serviceCreateSchema", () => {
+  it("normalizes slug and currency", () => {
+    const parsed = serviceCreateSchema.parse({
+      name: "Balayage",
+      slug: "  Balayage-Premium  ",
+      defaultDurationMinutes: 180,
+      defaultPriceCents: 18000,
+      currency: "usd",
+    });
+    expect(parsed.slug).toBe("balayage-premium");
+    expect(parsed.currency).toBe("USD");
+  });
+
+  it("rejects slug with whitespace or symbols", () => {
+    expect(() =>
+      serviceCreateSchema.parse({
+        name: "Cut",
+        slug: "men's cut",
+        defaultDurationMinutes: 30,
+        defaultPriceCents: 4500,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects out-of-range duration", () => {
+    expect(() =>
+      serviceCreateSchema.parse({
+        name: "Cut",
+        slug: "cut",
+        defaultDurationMinutes: 0,
+        defaultPriceCents: 4500,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("serviceUpdateSchema", () => {
+  it("accepts a partial update", () => {
+    const parsed = serviceUpdateSchema.parse({ defaultPriceCents: 5500 });
+    expect(parsed.defaultPriceCents).toBe(5500);
+    expect(parsed.name).toBeUndefined();
+  });
+});
+
+describe("serviceCategoryCreateSchema", () => {
+  it("defaults sortOrder to 0", () => {
+    expect(serviceCategoryCreateSchema.parse({ name: "Color" })).toEqual({
+      name: "Color",
+      sortOrder: 0,
+    });
+  });
+});
+
+describe("clientCreateSchema", () => {
+  it("derives displayName from first/last when omitted", () => {
+    const parsed = clientCreateSchema.parse({
+      firstName: "Sam",
+      lastName: "Lee",
+    });
+    expect(parsed.displayName).toBe("Sam Lee");
+  });
+
+  it("preserves an explicit displayName", () => {
+    const parsed = clientCreateSchema.parse({
+      firstName: "Sam",
+      displayName: "Sammy",
+    });
+    expect(parsed.displayName).toBe("Sammy");
+  });
+
+  it("lowercases email and treats blank phone as null", () => {
+    const parsed = clientCreateSchema.parse({
+      firstName: "Sam",
+      email: "  Sam@Example.COM ",
+      phone: "   ",
+    });
+    expect(parsed.email).toBe("sam@example.com");
+    expect(parsed.phone).toBeNull();
+  });
+
+  it("rejects a phone with no digits", () => {
+    expect(() =>
+      clientCreateSchema.parse({ firstName: "Sam", phone: "----" }),
+    ).toThrow();
+  });
+});
+
+describe("clientUpdateSchema", () => {
+  it("accepts an empty update (no-op)", () => {
+    expect(clientUpdateSchema.parse({})).toEqual({});
+  });
+});
+
+describe("salonSettingsUpdateSchema", () => {
+  it("accepts a known IANA timezone", () => {
+    expect(
+      salonSettingsUpdateSchema.parse({ timezone: "America/Los_Angeles" }),
+    ).toEqual({ timezone: "America/Los_Angeles" });
+  });
+
+  it("rejects an unknown timezone", () => {
+    expect(() =>
+      salonSettingsUpdateSchema.parse({ timezone: "Mars/Olympus_Mons" }),
+    ).toThrow();
+  });
+
+  it("rejects an empty payload", () => {
+    expect(() => salonSettingsUpdateSchema.parse({})).toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,10 +160,17 @@ importers:
         version: 5.9.3
 
   packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
 
 packages:
 


### PR DESCRIPTION
## Summary
- Staff, services, clients, and salon settings are now editable through the admin shell.
- Every write goes through `@shearsimp/shared` Zod schemas and appends a `domain_events` row in the same transaction as the business write.
- Schema needed no migration — Phase 1's composite uniques already cover `(salonId, slug/phone/email)`.

## What landed

**API** (`apps/api/src/`)
- `staff/`, `services/`, `clients/`, `settings/` Nest modules behind the existing `AuthGuard` + `TenantGuard`, scoped via `@CurrentSalon()`
- `common/zod-validation.pipe.ts` + `common/domain-events.ts` for consistent input validation and event-append boundaries
- Working-hours replace endpoint (`PUT /staff/:id/working-hours`) scoped via the `StaffMember` composite FK
- Service ↔ category linking uses the named composite-unique key, so cross-tenant categoryId is rejected at the schema level

**Web** (`apps/web/src/`)
- list / create / edit pages for each resource using server actions and shared Zod schemas
- working-hours editor (per-day windows, replace-on-save)
- client profile shows a read-only appointment history rollup (empty until Phase 3 populates appointments — the query is correct now)
- shared form primitives in `components/form.tsx`
- server-side `apiFetch` helper that forwards browser cookies so the same call works in both dev and Clerk auth modes

**Shared** (`packages/shared/`)
- new `schemas.ts` with Zod create/update schemas for each resource (slug normalization, currency uppercasing, IANA timezone validation, etc.)
- new `EventType` entries: `staff.*`, `service*.*`, `salon.updated`, `staff.working_hours_updated`

## Verification

- `pnpm --filter @shearsimp/shared test` — 19/19 Zod schema tests pass
- `pnpm --filter @shearsimp/api test` — 5/5 Phase 1 auth-parity tests still pass
- `pnpm --filter @shearsimp/db test` — enum parity OK across 9 enums
- `pnpm --filter @shearsimp/db prisma:validate` — schema valid
- `pnpm --filter @shearsimp/{shared,db,api,web} typecheck` — all clean

Service-level integration tests are intentionally deferred — they need a test Postgres harness and that's better introduced once Phase 3 brings real query complexity to test against.

## Test plan
- [ ] `pnpm db:seed` then sign in via dev mode
- [ ] Add a stylist, set working hours across two days, edit profile
- [ ] Add a service category, then a service that references it; confirm the slug uniqueness blocks a duplicate
- [ ] Add a client with a phone number; confirm a second client with the same phone is rejected with a friendly message
- [ ] Edit salon timezone in Settings; confirm the value persists
- [ ] Spot-check `domain_events` table — one row per write