### PR TITLE
Phase 3a: scheduling backend (CRUD, state machine, conflicts, outbox stub)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ PR: [#1](https://github.com/jnoecker/ShearSimplicity/pull/1)
 - Enum parity test between `@shearsimp/shared` and Prisma
 - `dotenv-cli` so Prisma scripts pick up the root `.env`
 
-## Phase 1.5 — Clerk Organizations 🚧
+## Phase 1.5 — Clerk Organizations ✅
 
 Replace `DevAuthProvider` with a real auth flow without changing controllers.
 
@@ -72,7 +72,7 @@ Replace `DevAuthProvider` with a real auth flow without changing controllers.
 
 **Risks:** Clerk's Next SDK is intrusive; treat its boundary carefully so swap-back to dev mode stays cheap. Don't leak Clerk types into shared packages.
 
-## Phase 2 — Core salon data 🚧
+## Phase 2 — Core salon data ✅
 
 CRUD UIs and APIs for the entities the rest of the product depends on.
 
@@ -86,18 +86,24 @@ CRUD UIs and APIs for the entities the rest of the product depends on.
 
 **Definition of done:** can create a salon, add 3 stylists with hours, add 5 services in 2 categories, add 10 clients, all without touching the database directly.
 
-## Phase 3 — Scheduling ⬜
+## Phase 3 — Scheduling 🚧
 
-Where the product earns its keep.
+Where the product earns its keep. Split into sub-phases so each PR stays
+focused.
+
+### Phase 3a — Scheduling backend 🚧
 
 - Create / reschedule / cancel appointments with conflict detection (no overlap on same stylist)
 - Status state machine: `SCHEDULED → CONFIRMED → CHECKED_IN → IN_PROGRESS → COMPLETED` (plus `CANCELLED`, `NO_SHOW`)
 - On status change, append `appointment.*` domain events
-- Calendar view: day, week, stylist column views; drag-to-reschedule
-- Stylist availability respects `WorkingHours` and existing appointments
 - Appointment notes (client-visible) and internal notes (staff only)
 - Capture `actualStartAt` / `actualEndAt` / `actualDurationMinutes` on completion (Phase 6 will use these as ground truth)
 - Outbox worker stub: process `appointment.created` events (no side effects yet — wired in Phase 4)
+
+### Phase 3b — Calendar UI ⬜
+
+- Calendar view: day, week, stylist column views; drag-to-reschedule
+- Stylist availability respects `WorkingHours` and existing appointments
 
 **Risks:** time zones. Store everything UTC; render in salon's `timezone`. DST edge cases at the salon-hour boundary.
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,8 @@ import { SalonsModule } from "./salons/salons.module";
 import { StaffModule } from "./staff/staff.module";
 import { ServicesModule } from "./services/services.module";
 import { ClientsModule } from "./clients/clients.module";
+import { AppointmentsModule } from "./appointments/appointments.module";
+import { OutboxModule } from "./outbox/outbox.module";
 import { SettingsModule } from "./settings/settings.module";
 import { WebhooksModule } from "./webhooks/webhooks.module";
 
@@ -25,6 +27,8 @@ import { WebhooksModule } from "./webhooks/webhooks.module";
     StaffModule,
     ServicesModule,
     ClientsModule,
+    AppointmentsModule,
+    OutboxModule,
     SettingsModule,
     WebhooksModule,
   ],

--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -1,0 +1,127 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from "@nestjs/common";
+import {
+  appointmentCancelSchema,
+  appointmentCompleteSchema,
+  appointmentCreateSchema,
+  appointmentListQuerySchema,
+  appointmentNotesUpdateSchema,
+  appointmentRescheduleSchema,
+  appointmentTransitionSchema,
+} from "@shearsimp/shared";
+import type {
+  AppointmentCancelInput,
+  AppointmentCompleteInput,
+  AppointmentCreateInput,
+  AppointmentListQueryInput,
+  AppointmentNotesUpdateInput,
+  AppointmentRescheduleInput,
+  AppointmentTransitionInput,
+} from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { AppointmentsService } from "./appointments.service";
+
+@Controller("appointments")
+export class AppointmentsController {
+  constructor(private readonly appointments: AppointmentsService) {}
+
+  @Get()
+  list(
+    @CurrentSalon() salon: ActiveSalon,
+    @Query(new ZodValidationPipe(appointmentListQuerySchema))
+    query: AppointmentListQueryInput,
+  ) {
+    return this.appointments.list(salon.salonId, query);
+  }
+
+  @Get(":id")
+  get(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+  ) {
+    return this.appointments.get(salon.salonId, id);
+  }
+
+  @Post()
+  create(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(appointmentCreateSchema))
+    input: AppointmentCreateInput,
+  ) {
+    return this.appointments.create(salon.salonId, user.userId, input);
+  }
+
+  @Post(":id/reschedule")
+  reschedule(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentRescheduleSchema))
+    input: AppointmentRescheduleInput,
+  ) {
+    return this.appointments.reschedule(salon.salonId, user.userId, id, input);
+  }
+
+  @Post(":id/cancel")
+  cancel(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentCancelSchema))
+    input: AppointmentCancelInput,
+  ) {
+    return this.appointments.cancel(salon.salonId, user.userId, id, input);
+  }
+
+  @Post(":id/transition")
+  transition(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentTransitionSchema))
+    input: AppointmentTransitionInput,
+  ) {
+    return this.appointments.transition(
+      salon.salonId,
+      user.userId,
+      id,
+      input.status,
+    );
+  }
+
+  @Post(":id/complete")
+  complete(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentCompleteSchema))
+    input: AppointmentCompleteInput,
+  ) {
+    return this.appointments.complete(salon.salonId, user.userId, id, input);
+  }
+
+  @Patch(":id/notes")
+  updateNotes(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentNotesUpdateSchema))
+    input: AppointmentNotesUpdateInput,
+  ) {
+    return this.appointments.updateNotes(salon.salonId, id, input);
+  }
+}

--- a/apps/api/src/appointments/appointments.module.ts
+++ b/apps/api/src/appointments/appointments.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { AppointmentsController } from "./appointments.controller";
+import { AppointmentsService } from "./appointments.service";
+
+@Module({
+  controllers: [AppointmentsController],
+  providers: [AppointmentsService],
+})
+export class AppointmentsModule {}

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -1,0 +1,497 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import {
+  AppointmentSource as AppointmentSourceEnum,
+  AppointmentStatus as AppointmentStatusEnum,
+  OutboxStatus,
+  Prisma,
+} from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type {
+  AppointmentCancelInput,
+  AppointmentCompleteInput,
+  AppointmentCreateInput,
+  AppointmentListQueryInput,
+  AppointmentNotesUpdateInput,
+  AppointmentRescheduleInput,
+} from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import { appendDomainEvent } from "../common/domain-events";
+import {
+  BLOCKING_STATUSES,
+  canCancel,
+  canReschedule,
+  canTransition,
+} from "./state-machine";
+
+// Hard cap to keep range queries bounded. A month of appointments per stylist
+// is a generous upper bound for the calendar UI; longer ranges should paginate.
+const RANGE_QUERY_MAX_DAYS = 62;
+
+const APPOINTMENT_INCLUDE = {
+  client: { select: { id: true, displayName: true, phone: true, email: true } },
+  staffMember: { select: { id: true, displayName: true, color: true } },
+  services: {
+    orderBy: [{ sortOrder: "asc" as const }],
+    select: {
+      id: true,
+      serviceId: true,
+      serviceNameSnapshot: true,
+      priceSnapshotCents: true,
+      durationSnapshotMinutes: true,
+      currencySnapshot: true,
+      actualMinutes: true,
+      sortOrder: true,
+    },
+  },
+} satisfies Prisma.AppointmentInclude;
+
+type AppointmentWithRelations = Prisma.AppointmentGetPayload<{
+  include: typeof APPOINTMENT_INCLUDE;
+}>;
+
+@Injectable()
+export class AppointmentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  list(salonId: string, query: AppointmentListQueryInput) {
+    if (query.to <= query.from) {
+      throw new BadRequestException("`to` must be after `from`");
+    }
+    const rangeDays =
+      (query.to.getTime() - query.from.getTime()) / (1000 * 60 * 60 * 24);
+    if (rangeDays > RANGE_QUERY_MAX_DAYS) {
+      throw new BadRequestException(
+        `Range too large; max ${RANGE_QUERY_MAX_DAYS} days`,
+      );
+    }
+
+    const where: Prisma.AppointmentWhereInput = {
+      salonId,
+      // Half-open interval [from, to). An appointment overlaps the window iff
+      // it starts before `to` and ends after `from`.
+      startAt: { lt: query.to },
+      endAt: { gt: query.from },
+    };
+    if (query.staffMemberId) where.staffMemberId = query.staffMemberId;
+    if (query.status && query.status.length > 0) {
+      where.status = { in: query.status as AppointmentStatusEnum[] };
+    }
+
+    return this.prisma.appointment.findMany({
+      where,
+      include: APPOINTMENT_INCLUDE,
+      orderBy: [{ startAt: "asc" }],
+    });
+  }
+
+  async get(salonId: string, id: string): Promise<AppointmentWithRelations> {
+    const appt = await this.prisma.appointment.findFirst({
+      where: { id, salonId },
+      include: APPOINTMENT_INCLUDE,
+    });
+    if (!appt) throw new NotFoundException("Appointment not found");
+    return appt;
+  }
+
+  async create(
+    salonId: string,
+    actorUserId: string,
+    input: AppointmentCreateInput,
+  ) {
+    // Verify client + staff + services up front so failures surface as 404 /
+    // 400 rather than as Prisma FK errors deep inside the transaction.
+    const [client, staff, services] = await Promise.all([
+      this.prisma.client.findFirst({
+        where: { id: input.clientId, salonId },
+        select: { id: true },
+      }),
+      this.prisma.staffMember.findFirst({
+        where: { id: input.staffMemberId, salonId, isActive: true },
+        select: { id: true },
+      }),
+      this.prisma.service.findMany({
+        where: { id: { in: input.serviceIds }, salonId },
+        select: {
+          id: true,
+          name: true,
+          defaultDurationMinutes: true,
+          defaultPriceCents: true,
+          currency: true,
+          isActive: true,
+        },
+      }),
+    ]);
+
+    if (!client) throw new NotFoundException("Client not found");
+    if (!staff) throw new NotFoundException("Staff member not found or inactive");
+    if (services.length !== input.serviceIds.length) {
+      throw new NotFoundException("One or more services not found in this salon");
+    }
+    if (services.some((s) => !s.isActive)) {
+      throw new BadRequestException("Cannot book inactive services");
+    }
+
+    // Order the snapshots in the request order so receptionists see services
+    // listed the way they entered them.
+    const orderedServices = input.serviceIds
+      .map((id) => services.find((s) => s.id === id))
+      .filter((s): s is (typeof services)[number] => Boolean(s));
+    const totalDuration = orderedServices.reduce(
+      (acc, s) => acc + s.defaultDurationMinutes,
+      0,
+    );
+    const startAt = input.startAt;
+    const endAt = new Date(startAt.getTime() + totalDuration * 60_000);
+
+    await this.assertNoStylistConflict({
+      salonId,
+      staffMemberId: input.staffMemberId,
+      startAt,
+      endAt,
+    });
+
+    return this.prisma.$transaction(async (tx) => {
+      const appointment = await tx.appointment.create({
+        data: {
+          salonId,
+          clientId: input.clientId,
+          staffMemberId: input.staffMemberId,
+          startAt,
+          endAt,
+          status: AppointmentStatusEnum.SCHEDULED,
+          source: input.source ?? AppointmentSourceEnum.STAFF,
+          notes: input.notes ?? null,
+          internalNotes: input.internalNotes ?? null,
+          createdById: actorUserId,
+          services: {
+            create: orderedServices.map((s, i) => ({
+              salonId,
+              serviceId: s.id,
+              serviceNameSnapshot: s.name,
+              priceSnapshotCents: s.defaultPriceCents,
+              durationSnapshotMinutes: s.defaultDurationMinutes,
+              currencySnapshot: s.currency,
+              sortOrder: i,
+            })),
+          },
+        },
+        include: APPOINTMENT_INCLUDE,
+      });
+
+      const eventPayload = appointmentSnapshot(appointment);
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT",
+        aggregateId: appointment.id,
+        eventType: EventType.APPOINTMENT_CREATED,
+        payload: eventPayload,
+        actorUserId,
+      });
+      // Outbox row for downstream side-effects (Phase 4 wires the SMS
+      // confirmation handler). The worker is a noop today; the row exists
+      // because the contract is "events ride along the same transaction".
+      await tx.outboxEvent.create({
+        data: {
+          salonId,
+          eventType: EventType.APPOINTMENT_CREATED,
+          payload: eventPayload as Prisma.InputJsonValue,
+          status: OutboxStatus.PENDING,
+        },
+      });
+      return appointment;
+    });
+  }
+
+  async reschedule(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: AppointmentRescheduleInput,
+  ) {
+    const existing = await this.get(salonId, id);
+    if (!canReschedule(existing.status)) {
+      throw new ConflictException(
+        `Cannot reschedule an appointment in status ${existing.status}`,
+      );
+    }
+
+    const targetStaffId = input.staffMemberId ?? existing.staffMemberId;
+    if (input.staffMemberId && input.staffMemberId !== existing.staffMemberId) {
+      const staff = await this.prisma.staffMember.findFirst({
+        where: { id: input.staffMemberId, salonId, isActive: true },
+        select: { id: true },
+      });
+      if (!staff) {
+        throw new NotFoundException("Staff member not found or inactive");
+      }
+    }
+
+    // Preserve duration: rescheduling moves the block, it doesn't resize it.
+    // Resize is "edit services", which is a different verb (and isn't in 3a).
+    const durationMs = existing.endAt.getTime() - existing.startAt.getTime();
+    const newStart = input.startAt;
+    const newEnd = new Date(newStart.getTime() + durationMs);
+
+    await this.assertNoStylistConflict({
+      salonId,
+      staffMemberId: targetStaffId,
+      startAt: newStart,
+      endAt: newEnd,
+      excludeAppointmentId: id,
+    });
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: {
+          startAt: newStart,
+          endAt: newEnd,
+          ...(input.staffMemberId && input.staffMemberId !== existing.staffMemberId
+            ? {
+                staffMember: {
+                  connect: {
+                    staff_members_id_salonId_key: {
+                      id: input.staffMemberId,
+                      salonId,
+                    },
+                  },
+                },
+              }
+            : {}),
+        },
+        include: APPOINTMENT_INCLUDE,
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT",
+        aggregateId: id,
+        eventType: EventType.APPOINTMENT_RESCHEDULED,
+        payload: {
+          before: {
+            startAt: existing.startAt,
+            endAt: existing.endAt,
+            staffMemberId: existing.staffMemberId,
+          },
+          after: {
+            startAt: updated.startAt,
+            endAt: updated.endAt,
+            staffMemberId: updated.staffMemberId,
+          },
+        },
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
+  async cancel(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: AppointmentCancelInput,
+  ) {
+    const existing = await this.get(salonId, id);
+    if (!canCancel(existing.status)) {
+      throw new ConflictException(
+        `Cannot cancel an appointment in status ${existing.status}`,
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: {
+          status: AppointmentStatusEnum.CANCELLED,
+          cancelledAt: new Date(),
+          cancellationReason: input.reason ?? null,
+        },
+        include: APPOINTMENT_INCLUDE,
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT",
+        aggregateId: id,
+        eventType: EventType.APPOINTMENT_CANCELLED,
+        payload: {
+          previousStatus: existing.status,
+          reason: input.reason ?? null,
+        },
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
+  async transition(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    target: AppointmentStatusEnum,
+  ) {
+    const existing = await this.get(salonId, id);
+    if (!canTransition(existing.status, target)) {
+      throw new ConflictException(
+        `Cannot transition from ${existing.status} to ${target}`,
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: { status: target },
+        include: APPOINTMENT_INCLUDE,
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT",
+        aggregateId: id,
+        eventType: eventTypeForTransition(target),
+        payload: { from: existing.status, to: target },
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
+  async complete(
+    salonId: string,
+    actorUserId: string,
+    id: string,
+    input: AppointmentCompleteInput,
+  ) {
+    const existing = await this.get(salonId, id);
+    if (!canTransition(existing.status, AppointmentStatusEnum.COMPLETED)) {
+      throw new ConflictException(
+        `Cannot complete an appointment in status ${existing.status}`,
+      );
+    }
+
+    const now = new Date();
+    const actualStart = input.actualStartAt ?? existing.startAt;
+    const actualEnd = input.actualEndAt ?? now;
+    if (actualEnd <= actualStart) {
+      throw new BadRequestException("actualEndAt must be after actualStartAt");
+    }
+    const actualDurationMinutes = Math.max(
+      1,
+      Math.round((actualEnd.getTime() - actualStart.getTime()) / 60_000),
+    );
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.appointment.update({
+        where: { id },
+        data: {
+          status: AppointmentStatusEnum.COMPLETED,
+          actualStartAt: actualStart,
+          actualEndAt: actualEnd,
+          actualDurationMinutes,
+        },
+        include: APPOINTMENT_INCLUDE,
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT",
+        aggregateId: id,
+        eventType: EventType.APPOINTMENT_COMPLETED,
+        payload: {
+          actualStartAt: actualStart,
+          actualEndAt: actualEnd,
+          actualDurationMinutes,
+        },
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
+  // Notes are mutable metadata, not state. No domain event today — if note
+  // history becomes a requirement later, swap to an event-sourced edit.
+  async updateNotes(
+    salonId: string,
+    id: string,
+    input: AppointmentNotesUpdateInput,
+  ) {
+    await this.get(salonId, id);
+    const data: Prisma.AppointmentUpdateInput = {};
+    if (input.notes !== undefined) data.notes = input.notes;
+    if (input.internalNotes !== undefined) data.internalNotes = input.internalNotes;
+    return this.prisma.appointment.update({
+      where: { id },
+      data,
+      include: APPOINTMENT_INCLUDE,
+    });
+  }
+
+  // Find an existing appointment that overlaps [startAt, endAt) on the same
+  // stylist with a blocking status. Two appointments overlap iff
+  //   existing.startAt < newEnd  AND  existing.endAt > newStart.
+  private async assertNoStylistConflict(args: {
+    salonId: string;
+    staffMemberId: string;
+    startAt: Date;
+    endAt: Date;
+    excludeAppointmentId?: string;
+  }) {
+    if (args.endAt <= args.startAt) {
+      throw new BadRequestException("Appointment endAt must be after startAt");
+    }
+    const conflict = await this.prisma.appointment.findFirst({
+      where: {
+        salonId: args.salonId,
+        staffMemberId: args.staffMemberId,
+        status: { in: BLOCKING_STATUSES as AppointmentStatusEnum[] },
+        startAt: { lt: args.endAt },
+        endAt: { gt: args.startAt },
+        ...(args.excludeAppointmentId
+          ? { NOT: { id: args.excludeAppointmentId } }
+          : {}),
+      },
+      select: { id: true, startAt: true, endAt: true },
+    });
+    if (conflict) {
+      throw new ConflictException(
+        `Stylist already booked from ${conflict.startAt.toISOString()} to ${conflict.endAt.toISOString()}`,
+      );
+    }
+  }
+}
+
+function eventTypeForTransition(target: AppointmentStatusEnum): string {
+  switch (target) {
+    case AppointmentStatusEnum.CONFIRMED:
+      return EventType.APPOINTMENT_CONFIRMED;
+    case AppointmentStatusEnum.CHECKED_IN:
+      return EventType.APPOINTMENT_CHECKED_IN;
+    case AppointmentStatusEnum.IN_PROGRESS:
+      return EventType.APPOINTMENT_STARTED;
+    case AppointmentStatusEnum.NO_SHOW:
+      return EventType.APPOINTMENT_NO_SHOWED;
+    default:
+      return `appointment.${target.toLowerCase()}`;
+  }
+}
+
+function appointmentSnapshot(a: AppointmentWithRelations) {
+  return {
+    id: a.id,
+    salonId: a.salonId,
+    clientId: a.clientId,
+    staffMemberId: a.staffMemberId,
+    startAt: a.startAt,
+    endAt: a.endAt,
+    status: a.status,
+    source: a.source,
+    services: a.services.map((s) => ({
+      serviceId: s.serviceId,
+      name: s.serviceNameSnapshot,
+      priceCents: s.priceSnapshotCents,
+      durationMinutes: s.durationSnapshotMinutes,
+      currency: s.currencySnapshot,
+    })),
+  };
+}

--- a/apps/api/src/appointments/state-machine.ts
+++ b/apps/api/src/appointments/state-machine.ts
@@ -1,0 +1,65 @@
+import { AppointmentStatus } from "@prisma/client";
+
+// Allowed transitions for appointments. Reschedule and cancellation are
+// modeled as separate verbs (each has its own endpoint and event), so this
+// table only covers status flips driven by the front desk's status menu.
+//
+// Terminal states (`COMPLETED`, `CANCELLED`, `NO_SHOW`) have no outgoing
+// edges — once an appointment lands there it stays there and any subsequent
+// correction lives in a follow-up appointment + adjustment, not a status
+// rewind.
+const TRANSITIONS: Record<AppointmentStatus, ReadonlyArray<AppointmentStatus>> = {
+  SCHEDULED: ["CONFIRMED", "CHECKED_IN", "IN_PROGRESS", "NO_SHOW", "CANCELLED"],
+  CONFIRMED: ["CHECKED_IN", "IN_PROGRESS", "NO_SHOW", "CANCELLED"],
+  CHECKED_IN: ["IN_PROGRESS", "CANCELLED"],
+  IN_PROGRESS: ["COMPLETED"],
+  COMPLETED: [],
+  CANCELLED: [],
+  NO_SHOW: [],
+};
+
+export function canTransition(
+  from: AppointmentStatus,
+  to: AppointmentStatus,
+): boolean {
+  return TRANSITIONS[from].includes(to);
+}
+
+export function allowedTransitions(
+  from: AppointmentStatus,
+): ReadonlyArray<AppointmentStatus> {
+  return TRANSITIONS[from];
+}
+
+// Reschedule and cancel run through their own endpoints; they're allowed only
+// before completion (COMPLETED) and never on already-cancelled / no-show rows.
+const NON_TERMINAL: ReadonlySet<AppointmentStatus> = new Set([
+  "SCHEDULED",
+  "CONFIRMED",
+  "CHECKED_IN",
+  "IN_PROGRESS",
+]);
+
+export function canReschedule(status: AppointmentStatus): boolean {
+  // Disallow reschedule once the visit is in progress — at that point the
+  // stylist is mid-cut and reschedule is the wrong verb (cancel + new booking).
+  return status === "SCHEDULED" || status === "CONFIRMED" || status === "CHECKED_IN";
+}
+
+export function canCancel(status: AppointmentStatus): boolean {
+  return NON_TERMINAL.has(status);
+}
+
+export function isTerminal(status: AppointmentStatus): boolean {
+  return !NON_TERMINAL.has(status);
+}
+
+// Statuses that count for stylist-overlap purposes. Cancelled and no-show
+// appointments free up the slot.
+export const BLOCKING_STATUSES: ReadonlyArray<AppointmentStatus> = [
+  "SCHEDULED",
+  "CONFIRMED",
+  "CHECKED_IN",
+  "IN_PROGRESS",
+  "COMPLETED",
+];

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -14,6 +14,14 @@ const schema = z
     DEV_SALON_ID: z.string().uuid(),
     DEV_SALON_SLUG: z.string().min(1),
 
+    // Disables the in-process outbox poller. Tests and one-off scripts set
+    // this so the worker doesn't tick during their lifetime; production
+    // leaves it unset.
+    OUTBOX_WORKER_DISABLED: z
+      .enum(["true", "false"])
+      .optional()
+      .transform((v) => v === "true"),
+
     CLERK_SECRET_KEY: z.string().optional(),
     // Clerk issues a single publishable key per app. The web side reads it
     // from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (the prefix is required for

--- a/apps/api/src/outbox/outbox.module.ts
+++ b/apps/api/src/outbox/outbox.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { OutboxWorker } from "./outbox.worker";
+
+@Module({
+  providers: [OutboxWorker],
+  exports: [OutboxWorker],
+})
+export class OutboxModule {}

--- a/apps/api/src/outbox/outbox.worker.ts
+++ b/apps/api/src/outbox/outbox.worker.ts
@@ -1,0 +1,136 @@
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from "@nestjs/common";
+import { OutboxStatus, type OutboxEvent } from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import { env } from "../env";
+import { PrismaService } from "../prisma/prisma.service";
+
+const POLL_INTERVAL_MS = 5_000;
+const BATCH_SIZE = 25;
+const MAX_ATTEMPTS = 5;
+
+// Outbox stub for Phase 3a. Phase 4 replaces this with a BullMQ-backed
+// processor that actually sends SMS confirmations on `appointment.created`.
+//
+// The worker exists today so the contract is visible end-to-end: writers
+// append OutboxEvent rows in the same transaction as the business write, the
+// worker eventually picks them up, the handler decides what to do.
+@Injectable()
+export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboxWorker.name);
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private stopped = false;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  onModuleInit() {
+    if (env.OUTBOX_WORKER_DISABLED) {
+      this.logger.log("OutboxWorker disabled via OUTBOX_WORKER_DISABLED");
+      return;
+    }
+    this.scheduleNext(0);
+  }
+
+  onModuleDestroy() {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private scheduleNext(delayMs: number) {
+    if (this.stopped) return;
+    this.timer = setTimeout(() => {
+      void this.tick();
+    }, delayMs);
+  }
+
+  private async tick() {
+    if (this.running) {
+      this.scheduleNext(POLL_INTERVAL_MS);
+      return;
+    }
+    this.running = true;
+    try {
+      await this.processBatch();
+    } catch (err) {
+      this.logger.error("Outbox tick failed", err as Error);
+    } finally {
+      this.running = false;
+      this.scheduleNext(POLL_INTERVAL_MS);
+    }
+  }
+
+  // Fetches a small batch of due events and processes them sequentially. We
+  // don't claim rows with a status flip + SELECT FOR UPDATE here because there
+  // is only one worker process at this stage; Phase 4 introduces BullMQ which
+  // handles dispatch and concurrency properly.
+  async processBatch() {
+    const due = await this.prisma.outboxEvent.findMany({
+      where: {
+        status: OutboxStatus.PENDING,
+        nextAttemptAt: { lte: new Date() },
+      },
+      orderBy: [{ nextAttemptAt: "asc" }],
+      take: BATCH_SIZE,
+    });
+    for (const event of due) {
+      await this.processOne(event);
+    }
+  }
+
+  private async processOne(event: OutboxEvent) {
+    try {
+      await this.prisma.outboxEvent.update({
+        where: { id: event.id },
+        data: { status: OutboxStatus.PROCESSING, attempts: { increment: 1 } },
+      });
+      await dispatch(event);
+      await this.prisma.outboxEvent.update({
+        where: { id: event.id },
+        data: {
+          status: OutboxStatus.COMPLETED,
+          processedAt: new Date(),
+          lastError: null,
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `Outbox event ${event.id} (${event.eventType}) failed: ${message}`,
+      );
+      const dead = event.attempts + 1 >= MAX_ATTEMPTS;
+      await this.prisma.outboxEvent.update({
+        where: { id: event.id },
+        data: {
+          status: dead ? OutboxStatus.DEAD_LETTER : OutboxStatus.PENDING,
+          lastError: message.slice(0, 1000),
+          // Linear backoff is fine for a stub; replace with exponential when
+          // real handlers go in.
+          nextAttemptAt: new Date(
+            Date.now() + (event.attempts + 1) * 30_000,
+          ),
+        },
+      });
+    }
+  }
+}
+
+// Handler dispatch table. Phase 4 will replace the appointment.created branch
+// with a real SMS send. Until then, every event no-ops successfully so the
+// worker exercises the read/update/finalize path end-to-end.
+async function dispatch(event: OutboxEvent): Promise<void> {
+  switch (event.eventType) {
+    case EventType.APPOINTMENT_CREATED:
+      // Intentional no-op for Phase 3a.
+      return;
+    default:
+      return;
+  }
+}

--- a/apps/api/src/outbox/outbox.worker.ts
+++ b/apps/api/src/outbox/outbox.worker.ts
@@ -33,7 +33,26 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       this.logger.log("OutboxWorker disabled via OUTBOX_WORKER_DISABLED");
       return;
     }
+    // Reclaim any rows a previous worker left in PROCESSING (crash, hard
+    // restart). Phase 4's BullMQ-backed worker will lease rows properly with
+    // a heartbeat; this stub has no leasing, so the only safe rule is "if
+    // it's PROCESSING at boot, nobody is working on it."
+    void this.reclaimStaleProcessing();
     this.scheduleNext(0);
+  }
+
+  private async reclaimStaleProcessing() {
+    try {
+      const { count } = await this.prisma.outboxEvent.updateMany({
+        where: { status: OutboxStatus.PROCESSING },
+        data: { status: OutboxStatus.PENDING },
+      });
+      if (count > 0) {
+        this.logger.log(`Reclaimed ${count} stale PROCESSING outbox row(s)`);
+      }
+    } catch (err) {
+      this.logger.error("Outbox reclaim failed", err as Error);
+    }
   }
 
   onModuleDestroy() {
@@ -87,15 +106,16 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
 
   private async processOne(event: OutboxEvent) {
     try {
-      await this.prisma.outboxEvent.update({
-        where: { id: event.id },
-        data: { status: OutboxStatus.PROCESSING, attempts: { increment: 1 } },
-      });
       await dispatch(event);
+      // Single terminal write per attempt: a crash mid-dispatch leaves the
+      // row in PENDING and the next tick retries it. Phase 4 introduces
+      // proper leasing (claim with FOR UPDATE SKIP LOCKED + worker heartbeat
+      // via BullMQ); the stub deliberately avoids non-leased PROCESSING.
       await this.prisma.outboxEvent.update({
         where: { id: event.id },
         data: {
           status: OutboxStatus.COMPLETED,
+          attempts: { increment: 1 },
           processedAt: new Date(),
           lastError: null,
         },

--- a/apps/api/test/appointment-state-machine.test.ts
+++ b/apps/api/test/appointment-state-machine.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { AppointmentStatus } from "@prisma/client";
+import {
+  BLOCKING_STATUSES,
+  allowedTransitions,
+  canCancel,
+  canReschedule,
+  canTransition,
+  isTerminal,
+} from "../src/appointments/state-machine";
+
+describe("appointment state machine", () => {
+  it("allows the happy-path forward chain", () => {
+    expect(canTransition("SCHEDULED", "CONFIRMED")).toBe(true);
+    expect(canTransition("CONFIRMED", "CHECKED_IN")).toBe(true);
+    expect(canTransition("CHECKED_IN", "IN_PROGRESS")).toBe(true);
+    expect(canTransition("IN_PROGRESS", "COMPLETED")).toBe(true);
+  });
+
+  it("forbids backwards transitions", () => {
+    expect(canTransition("CONFIRMED", "SCHEDULED")).toBe(false);
+    expect(canTransition("CHECKED_IN", "CONFIRMED")).toBe(false);
+    expect(canTransition("IN_PROGRESS", "CHECKED_IN")).toBe(false);
+    expect(canTransition("COMPLETED", "IN_PROGRESS")).toBe(false);
+  });
+
+  it("treats COMPLETED, CANCELLED, NO_SHOW as terminal", () => {
+    expect(isTerminal("COMPLETED")).toBe(true);
+    expect(isTerminal("CANCELLED")).toBe(true);
+    expect(isTerminal("NO_SHOW")).toBe(true);
+    expect(allowedTransitions("COMPLETED")).toEqual([]);
+    expect(allowedTransitions("CANCELLED")).toEqual([]);
+    expect(allowedTransitions("NO_SHOW")).toEqual([]);
+  });
+
+  it("allows fast-forward to NO_SHOW from any pre-arrival state", () => {
+    expect(canTransition("SCHEDULED", "NO_SHOW")).toBe(true);
+    expect(canTransition("CONFIRMED", "NO_SHOW")).toBe(true);
+  });
+
+  it("does not allow NO_SHOW once the visit has started", () => {
+    expect(canTransition("CHECKED_IN", "NO_SHOW")).toBe(false);
+    expect(canTransition("IN_PROGRESS", "NO_SHOW")).toBe(false);
+  });
+
+  it("allows reschedule only before IN_PROGRESS", () => {
+    expect(canReschedule("SCHEDULED")).toBe(true);
+    expect(canReschedule("CONFIRMED")).toBe(true);
+    expect(canReschedule("CHECKED_IN")).toBe(true);
+    expect(canReschedule("IN_PROGRESS")).toBe(false);
+    expect(canReschedule("COMPLETED")).toBe(false);
+    expect(canReschedule("CANCELLED")).toBe(false);
+  });
+
+  it("allows cancel from every non-terminal state", () => {
+    const everyStatus: AppointmentStatus[] = [
+      "SCHEDULED",
+      "CONFIRMED",
+      "CHECKED_IN",
+      "IN_PROGRESS",
+      "COMPLETED",
+      "CANCELLED",
+      "NO_SHOW",
+    ];
+    for (const s of everyStatus) {
+      expect(canCancel(s)).toBe(!isTerminal(s));
+    }
+  });
+
+  it("counts COMPLETED as a stylist-blocking status", () => {
+    // Important: a completed appointment still occupies the time slot it ran
+    // in. Otherwise overlap checks would incorrectly let a new booking sit on
+    // top of a finished one.
+    expect(BLOCKING_STATUSES).toContain("COMPLETED");
+  });
+
+  it("does not block on CANCELLED or NO_SHOW", () => {
+    expect(BLOCKING_STATUSES).not.toContain("CANCELLED");
+    expect(BLOCKING_STATUSES).not.toContain("NO_SHOW");
+  });
+});

--- a/packages/db/test/enum-parity.test.ts
+++ b/packages/db/test/enum-parity.test.ts
@@ -8,6 +8,7 @@ import * as Prisma from "@prisma/client";
 import {
   Role,
   AppointmentStatus,
+  AppointmentSource,
   PaymentStatus,
   MessageDirection,
   MessageStatus,
@@ -29,6 +30,11 @@ const cases: ParityCase[] = [
     name: "AppointmentStatus",
     shared: AppointmentStatus,
     prisma: Prisma.AppointmentStatus,
+  },
+  {
+    name: "AppointmentSource",
+    shared: AppointmentSource,
+    prisma: Prisma.AppointmentSource,
   },
   { name: "PaymentStatus", shared: PaymentStatus, prisma: Prisma.PaymentStatus },
   {

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -19,6 +19,16 @@ export const AppointmentStatus = {
 export type AppointmentStatus =
   (typeof AppointmentStatus)[keyof typeof AppointmentStatus];
 
+export const AppointmentSource = {
+  STAFF: "STAFF",
+  ONLINE: "ONLINE",
+  PHONE: "PHONE",
+  AI_AGENT: "AI_AGENT",
+  IMPORT: "IMPORT",
+} as const;
+export type AppointmentSource =
+  (typeof AppointmentSource)[keyof typeof AppointmentSource];
+
 export const PaymentStatus = {
   PENDING: "PENDING",
   SUCCEEDED: "SUCCEEDED",
@@ -78,6 +88,7 @@ export const EventType = {
   APPOINTMENT_CREATED: "appointment.created",
   APPOINTMENT_RESCHEDULED: "appointment.rescheduled",
   APPOINTMENT_CANCELLED: "appointment.cancelled",
+  APPOINTMENT_CONFIRMED: "appointment.confirmed",
   APPOINTMENT_CHECKED_IN: "appointment.checked_in",
   APPOINTMENT_STARTED: "appointment.started",
   APPOINTMENT_COMPLETED: "appointment.completed",

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Role } from "./enums.js";
+import { AppointmentSource, AppointmentStatus, Role } from "./enums.js";
 
 // Field-level building blocks — reused across create/update shapes so the
 // same trim/length/format rules apply everywhere.
@@ -209,6 +209,109 @@ export const clientUpdateSchema = z.object({
 
 export type ClientCreateInput = z.infer<typeof clientCreateSchema>;
 export type ClientUpdateInput = z.infer<typeof clientUpdateSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Appointments (Phase 3a)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// All times accepted from the client are ISO-8601 strings with offset (or Z).
+// We coerce to Date here so downstream code is dealing in absolute instants —
+// the salon timezone only matters for rendering, not storage.
+const isoDateTime = z
+  .string()
+  .datetime({ offset: true })
+  .transform((s) => new Date(s));
+
+const optionalNotes = optionalTrimmed(4000);
+
+export const appointmentSourceSchema = z.nativeEnum(AppointmentSource);
+export const appointmentStatusSchema = z.nativeEnum(AppointmentStatus);
+
+// At least one service is required: an appointment with zero services has no
+// duration and the booking flow can't compute endAt.
+export const appointmentCreateSchema = z.object({
+  clientId: uuidSchema,
+  staffMemberId: uuidSchema,
+  serviceIds: z.array(uuidSchema).min(1).max(20),
+  startAt: isoDateTime,
+  notes: optionalNotes,
+  internalNotes: optionalNotes,
+  source: appointmentSourceSchema.default(AppointmentSource.STAFF),
+});
+
+export const appointmentRescheduleSchema = z.object({
+  startAt: isoDateTime,
+  // Allow moving to a different stylist as part of a reschedule. When omitted,
+  // the existing stylist is kept.
+  staffMemberId: uuidSchema.optional(),
+});
+
+export const appointmentCancelSchema = z.object({
+  reason: optionalTrimmed(500),
+});
+
+export const appointmentNotesUpdateSchema = z
+  .object({
+    notes: optionalNotes.optional(),
+    internalNotes: optionalNotes.optional(),
+  })
+  .refine(
+    (n) => n.notes !== undefined || n.internalNotes !== undefined,
+    "Provide notes or internalNotes",
+  );
+
+// Status transitions outside reschedule/cancel/complete go through this
+// endpoint. The state-machine guard lives in the service.
+export const appointmentTransitionSchema = z.object({
+  status: z.enum([
+    AppointmentStatus.CONFIRMED,
+    AppointmentStatus.CHECKED_IN,
+    AppointmentStatus.IN_PROGRESS,
+    AppointmentStatus.NO_SHOW,
+  ]),
+});
+
+export const appointmentCompleteSchema = z.object({
+  // When omitted, server uses now. Validation guarantees end > start when both
+  // are provided.
+  actualStartAt: isoDateTime.optional(),
+  actualEndAt: isoDateTime.optional(),
+});
+
+export const appointmentListQuerySchema = z.object({
+  // Day/week range queries use [from, to). Both required so we don't
+  // accidentally scan the whole table.
+  from: isoDateTime,
+  to: isoDateTime,
+  staffMemberId: uuidSchema.optional(),
+  // CSV is awkward for arrays; comma-split for convenience.
+  status: z
+    .string()
+    .optional()
+    .transform((s) =>
+      s
+        ? (s.split(",").map((v) => v.trim()).filter(Boolean) as AppointmentStatus[])
+        : undefined,
+    ),
+});
+
+export type AppointmentCreateInput = z.infer<typeof appointmentCreateSchema>;
+export type AppointmentRescheduleInput = z.infer<
+  typeof appointmentRescheduleSchema
+>;
+export type AppointmentCancelInput = z.infer<typeof appointmentCancelSchema>;
+export type AppointmentNotesUpdateInput = z.infer<
+  typeof appointmentNotesUpdateSchema
+>;
+export type AppointmentTransitionInput = z.infer<
+  typeof appointmentTransitionSchema
+>;
+export type AppointmentCompleteInput = z.infer<
+  typeof appointmentCompleteSchema
+>;
+export type AppointmentListQueryInput = z.infer<
+  typeof appointmentListQuerySchema
+>;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Salon settings (Phase 2 surface — name, timezone. Business hours and

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -284,15 +284,26 @@ export const appointmentListQuerySchema = z.object({
   from: isoDateTime,
   to: isoDateTime,
   staffMemberId: uuidSchema.optional(),
-  // CSV is awkward for arrays; comma-split for convenience.
+  // CSV is awkward for arrays; comma-split for convenience. Each token is
+  // validated against the enum so an unknown value surfaces as a 400 here
+  // rather than a Prisma 500 later.
   status: z
     .string()
     .optional()
-    .transform((s) =>
-      s
-        ? (s.split(",").map((v) => v.trim()).filter(Boolean) as AppointmentStatus[])
-        : undefined,
-    ),
+    .transform((s, ctx) => {
+      if (!s) return undefined;
+      const tokens = s.split(",").map((v) => v.trim()).filter(Boolean);
+      const valid = new Set<string>(Object.values(AppointmentStatus));
+      const bad = tokens.filter((t) => !valid.has(t));
+      if (bad.length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unknown appointment status: ${bad.join(", ")}`,
+        });
+        return z.NEVER;
+      }
+      return tokens as AppointmentStatus[];
+    }),
 });
 
 export type AppointmentCreateInput = z.infer<typeof appointmentCreateSchema>;

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -251,4 +251,14 @@ describe("appointmentListQuerySchema", () => {
     });
     expect(parsed.status).toBeUndefined();
   });
+
+  it("rejects unknown status tokens with a 400-shaped error", () => {
+    expect(() =>
+      appointmentListQuerySchema.parse({
+        from: "2026-05-01T00:00:00Z",
+        to: "2026-05-02T00:00:00Z",
+        status: "SCHEDULED,BOGUS",
+      }),
+    ).toThrow(/Unknown appointment status: BOGUS/);
+  });
 });

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  appointmentCreateSchema,
+  appointmentListQuerySchema,
+  appointmentTransitionSchema,
   clientCreateSchema,
   clientUpdateSchema,
   salonSettingsUpdateSchema,
@@ -180,5 +183,72 @@ describe("salonSettingsUpdateSchema", () => {
 
   it("rejects an empty payload", () => {
     expect(() => salonSettingsUpdateSchema.parse({})).toThrow();
+  });
+});
+
+describe("appointmentCreateSchema", () => {
+  const validInput = {
+    clientId: "11111111-1111-1111-1111-111111111111",
+    staffMemberId: "22222222-2222-2222-2222-222222222222",
+    serviceIds: ["33333333-3333-3333-3333-333333333333"],
+    startAt: "2026-05-01T14:00:00Z",
+  };
+
+  it("coerces startAt to a Date and applies default source", () => {
+    const parsed = appointmentCreateSchema.parse(validInput);
+    expect(parsed.startAt).toBeInstanceOf(Date);
+    expect(parsed.startAt.toISOString()).toBe("2026-05-01T14:00:00.000Z");
+    expect(parsed.source).toBe("STAFF");
+  });
+
+  it("requires at least one service", () => {
+    expect(() =>
+      appointmentCreateSchema.parse({ ...validInput, serviceIds: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a startAt without offset/Z", () => {
+    expect(() =>
+      appointmentCreateSchema.parse({
+        ...validInput,
+        startAt: "2026-05-01T14:00:00",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("appointmentTransitionSchema", () => {
+  it("accepts the four manually-driven targets", () => {
+    for (const status of ["CONFIRMED", "CHECKED_IN", "IN_PROGRESS", "NO_SHOW"]) {
+      expect(appointmentTransitionSchema.parse({ status }).status).toBe(status);
+    }
+  });
+
+  it("rejects targets that have dedicated endpoints", () => {
+    // CANCELLED, COMPLETED, and SCHEDULED each go through their own routes
+    // (cancel, complete, create) — letting them through here would bypass the
+    // input that those endpoints require.
+    for (const status of ["CANCELLED", "COMPLETED", "SCHEDULED"]) {
+      expect(() => appointmentTransitionSchema.parse({ status })).toThrow();
+    }
+  });
+});
+
+describe("appointmentListQuerySchema", () => {
+  it("splits comma-separated status into an array", () => {
+    const parsed = appointmentListQuerySchema.parse({
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-02T00:00:00Z",
+      status: "SCHEDULED,CONFIRMED",
+    });
+    expect(parsed.status).toEqual(["SCHEDULED", "CONFIRMED"]);
+  });
+
+  it("returns undefined status when omitted", () => {
+    const parsed = appointmentListQuerySchema.parse({
+      from: "2026-05-01T00:00:00Z",
+      to: "2026-05-02T00:00:00Z",
+    });
+    expect(parsed.status).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Appointment domain: create / reschedule / cancel / status transitions / complete-with-actuals / notes — all under `/appointments`, scoped by the existing `TenantGuard`.
- Guarded state machine in `appointments/state-machine.ts`; reschedule disallowed once `IN_PROGRESS`; `COMPLETED` still occupies its slot, `CANCELLED` / `NO_SHOW` free it.
- Stylist conflict detection via half-open overlap (`start < newEnd && end > newStart`), excluding self on reschedule.
- Service snapshots (name / price / duration / currency) frozen at booking time; `endAt` derived from the sum of default durations and preserved across reschedule.
- Domain events on every state change; `outbox_events` row appended in the same transaction as `appointment.created`.
- `OutboxWorker` stub: polling every 5s, linear backoff, dead-letters at 5 attempts. Dispatcher is a no-op until Phase 4 wires SMS confirmations.
- ROADMAP: 1.5 and 2 marked complete; 3 split into 3a (this PR) and 3b (calendar UI).

## Test plan

- [x] `pnpm -r typecheck` — clean across all packages
- [x] `pnpm db:validate` — Prisma schema valid
- [x] `pnpm -r test` — 41 tests passing (9 new state-machine, 7 new schema, enum parity now covers `AppointmentSource`)
- [ ] Manual smoke: create → confirm → check-in → in-progress → complete via the dev cookie auth, verify `domain_events` and `outbox_events` rows
- [ ] Manual smoke: overlapping booking on the same stylist returns 409
- [ ] Manual smoke: reschedule a `COMPLETED` appointment returns 409