### PR TITLE
fix: make api dev runner work end-to-end

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "dotenv -e ../../.env -- tsx watch src/main.ts",
+    "dev": "dotenv -e ../../.env -- nest start --watch",
     "build": "nest build",
     "start": "dotenv -e ../../.env -- node dist/main.js",
     "start:prod": "node dist/main.js",

--- a/apps/api/src/common/zod-validation.pipe.ts
+++ b/apps/api/src/common/zod-validation.pipe.ts
@@ -4,10 +4,6 @@ import type { ZodTypeAny, infer as zInfer } from "zod";
 /**
  * Validates and transforms request payloads with a Zod schema. Schema parse
  * errors surface as a 400 with a flattened issue list.
- *
- * Pair with the global Nest ValidationPipe by listing this one explicitly on
- * the parameter — the global pipe still runs for non-Zod bodies (e.g. plain
- * primitives) and remains the place class-validator decorators are honored.
  */
 export class ZodValidationPipe<S extends ZodTypeAny>
   implements PipeTransform<unknown, zInfer<S>>

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
-import { Logger, ValidationPipe } from "@nestjs/common";
+import { Logger } from "@nestjs/common";
 import cookieParser from "cookie-parser";
 import { AppModule } from "./app.module";
 import { env } from "./env";
@@ -19,13 +19,6 @@ async function bootstrap(): Promise<void> {
     origin: env.WEB_ORIGIN,
     credentials: true,
   });
-  app.useGlobalPipes(
-    new ValidationPipe({
-      transform: true,
-      whitelist: true,
-      forbidNonWhitelisted: true,
-    }),
-  );
 
   await app.listen(env.API_PORT);
   Logger.log(

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "packageManager": "pnpm@9.12.0",
   "scripts": {
-    "dev": "pnpm -r --parallel --stream dev",
+    "dev": "pnpm --filter \"./packages/*\" build && pnpm -r --parallel --stream dev",
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,10 +2,13 @@
   "name": "@shearsimp/db",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
     "./prisma": "./node_modules/@prisma/client/index.js"
   },
   "scripts": {
@@ -17,6 +20,7 @@
     "seed": "dotenv -e ../../.env -- tsx prisma/seed.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsc",
+    "dev": "tsc -w --preserveWatchOutput",
     "lint": "echo 'lint: noop'",
     "test": "dotenv -e ../../.env -- tsx test/enum-parity.test.ts"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,14 +2,18 @@
   "name": "@shearsimp/shared",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsc",
+    "dev": "tsc -w --preserveWatchOutput",
     "lint": "echo 'lint: noop'",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary

The api dev server couldn't serve a single authenticated request. Three blockers, fixed in one pass:

- **Boot crash from global `ValidationPipe`.** Nest's global `ValidationPipe` requires `class-validator`, which isn't installed (the codebase validates everything through `ZodValidationPipe`). Removed the global pipe and the now-unused doc comment that referenced it.
- **Decorator metadata wasn't being emitted.** `apps/api` was running under `tsx watch`, which (via esbuild) didn't reliably emit TypeScript decorator metadata. Nest's DI silently injected `undefined` for type-only constructor params — `AuthGuard.canActivate` blew up on `this.reflector` the moment a guarded route was hit. Switched the api `dev` script to `nest start --watch`, which compiles via `tsc` and honors `emitDecoratorMetadata`.
- **Workspace packages exposed raw TS.** Once the api ran as plain Node, it couldn't `require("@shearsimp/shared")` because `main` pointed at `./src/index.ts`. Built `packages/shared` and `packages/db` to `dist/` and updated their `main`/`types`/`exports` to match. Added `dev: tsc -w` scripts so edits propagate, and made the root `pnpm dev` do a one-shot package build before kicking off the parallel watchers so dist exists before api/web start.

## Test plan

- [ ] `pnpm dev` from a clean checkout
- [ ] Sign in via dev auth, navigate to `/clients` and `/staff` — both render without a 500
- [ ] Edit a file in `packages/shared` and confirm the api picks up the change without a manual rebuild
- [ ] `pnpm typecheck` and `pnpm build` still pass