### PR TITLE
Phase 3b: scheduling calendar UI + design system foundation

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -3,6 +3,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": false
   }
 }

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -169,8 +169,12 @@ export class AppointmentsService {
           internalNotes: input.internalNotes ?? null,
           createdById: actorUserId,
           services: {
+            // salonId is not a settable field on AppointmentService nested
+            // creates — Prisma derives it from the parent appointment via the
+            // composite FK. Including it raises "Unknown argument salonId"
+            // at runtime even though TS doesn't catch the excess prop in
+            // .map() callbacks.
             create: orderedServices.map((s, i) => ({
-              salonId,
               serviceId: s.id,
               serviceNameSnapshot: s.name,
               priceSnapshotCents: s.defaultPriceCents,

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,9 +2,8 @@
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@shearsimp/shared"],
-  experimental: {
-    typedRoutes: true,
-  },
+  // typedRoutes graduated out of `experimental` in Next 15.4.
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@clerk/nextjs": "6",
     "@shearsimp/shared": "workspace:*",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -5,6 +5,16 @@ import { Topbar } from "@/components/topbar";
 import { getServerSession } from "@/lib/session";
 import { serverEnv } from "@/lib/env";
 
+function initialsFromEmail(email: string) {
+  const handle = email.split("@")[0] ?? email;
+  const parts = handle
+    .split(/[._-]/)
+    .filter(Boolean)
+    .slice(0, 2);
+  if (parts.length === 0) return handle.slice(0, 2).toUpperCase();
+  return parts.map((p) => p.charAt(0).toUpperCase()).join("");
+}
+
 export default async function AppLayout({
   children,
 }: {
@@ -16,22 +26,36 @@ export default async function AppLayout({
   }
 
   // Next 15 doesn't expose the current pathname inside server components
-  // directly — we rely on a header set by middleware (or fall back to "/").
+  // directly — we rely on a header set by middleware.
   const hdrs = await headers();
   const activeHref = hdrs.get("x-pathname") ?? "/";
 
+  const userInitials = initialsFromEmail(session.email);
+  const userName = session.email;
+  const userRole = session.salonName ?? "Owner";
+
   return (
-    <div className="min-h-screen bg-zinc-50">
-      <Sidebar activeHref={activeHref} />
-      <div className="pl-56">
+    <div className="ss-app">
+      <div className="ss-orb ss-orb-magenta" />
+      <div className="ss-orb ss-orb-cyan" />
+      <div className="ss-orb ss-orb-violet" />
+
+      <Sidebar
+        activeHref={activeHref}
+        userInitials={userInitials}
+        userName={userName}
+        userRole={userRole}
+      />
+
+      <main className="ss-main">
         <Topbar
           mode={serverEnv.authProvider}
           salonName={session.salonName}
           salonSlug={session.salonSlug}
           userEmail={session.email}
         />
-        <main className="mx-auto max-w-6xl px-6 py-8">{children}</main>
-      </div>
+        <div className="ss-content">{children}</div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { apiFetch, ApiError } from "@/lib/api";
+
+export interface ActionResult {
+  ok: boolean;
+  message?: string;
+}
+
+function fail(e: unknown): ActionResult {
+  if (e instanceof ApiError) {
+    return { ok: false, message: e.topMessage() };
+  }
+  if (e instanceof Error) {
+    return { ok: false, message: e.message };
+  }
+  return { ok: false, message: "Request failed" };
+}
+
+export async function rescheduleAppointment(input: {
+  id: string;
+  startAtIso: string;
+  staffMemberId?: string;
+}): Promise<ActionResult> {
+  try {
+    await apiFetch(`/appointments/${input.id}/reschedule`, {
+      method: "POST",
+      data: {
+        startAt: input.startAtIso,
+        ...(input.staffMemberId ? { staffMemberId: input.staffMemberId } : {}),
+      },
+    });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function transitionAppointment(input: {
+  id: string;
+  status: "CONFIRMED" | "CHECKED_IN" | "IN_PROGRESS" | "NO_SHOW";
+}): Promise<ActionResult> {
+  try {
+    await apiFetch(`/appointments/${input.id}/transition`, {
+      method: "POST",
+      data: { status: input.status },
+    });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function completeAppointment(
+  id: string,
+): Promise<ActionResult> {
+  try {
+    await apiFetch(`/appointments/${id}/complete`, {
+      method: "POST",
+      data: {},
+    });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function cancelAppointment(input: {
+  id: string;
+  reason?: string;
+}): Promise<ActionResult> {
+  try {
+    await apiFetch(`/appointments/${input.id}/cancel`, {
+      method: "POST",
+      data: { reason: input.reason ?? "" },
+    });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -1,0 +1,702 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { categoryKind, type CategoryKind } from "@/lib/service-categories";
+import {
+  formatTimeInTimezone,
+  instantAtMinutes,
+  minutesFromDayStart,
+} from "@/lib/salon-time";
+import {
+  cancelAppointment,
+  completeAppointment,
+  rescheduleAppointment,
+  transitionAppointment,
+} from "../_actions";
+
+// Minutes-since-day-start grid. The calendar opens at SLOT_START minutes (9 AM
+// default) and runs until SLOT_END (7 PM). 15-minute granularity at 14px/slot
+// matches the design — 56px per hour, fits a 10-hour day in 560px.
+const SLOT_MIN = 15;
+const SLOT_HEIGHT = 14;
+const SLOT_START_MIN = 9 * 60;
+const SLOT_END_MIN = 19 * 60;
+const TOTAL_SLOTS = (SLOT_END_MIN - SLOT_START_MIN) / SLOT_MIN;
+const DRAG_MIME = "application/x-shearsimp-appointment";
+
+const STAFF_GRADIENTS = [
+  "linear-gradient(135deg, #1ec3d9, #0892a8)",
+  "linear-gradient(135deg, #0892a8, #4a82b3)",
+  "linear-gradient(135deg, #4a82b3, #1ec3d9)",
+  "linear-gradient(135deg, #5cdcec, #0892a8)",
+  "linear-gradient(135deg, #1ec3d9, #6fa6cc)",
+  "linear-gradient(135deg, #0892a8, #5cdcec)",
+];
+
+export interface ScheduleStaff {
+  id: string;
+  displayName: string;
+  title: string | null;
+  color: string | null;
+  isActive: boolean;
+}
+
+export interface ScheduleService {
+  id: string;
+  name: string;
+  category: { id: string; name: string } | null;
+}
+
+export interface ScheduleAppointmentService {
+  serviceId: string;
+  serviceNameSnapshot: string;
+}
+
+export interface ScheduleAppointment {
+  id: string;
+  startAt: string;
+  endAt: string;
+  status:
+    | "SCHEDULED"
+    | "CONFIRMED"
+    | "CHECKED_IN"
+    | "IN_PROGRESS"
+    | "COMPLETED"
+    | "CANCELLED"
+    | "NO_SHOW";
+  notes: string | null;
+  internalNotes: string | null;
+  client: { id: string; displayName: string; phone: string | null };
+  staffMember: { id: string; displayName: string };
+  services: ScheduleAppointmentService[];
+}
+
+interface Props {
+  isoDate: string;
+  timezone: string;
+  dayLabel: string;
+  prevIso: string;
+  nextIso: string;
+  todayIso: string;
+  appointments: ScheduleAppointment[];
+  staff: ScheduleStaff[];
+  services: ScheduleService[];
+}
+
+const LEGEND: Array<{ k: CategoryKind; l: string }> = [
+  { k: "color", l: "Color services" },
+  { k: "cut", l: "Cuts" },
+  { k: "styling", l: "Styling" },
+  { k: "treat", l: "Treatments" },
+  { k: "bridal", l: "Bridal & special" },
+  { k: "block", l: "Blocked" },
+];
+
+interface RenderBlock {
+  appointment: ScheduleAppointment;
+  staffIndex: number;
+  startMin: number;
+  durationMin: number;
+  kind: CategoryKind;
+}
+
+function staffGradient(index: number): string {
+  return STAFF_GRADIENTS[index % STAFF_GRADIENTS.length];
+}
+
+export function ScheduleView({
+  isoDate,
+  timezone,
+  dayLabel,
+  prevIso,
+  nextIso,
+  todayIso,
+  appointments,
+  staff,
+  services,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [hoverDrop, setHoverDrop] = useState<{
+    staffIndex: number;
+    slot: number;
+  } | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Lookup table from serviceId to its category kind (for color coding).
+  // Keyed by snapshot service id rather than name so it's stable across
+  // service renames.
+  const kindForServiceId = useMemo(() => {
+    const map = new Map<string, CategoryKind>();
+    for (const s of services) {
+      map.set(
+        s.id,
+        categoryKind({
+          categoryName: s.category?.name ?? null,
+          serviceName: s.name,
+        }),
+      );
+    }
+    return map;
+  }, [services]);
+
+  const blocks: RenderBlock[] = useMemo(() => {
+    const staffIndex = new Map<string, number>();
+    staff.forEach((s, i) => staffIndex.set(s.id, i));
+    const out: RenderBlock[] = [];
+    for (const a of appointments) {
+      // Hide cancelled / no-show: they shouldn't paint over the slot any more.
+      // (BLOCKING_STATUSES on the API side already excludes these for conflict
+      // detection; mirroring that here keeps the visual consistent.)
+      if (a.status === "CANCELLED" || a.status === "NO_SHOW") continue;
+      const idx = staffIndex.get(a.staffMember.id);
+      if (idx === undefined) continue;
+      const startMin = minutesFromDayStart(
+        new Date(a.startAt),
+        isoDate,
+        timezone,
+      );
+      const endMin = minutesFromDayStart(
+        new Date(a.endAt),
+        isoDate,
+        timezone,
+      );
+      const kind =
+        a.services
+          .map((s) => kindForServiceId.get(s.serviceId))
+          .find((k): k is CategoryKind => Boolean(k)) ?? "cut";
+      out.push({
+        appointment: a,
+        staffIndex: idx,
+        startMin,
+        durationMin: Math.max(SLOT_MIN, endMin - startMin),
+        kind,
+      });
+    }
+    return out;
+  }, [appointments, staff, kindForServiceId, isoDate, timezone]);
+
+  const selected = useMemo(
+    () =>
+      selectedId
+        ? appointments.find((a) => a.id === selectedId) ?? null
+        : null,
+    [selectedId, appointments],
+  );
+
+  function onDragStart(e: React.DragEvent, appointmentId: string) {
+    e.dataTransfer.setData(DRAG_MIME, appointmentId);
+    e.dataTransfer.effectAllowed = "move";
+    setDraggingId(appointmentId);
+  }
+  function onDragEnd() {
+    setDraggingId(null);
+    setHoverDrop(null);
+  }
+  function onDragOver(e: React.DragEvent, staffIndex: number, slot: number) {
+    if (!e.dataTransfer.types.includes(DRAG_MIME) && !draggingId) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    if (
+      hoverDrop?.staffIndex !== staffIndex ||
+      hoverDrop?.slot !== slot
+    ) {
+      setHoverDrop({ staffIndex, slot });
+    }
+  }
+  function onDrop(e: React.DragEvent, staffIndex: number, slot: number) {
+    e.preventDefault();
+    const appointmentId = e.dataTransfer.getData(DRAG_MIME) || draggingId;
+    setHoverDrop(null);
+    setDraggingId(null);
+    if (!appointmentId) return;
+
+    const block = blocks.find((b) => b.appointment.id === appointmentId);
+    if (!block) return;
+
+    const newStartMin = SLOT_START_MIN + slot * SLOT_MIN;
+    if (
+      block.staffIndex === staffIndex &&
+      block.startMin === newStartMin
+    ) {
+      return;
+    }
+    const targetStaff = staff[staffIndex];
+    if (!targetStaff) return;
+    const newStartIso = instantAtMinutes(
+      newStartMin,
+      isoDate,
+      timezone,
+    ).toISOString();
+
+    setErrorMsg(null);
+    startTransition(async () => {
+      const result = await rescheduleAppointment({
+        id: appointmentId,
+        startAtIso: newStartIso,
+        staffMemberId:
+          block.staffIndex === staffIndex ? undefined : targetStaff.id,
+      });
+      if (!result.ok) {
+        setErrorMsg(result.message ?? "Reschedule failed");
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <header className="ss-page-head">
+        <div className="ss-page-eyebrow">Schedule</div>
+        <h2 className="ss-page-title">{dayLabel}</h2>
+        <p className="ss-page-sub">
+          {staff.length} stylists. Drag a block to reschedule, click for
+          details.
+        </p>
+      </header>
+
+      <div className="ss-schedule-toolbar">
+        <div className="ss-schedule-toolbar-group">
+          <Link
+            href={`/schedule?date=${prevIso}`}
+            className="ss-icon-btn"
+            aria-label="Previous day"
+          >
+            <ChevIcon dir="left" />
+          </Link>
+          <Link
+            href={`/schedule?date=${todayIso}`}
+            className="ss-btn ss-btn-ghost"
+          >
+            Today
+          </Link>
+          <Link
+            href={`/schedule?date=${nextIso}`}
+            className="ss-icon-btn"
+            aria-label="Next day"
+          >
+            <ChevIcon dir="right" />
+          </Link>
+          <span className="ss-schedule-toolbar-meta">{dayLabel}</span>
+        </div>
+      </div>
+
+      {errorMsg && (
+        <div className="ss-schedule-error" role="alert">
+          {errorMsg}
+        </div>
+      )}
+
+      <div className="ss-cal-legend">
+        {LEGEND.map(({ k, l }) => (
+          <div key={k} className="ss-cal-legend-item">
+            <span className={`ss-cal-legend-swatch is-${k}`} />
+            <span>{l}</span>
+          </div>
+        ))}
+      </div>
+
+      {staff.length === 0 ? (
+        <div className="ss-card" style={{ padding: 24, textAlign: "center" }}>
+          No active stylists. Add staff in{" "}
+          <Link href="/staff" className="ss-link">
+            Staff
+          </Link>{" "}
+          to populate the calendar.
+        </div>
+      ) : (
+        <div
+          className="ss-cal"
+          style={{
+            gridTemplateColumns: `56px repeat(${staff.length}, 1fr)`,
+            opacity: isPending ? 0.7 : 1,
+            transition: "opacity 150ms ease",
+          }}
+        >
+          <div className="ss-cal-h is-corner" />
+          {staff.map((s, i) => (
+            <div
+              key={s.id}
+              className="ss-cal-h"
+              style={
+                {
+                  ["--ss-staff-grad" as string]:
+                    s.color
+                      ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                      : staffGradient(i),
+                } as React.CSSProperties
+              }
+            >
+              <div
+                className="ss-chair-avatar"
+                style={{
+                  background:
+                    s.color
+                      ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                      : staffGradient(i),
+                  width: 30,
+                  height: 30,
+                  fontSize: 12,
+                }}
+              >
+                {initialsOf(s.displayName)}
+              </div>
+              <div>
+                <div className="ss-cal-h-name">
+                  {s.displayName.split(" ")[0]}
+                </div>
+                {s.title && (
+                  <div className="ss-cal-h-role">{s.title}</div>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {Array.from({ length: TOTAL_SLOTS }).map((_, slot) => {
+            const isHour = slot % 4 === 0;
+            const isHalf = slot % 4 === 2;
+            const minutes = SLOT_START_MIN + slot * SLOT_MIN;
+            const rowCls = `ss-cal-row${isHour ? " is-hour" : isHalf ? " is-half" : " is-quarter"}`;
+            return (
+              <ScheduleRow
+                key={slot}
+                slot={slot}
+                isHour={isHour}
+                rowCls={rowCls}
+                hourLabel={
+                  isHour
+                    ? formatTimeInTimezone(
+                        instantAtMinutes(minutes, isoDate, timezone),
+                        timezone,
+                      )
+                    : ""
+                }
+                staff={staff}
+                blocks={blocks.filter(
+                  (b) => slotForBlock(b) === slot,
+                )}
+                hoverDrop={hoverDrop}
+                draggingId={draggingId}
+                selectedId={selectedId}
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+                onDragOver={onDragOver}
+                onDrop={onDrop}
+                onSelect={(id) => setSelectedId(id)}
+                timezone={timezone}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {selected && (
+        <DetailsPanel
+          appointment={selected}
+          timezone={timezone}
+          isPending={isPending}
+          onClose={() => setSelectedId(null)}
+          onAction={(run) => {
+            setErrorMsg(null);
+            startTransition(async () => {
+              const r = await run();
+              if (!r.ok) {
+                setErrorMsg(r.message ?? "Action failed");
+                return;
+              }
+              setSelectedId(null);
+              router.refresh();
+            });
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// Row of one time-column + N stylist columns. Pulled out so React can
+// memoize per-slot work and so the drop targets stay independent.
+function ScheduleRow({
+  slot,
+  isHour,
+  rowCls,
+  hourLabel,
+  staff,
+  blocks,
+  hoverDrop,
+  draggingId,
+  selectedId,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop,
+  onSelect,
+  timezone,
+}: {
+  slot: number;
+  isHour: boolean;
+  rowCls: string;
+  hourLabel: string;
+  staff: ScheduleStaff[];
+  blocks: RenderBlock[];
+  hoverDrop: { staffIndex: number; slot: number } | null;
+  draggingId: string | null;
+  selectedId: string | null;
+  onDragStart: (e: React.DragEvent, id: string) => void;
+  onDragEnd: () => void;
+  onDragOver: (e: React.DragEvent, staffIndex: number, slot: number) => void;
+  onDrop: (e: React.DragEvent, staffIndex: number, slot: number) => void;
+  onSelect: (id: string) => void;
+  timezone: string;
+}) {
+  return (
+    <>
+      <div className={`ss-cal-time${isHour ? " is-hour" : ""}`}>
+        {hourLabel}
+      </div>
+      {staff.map((_, ci) => {
+        const block = blocks.find((b) => b.staffIndex === ci);
+        const isHover =
+          hoverDrop?.staffIndex === ci && hoverDrop?.slot === slot;
+        return (
+          <div
+            className={`ss-cal-cell ${rowCls}${isHover ? " is-drop-target" : ""}`}
+            key={`${ci}-${slot}`}
+            style={{ height: SLOT_HEIGHT }}
+            onDragOver={(e) => onDragOver(e, ci, slot)}
+            onDrop={(e) => onDrop(e, ci, slot)}
+          >
+            {block && (
+              <AppointmentBlock
+                block={block}
+                isDragging={draggingId === block.appointment.id}
+                isSelected={selectedId === block.appointment.id}
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+                onSelect={onSelect}
+                timezone={timezone}
+              />
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function AppointmentBlock({
+  block,
+  isDragging,
+  isSelected,
+  onDragStart,
+  onDragEnd,
+  onSelect,
+  timezone,
+}: {
+  block: RenderBlock;
+  isDragging: boolean;
+  isSelected: boolean;
+  onDragStart: (e: React.DragEvent, id: string) => void;
+  onDragEnd: () => void;
+  onSelect: (id: string) => void;
+  timezone: string;
+}) {
+  const { appointment, durationMin, kind } = block;
+  const heightPx = (durationMin / SLOT_MIN) * SLOT_HEIGHT - 4;
+  const time = formatTimeInTimezone(new Date(appointment.startAt), timezone);
+  const services = appointment.services
+    .map((s) => s.serviceNameSnapshot)
+    .join(" · ");
+  return (
+    <div
+      className={`ss-cal-block is-${kind}${isSelected ? " is-selected" : ""}${isDragging ? " is-dragging" : ""}`}
+      style={{ top: 0, height: `${heightPx}px` }}
+      draggable
+      role="button"
+      tabIndex={0}
+      onDragStart={(e) => onDragStart(e, appointment.id)}
+      onDragEnd={onDragEnd}
+      onClick={() => onSelect(appointment.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(appointment.id);
+        }
+      }}
+    >
+      <div className="ss-cal-block-name">
+        {appointment.client.displayName}
+      </div>
+      <div className="ss-cal-block-svc">
+        {time} · {services || "Service"}
+      </div>
+    </div>
+  );
+}
+
+function DetailsPanel({
+  appointment,
+  timezone,
+  isPending,
+  onClose,
+  onAction,
+}: {
+  appointment: ScheduleAppointment;
+  timezone: string;
+  isPending: boolean;
+  onClose: () => void;
+  onAction: (
+    run: () => Promise<{ ok: boolean; message?: string }>,
+  ) => void;
+}) {
+  const start = formatTimeInTimezone(new Date(appointment.startAt), timezone);
+  const end = formatTimeInTimezone(new Date(appointment.endAt), timezone);
+  const services = appointment.services
+    .map((s) => s.serviceNameSnapshot)
+    .join(", ");
+
+  // Map current status to the next legal "advance" verb. Mirrors the API's
+  // state machine so users only see actions that won't 409.
+  const advanceTarget: Array<{
+    label: string;
+    status: "CONFIRMED" | "CHECKED_IN" | "IN_PROGRESS" | "NO_SHOW";
+  }> =
+    appointment.status === "SCHEDULED"
+      ? [
+          { label: "Confirm", status: "CONFIRMED" },
+          { label: "Check in", status: "CHECKED_IN" },
+          { label: "No-show", status: "NO_SHOW" },
+        ]
+      : appointment.status === "CONFIRMED"
+        ? [
+            { label: "Check in", status: "CHECKED_IN" },
+            { label: "No-show", status: "NO_SHOW" },
+          ]
+        : appointment.status === "CHECKED_IN"
+          ? [{ label: "Start", status: "IN_PROGRESS" }]
+          : [];
+
+  const canComplete = appointment.status === "IN_PROGRESS";
+  const canCancel = !["COMPLETED", "CANCELLED", "NO_SHOW"].includes(
+    appointment.status,
+  );
+
+  return (
+    <div className="ss-detail-panel" role="dialog" aria-label="Appointment details">
+      <button
+        type="button"
+        className="ss-detail-close"
+        onClick={onClose}
+        aria-label="Close"
+      >
+        ×
+      </button>
+      <div className="ss-page-eyebrow">{appointment.status.replace("_", " ")}</div>
+      <h3 className="ss-detail-title">{appointment.client.displayName}</h3>
+      <p className="ss-detail-sub">
+        {start} – {end} · with {appointment.staffMember.displayName}
+      </p>
+      <p className="ss-detail-services">{services}</p>
+      {appointment.client.phone && (
+        <p className="ss-detail-meta">{appointment.client.phone}</p>
+      )}
+      {appointment.notes && (
+        <div className="ss-detail-section">
+          <div className="ss-detail-label">Client notes</div>
+          <p>{appointment.notes}</p>
+        </div>
+      )}
+      {appointment.internalNotes && (
+        <div className="ss-detail-section">
+          <div className="ss-detail-label">Internal</div>
+          <p>{appointment.internalNotes}</p>
+        </div>
+      )}
+      <div className="ss-detail-actions">
+        {advanceTarget.map((t) => (
+          <button
+            key={t.status}
+            type="button"
+            className="ss-btn ss-btn-primary"
+            disabled={isPending}
+            onClick={() =>
+              onAction(() =>
+                transitionAppointment({
+                  id: appointment.id,
+                  status: t.status,
+                }),
+              )
+            }
+          >
+            {t.label}
+          </button>
+        ))}
+        {canComplete && (
+          <button
+            type="button"
+            className="ss-btn ss-btn-primary"
+            disabled={isPending}
+            onClick={() =>
+              onAction(() => completeAppointment(appointment.id))
+            }
+          >
+            Complete
+          </button>
+        )}
+        {canCancel && (
+          <button
+            type="button"
+            className="ss-btn ss-btn-ghost"
+            disabled={isPending}
+            onClick={() => {
+              const reason = window.prompt("Cancellation reason (optional)") ?? "";
+              onAction(() =>
+                cancelAppointment({ id: appointment.id, reason }),
+              );
+            }}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChevIcon({ dir }: { dir: "left" | "right" }) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={dir === "left" ? "m15 18-6-6 6-6" : "m9 18 6-6-6-6"} />
+    </svg>
+  );
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
+}
+
+function slotForBlock(block: RenderBlock): number {
+  return Math.max(
+    0,
+    Math.round((block.startMin - SLOT_START_MIN) / SLOT_MIN),
+  );
+}

--- a/apps/web/src/app/(app)/schedule/page.tsx
+++ b/apps/web/src/app/(app)/schedule/page.tsx
@@ -1,21 +1,60 @@
-import { EmptyState } from "@/components/empty-state";
+import { apiFetch } from "@/lib/api";
+import {
+  dayWindow,
+  formatDayLabel,
+  shiftIsoDate,
+  todayIsoInTimezone,
+} from "@/lib/salon-time";
+import { ScheduleView, type ScheduleAppointment, type ScheduleStaff, type ScheduleService } from "./_components/schedule-view";
 
-export default function SchedulePage() {
+interface SettingsResponse {
+  id: string;
+  name: string;
+  timezone: string;
+}
+
+// Server-side fetches all the data the calendar needs in parallel: the salon
+// timezone (for day boundaries and labels), the active stylist roster, the
+// services list (for color coding), and the appointments overlapping the
+// chosen day window.
+export default async function SchedulePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const params = await searchParams;
+  const settings = await apiFetch<SettingsResponse>("/settings");
+  const tz = settings.timezone;
+  const isoDate = params.date ?? todayIsoInTimezone(tz);
+  const window = dayWindow(isoDate, tz);
+
+  const [appointments, staff, services] = await Promise.all([
+    apiFetch<ScheduleAppointment[]>("/appointments", {
+      query: {
+        from: window.fromUtc.toISOString(),
+        to: window.toUtc.toISOString(),
+      },
+    }),
+    apiFetch<ScheduleStaff[]>("/staff"),
+    apiFetch<ScheduleService[]>("/services"),
+  ]);
+
+  const prevIso = shiftIsoDate(isoDate, -1, tz);
+  const nextIso = shiftIsoDate(isoDate, 1, tz);
+  const todayIso = todayIsoInTimezone(tz);
+  const dayLabel = formatDayLabel(isoDate, tz);
+
   return (
-    <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Schedule
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Calendar, stylist availability, and conflict detection.
-        </p>
-      </header>
-      <EmptyState
-        title="Calendar coming in Phase 3"
-        body="Day/week/stylist views, drag-to-reschedule, and conflict detection will live here."
-        phase="Phase 3"
-      />
-    </div>
+    <ScheduleView
+      isoDate={isoDate}
+      timezone={tz}
+      dayLabel={dayLabel}
+      prevIso={prevIso}
+      nextIso={nextIso}
+      todayIso={todayIso}
+      appointments={appointments}
+      staff={staff.filter((s) => s.isActive)}
+      services={services}
+    />
   );
 }

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// global-error.tsx replaces the Next.js fallback 500 page entirely. Defining
+// it (with its own <html> + <body>) keeps the build from auto-generating the
+// pages-router /500 stub, which trips a known Next 15.5 bug where the stub
+// imports next/document.
+export default function GlobalError({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "column",
+          gap: 12,
+          fontFamily: "system-ui, sans-serif",
+          background: "#f3fbfd",
+          color: "#0f2630",
+        }}
+      >
+        <h1 style={{ fontSize: 22, margin: 0 }}>Something went wrong</h1>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            padding: "8px 16px",
+            borderRadius: 8,
+            border: "1px solid #0892a8",
+            background: "white",
+            color: "#0892a8",
+            cursor: "pointer",
+          }}
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,10 +1,34 @@
 import type { Metadata } from "next";
+import { Cormorant_Garamond, Great_Vibes, Quicksand } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { serverEnv } from "@/lib/env";
 import "./globals.css";
+import "../styles/styles.css";
+import "../styles/styles-extra.css";
+
+const quicksand = Quicksand({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-quicksand",
+  display: "swap",
+});
+
+const cormorant = Cormorant_Garamond({
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+  variable: "--font-cormorant",
+  display: "swap",
+});
+
+const greatVibes = Great_Vibes({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-great-vibes",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
-  title: "ShearSimplicity",
+  title: "Shear Simplicity",
   description: "Salon scheduling and POS",
 };
 
@@ -14,8 +38,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   const body = (
-    <html lang="en">
-      <body>{children}</body>
+    <html
+      lang="en"
+      className={`${quicksand.variable} ${cormorant.variable} ${greatVibes.variable}`}
+    >
+      <body className="theme-light">{children}</body>
     </html>
   );
   // ClerkProvider is a no-op in dev mode but pulls in Clerk's runtime —

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+// Explicit not-found page so Next doesn't fall back to its built-in /404
+// prerender, which trips a known Html-import error under typedRoutes in
+// Next 15.5.x.
+export default function NotFound() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexDirection: "column",
+        gap: 12,
+        fontFamily: "system-ui, sans-serif",
+        background: "#f3fbfd",
+        color: "#0f2630",
+      }}
+    >
+      <h1 style={{ fontSize: 22, margin: 0 }}>Page not found</h1>
+      <Link href="/" style={{ color: "#0892a8" }}>
+        Back to dashboard
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -3,56 +3,130 @@ import Link from "next/link";
 interface NavItem {
   href: string;
   label: string;
+  iconPath: string;
 }
 
-const items: NavItem[] = [
-  { href: "/", label: "Dashboard" },
-  { href: "/schedule", label: "Schedule" },
-  { href: "/clients", label: "Clients" },
-  { href: "/staff", label: "Staff" },
-  { href: "/services", label: "Services" },
-  { href: "/messages", label: "Messages" },
-  { href: "/settings", label: "Settings" },
+// Lucide-style stroked icons inlined as SVG paths. Using inline SVG keeps the
+// design CSS in control of size/stroke and avoids a runtime icon library.
+const NAV: NavItem[] = [
+  {
+    href: "/",
+    label: "Dashboard",
+    iconPath: "M3 13h7V3H3v10Zm0 8h7v-6H3v6Zm11 0h7V11h-7v10Zm0-18v6h7V3h-7Z",
+  },
+  {
+    href: "/schedule",
+    label: "Schedule",
+    iconPath:
+      "M8 2v4M16 2v4M3 9h18M5 5h14a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z",
+  },
+  {
+    href: "/clients",
+    label: "Clients",
+    iconPath:
+      "M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm13 10v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75",
+  },
+  {
+    href: "/staff",
+    label: "Staff",
+    iconPath:
+      "M20 21v-2a4 4 0 0 0-3-3.87M4 21v-2a4 4 0 0 1 3-3.87M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0 0c2 0 4 1 4 4v5H8v-5c0-3 2-4 4-4Z",
+  },
+  {
+    href: "/services",
+    label: "Services",
+    iconPath:
+      "M14.121 14.121 20 20M5.636 18.364a3 3 0 1 1 4.243-4.243 3 3 0 0 1-4.243 4.243Zm0-12.728a3 3 0 1 1 4.243 4.243 3 3 0 0 1-4.243-4.243Zm6.364 6.364L20 4",
+  },
+  {
+    href: "/messages",
+    label: "Messages",
+    iconPath: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10Z",
+  },
 ];
 
-export function Sidebar({ activeHref }: { activeHref: string }) {
+const SETTINGS_ICON =
+  "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm7.4-3a7.4 7.4 0 0 0-.13-1.41l2.11-1.65-2-3.46-2.49 1a7.45 7.45 0 0 0-2.44-1.41L14 2h-4l-.46 2.6a7.45 7.45 0 0 0-2.44 1.41l-2.49-1-2 3.46L4.73 10.59A7.4 7.4 0 0 0 4.6 12c0 .48.05.95.13 1.41l-2.11 1.65 2 3.46 2.49-1a7.45 7.45 0 0 0 2.44 1.41L10 22h4l.46-2.6a7.45 7.45 0 0 0 2.44-1.41l2.49 1 2-3.46-2.11-1.65A7.4 7.4 0 0 0 19.4 12Z";
+
+function NavIcon({ d }: { d: string }) {
   return (
-    <aside className="fixed inset-y-0 left-0 flex w-56 flex-col border-r border-zinc-200 bg-white">
-      <div className="flex h-14 items-center border-b border-zinc-200 px-5">
-        <Link
-          href="/"
-          className="text-sm font-semibold tracking-tight text-zinc-900"
-        >
-          ShearSimplicity
-        </Link>
+    <svg
+      className="ss-nav-icon"
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
+
+function isActive(activeHref: string, itemHref: string) {
+  if (itemHref === "/") return activeHref === "/";
+  return activeHref === itemHref || activeHref.startsWith(itemHref + "/");
+}
+
+export function Sidebar({
+  activeHref,
+  userInitials,
+  userName,
+  userRole,
+}: {
+  activeHref: string;
+  userInitials: string;
+  userName: string;
+  userRole: string;
+}) {
+  return (
+    <aside className="ss-sidebar">
+      <div className="ss-brand">
+        <h1 className="ss-brand-script">Shear</h1>
+        <p className="ss-brand-sub">Simplicity</p>
+        <div className="ss-brand-flourish">
+          <svg width={12} height={12} viewBox="0 0 12 12" fill="currentColor">
+            <path d="M6 0 L7 5 L12 6 L7 7 L6 12 L5 7 L0 6 L5 5 Z" />
+          </svg>
+        </div>
       </div>
-      <nav className="flex-1 overflow-y-auto p-3">
-        <ul className="space-y-1">
-          {items.map((item) => {
-            const active =
-              item.href === "/"
-                ? activeHref === "/"
-                : activeHref.startsWith(item.href);
-            return (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  className={
-                    "block rounded-md px-3 py-2 text-sm font-medium transition-colors " +
-                    (active
-                      ? "bg-zinc-100 text-zinc-900"
-                      : "text-zinc-600 hover:bg-zinc-50 hover:text-zinc-900")
-                  }
-                >
-                  {item.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
-      <div className="border-t border-zinc-200 px-4 py-3 text-xs text-zinc-400">
-        Phase 2 · Core data
+
+      <ul className="ss-nav">
+        {NAV.map((n) => (
+          <li key={n.href}>
+            <Link
+              href={n.href}
+              className={`ss-nav-item ${isActive(activeHref, n.href) ? "is-active" : ""}`}
+            >
+              <NavIcon d={n.iconPath} />
+              <span>{n.label}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <div className="ss-nav-section">Studio</div>
+      <ul className="ss-nav">
+        <li>
+          <Link
+            href="/settings"
+            className={`ss-nav-item ${isActive(activeHref, "/settings") ? "is-active" : ""}`}
+          >
+            <NavIcon d={SETTINGS_ICON} />
+            <span>Settings</span>
+          </Link>
+        </li>
+      </ul>
+
+      <div className="ss-sidebar-footer">
+        <div className="ss-avatar">{userInitials}</div>
+        <div className="ss-user-meta">
+          <div className="ss-user-name">{userName}</div>
+          <div className="ss-user-role">{userRole}</div>
+        </div>
       </div>
     </aside>
   );

--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -1,4 +1,28 @@
+import Link from "next/link";
 import { TopbarOrgSwitcher, TopbarUserButton } from "./topbar-clerk";
+
+const SEARCH_ICON =
+  "M21 21l-4.35-4.35M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z";
+const BELL_ICON =
+  "M18 16v-5a6 6 0 1 0-12 0v5l-2 3h16l-2-3ZM10 21a2 2 0 0 0 4 0";
+const PLUS_ICON = "M12 5v14M5 12h14";
+
+function StrokedIcon({ d, size = 17 }: { d: string; size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
 
 export function Topbar({
   mode,
@@ -11,35 +35,53 @@ export function Topbar({
   salonSlug: string | null;
   userEmail: string;
 }) {
+  const orgInitial = (salonName ?? "S").trim().charAt(0).toUpperCase();
+  void userEmail;
   return (
-    <header className="sticky top-0 z-10 flex h-14 items-center justify-between border-b border-zinc-200 bg-white/80 px-6 backdrop-blur">
-      <div className="flex items-center gap-3">
-        {mode === "clerk" ? (
-          <TopbarOrgSwitcher />
-        ) : (
-          <span className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 shadow-sm">
-            {salonName ?? "—"}
-            {salonSlug ? (
-              <span className="text-zinc-400">({salonSlug})</span>
-            ) : null}
-          </span>
-        )}
+    <div className="ss-topbar">
+      {mode === "clerk" ? (
+        <TopbarOrgSwitcher />
+      ) : (
+        <div className="ss-org-pill">
+          <div className="ss-org-mark">{orgInitial}</div>
+          <span>{salonName ?? "—"}</span>
+          {salonSlug ? <span className="ss-org-tag">· {salonSlug}</span> : null}
+        </div>
+      )}
+
+      <div className="ss-search">
+        <StrokedIcon d={SEARCH_ICON} size={15} />
+        <input placeholder="Find a client, appointment, or service…" />
       </div>
-      <div className="flex items-center gap-3">
-        <span className="text-sm text-zinc-500">{userEmail}</span>
-        {mode === "clerk" ? (
-          <TopbarUserButton />
-        ) : (
-          <form action="/api/dev-sign-out" method="post">
-            <button
-              type="submit"
-              className="rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
-            >
-              Sign out
-            </button>
-          </form>
-        )}
-      </div>
-    </header>
+
+      <div className="ss-topbar-spacer" />
+
+      <button className="ss-icon-btn" aria-label="Notifications" type="button">
+        <StrokedIcon d={BELL_ICON} />
+        <span className="ss-dot" />
+      </button>
+
+      <Link
+        href="/schedule?new=1"
+        className="ss-icon-btn"
+        aria-label="New appointment"
+      >
+        <StrokedIcon d={PLUS_ICON} />
+      </Link>
+
+      {mode === "clerk" ? (
+        <TopbarUserButton />
+      ) : (
+        <form action="/api/dev-sign-out" method="post">
+          <button
+            type="submit"
+            className="ss-btn ss-btn-ghost"
+            style={{ marginLeft: 8 }}
+          >
+            Sign out
+          </button>
+        </form>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/lib/salon-time.ts
+++ b/apps/web/src/lib/salon-time.ts
@@ -1,0 +1,79 @@
+import { fromZonedTime, toZonedTime, format as formatTz } from "date-fns-tz";
+import { addDays } from "date-fns";
+
+// All appointment timestamps live as absolute UTC instants. The salon decides
+// what day-boundary to draw — these helpers convert between "calendar date in
+// the salon's wall clock" and the UTC instants we send to the API.
+
+export interface DayWindow {
+  /** Inclusive UTC instant of midnight in the salon's timezone. */
+  fromUtc: Date;
+  /** Exclusive UTC instant of the next day's midnight in the salon's timezone. */
+  toUtc: Date;
+  /** "YYYY-MM-DD" in the salon's timezone — round-trip safe through the URL. */
+  isoDate: string;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function todayIsoInTimezone(timezone: string): string {
+  return formatTz(new Date(), "yyyy-MM-dd", { timeZone: timezone });
+}
+
+export function dayWindow(isoDate: string, timezone: string): DayWindow {
+  if (!ISO_DATE.test(isoDate)) {
+    throw new Error(`Expected YYYY-MM-DD, got "${isoDate}"`);
+  }
+  // fromZonedTime("2026-04-29T00:00:00", "America/New_York") yields the UTC
+  // instant when New York's wall clock reads midnight on the 29th — i.e. the
+  // start of that calendar day.
+  const fromUtc = fromZonedTime(`${isoDate}T00:00:00`, timezone);
+  const toUtc = fromZonedTime(`${isoDate}T00:00:00`, timezone);
+  toUtc.setTime(addDays(toUtc, 1).getTime());
+  return { fromUtc, toUtc, isoDate };
+}
+
+/** Add N calendar days in the salon's timezone (handles DST). */
+export function shiftIsoDate(
+  isoDate: string,
+  delta: number,
+  timezone: string,
+): string {
+  const base = fromZonedTime(`${isoDate}T12:00:00`, timezone);
+  const shifted = addDays(base, delta);
+  return formatTz(shifted, "yyyy-MM-dd", { timeZone: timezone });
+}
+
+export function formatTimeInTimezone(date: Date, timezone: string): string {
+  return formatTz(date, "h:mm a", { timeZone: timezone });
+}
+
+export function formatDayLabel(isoDate: string, timezone: string): string {
+  // Anchor at midday so the label can't slip into the previous/next day at the
+  // DST boundary while we format.
+  const d = fromZonedTime(`${isoDate}T12:00:00`, timezone);
+  return formatTz(d, "EEEE, MMMM d", { timeZone: timezone });
+}
+
+/** Minutes from the start of the salon-local day for a given UTC instant. */
+export function minutesFromDayStart(
+  instant: Date,
+  isoDate: string,
+  timezone: string,
+): number {
+  const dayStart = dayWindow(isoDate, timezone).fromUtc;
+  return Math.round((instant.getTime() - dayStart.getTime()) / 60_000);
+}
+
+/** Inverse of minutesFromDayStart — used by the drop handler. */
+export function instantAtMinutes(
+  minutes: number,
+  isoDate: string,
+  timezone: string,
+): Date {
+  const dayStart = dayWindow(isoDate, timezone).fromUtc;
+  return new Date(dayStart.getTime() + minutes * 60_000);
+}
+
+/** Local-clock label for a UTC instant rendered in the salon's timezone. */
+export { toZonedTime };

--- a/apps/web/src/lib/salon-time.ts
+++ b/apps/web/src/lib/salon-time.ts
@@ -4,6 +4,11 @@ import { addDays } from "date-fns";
 // All appointment timestamps live as absolute UTC instants. The salon decides
 // what day-boundary to draw — these helpers convert between "calendar date in
 // the salon's wall clock" and the UTC instants we send to the API.
+//
+// DST note: a salon-local day can be 23, 24, or 25 UTC hours long. Every
+// helper here works in salon wall-clock units rather than elapsed UTC minutes
+// so the calendar grid (and the drop handler) stays correct on transition
+// days.
 
 export interface DayWindow {
   /** Inclusive UTC instant of midnight in the salon's timezone. */
@@ -24,12 +29,11 @@ export function dayWindow(isoDate: string, timezone: string): DayWindow {
   if (!ISO_DATE.test(isoDate)) {
     throw new Error(`Expected YYYY-MM-DD, got "${isoDate}"`);
   }
-  // fromZonedTime("2026-04-29T00:00:00", "America/New_York") yields the UTC
-  // instant when New York's wall clock reads midnight on the 29th — i.e. the
-  // start of that calendar day.
+  // toUtc is *next* salon-local midnight, not fromUtc + 24h. On a
+  // spring-forward day toUtc is 23h after fromUtc; on fall-back it's 25h.
   const fromUtc = fromZonedTime(`${isoDate}T00:00:00`, timezone);
-  const toUtc = fromZonedTime(`${isoDate}T00:00:00`, timezone);
-  toUtc.setTime(addDays(toUtc, 1).getTime());
+  const nextIsoDate = shiftIsoDate(isoDate, 1, timezone);
+  const toUtc = fromZonedTime(`${nextIsoDate}T00:00:00`, timezone);
   return { fromUtc, toUtc, isoDate };
 }
 
@@ -39,6 +43,8 @@ export function shiftIsoDate(
   delta: number,
   timezone: string,
 ): string {
+  // Anchor at midday so the +/- 24 UTC hours from addDays can't slip across
+  // a DST gap and produce yesterday/tomorrow's date.
   const base = fromZonedTime(`${isoDate}T12:00:00`, timezone);
   const shifted = addDays(base, delta);
   return formatTz(shifted, "yyyy-MM-dd", { timeZone: timezone });
@@ -55,14 +61,22 @@ export function formatDayLabel(isoDate: string, timezone: string): string {
   return formatTz(d, "EEEE, MMMM d", { timeZone: timezone });
 }
 
-/** Minutes from the start of the salon-local day for a given UTC instant. */
+/**
+ * Salon wall-clock minutes from midnight for a given UTC instant. We read the
+ * instant's H:mm in the salon timezone and convert to minutes — that way a 9
+ * AM appointment lands at slot 540 regardless of whether the day was 23, 24,
+ * or 25 UTC hours long. `isoDate` is preserved in the signature so the
+ * caller's grid context is explicit, even though the math no longer needs it.
+ */
 export function minutesFromDayStart(
   instant: Date,
   isoDate: string,
   timezone: string,
 ): number {
-  const dayStart = dayWindow(isoDate, timezone).fromUtc;
-  return Math.round((instant.getTime() - dayStart.getTime()) / 60_000);
+  void isoDate;
+  const hm = formatTz(instant, "HH:mm", { timeZone: timezone });
+  const [hh, mm] = hm.split(":").map(Number);
+  return hh * 60 + mm;
 }
 
 /** Inverse of minutesFromDayStart — used by the drop handler. */
@@ -71,8 +85,12 @@ export function instantAtMinutes(
   isoDate: string,
   timezone: string,
 ): Date {
-  const dayStart = dayWindow(isoDate, timezone).fromUtc;
-  return new Date(dayStart.getTime() + minutes * 60_000);
+  // Build the salon-local wall-clock string and convert. fromZonedTime picks
+  // the correct UTC offset for the date, so HH:mm round-trips through DST
+  // gaps without drifting an hour.
+  const hh = String(Math.floor(minutes / 60)).padStart(2, "0");
+  const mm = String(minutes % 60).padStart(2, "0");
+  return fromZonedTime(`${isoDate}T${hh}:${mm}:00`, timezone);
 }
 
 /** Local-clock label for a UTC instant rendered in the salon's timezone. */

--- a/apps/web/src/lib/service-categories.ts
+++ b/apps/web/src/lib/service-categories.ts
@@ -1,0 +1,43 @@
+// Map a service category name (free-text, set by the salon) to one of the
+// fixed visual "kinds" the calendar uses for color coding. Keep this on the
+// web side until/unless we promote `kind` to a real schema field — the salon
+// can rename a category and the matcher still finds the right bucket.
+
+export type CategoryKind =
+  | "color"
+  | "cut"
+  | "styling"
+  | "treat"
+  | "bridal"
+  | "block";
+
+interface Pattern {
+  kind: CategoryKind;
+  match: RegExp;
+}
+
+const PATTERNS: ReadonlyArray<Pattern> = [
+  { kind: "color", match: /color|balayage|highlight|gloss|tint/i },
+  { kind: "cut", match: /cut|trim|barber|shave|beard/i },
+  { kind: "styling", match: /style|blowout|blow.?dry|braid|updo (?!bridal)/i },
+  { kind: "treat", match: /toner|treat|olaplex|condition|mask|keratin/i },
+  { kind: "bridal", match: /bridal|wedding|special/i },
+];
+
+export function categoryKind(input: {
+  categoryName?: string | null;
+  serviceName?: string | null;
+}): CategoryKind {
+  // Category name wins when present — that's what the salon tagged the
+  // service as. Fall back to the service name itself, since salons don't
+  // always categorize.
+  for (const source of [input.categoryName, input.serviceName]) {
+    if (!source) continue;
+    for (const p of PATTERNS) {
+      if (p.match.test(source)) return p.kind;
+    }
+  }
+  // No match: treat as a generic cut so it still picks up a real color
+  // rather than the "blocked" hatched style.
+  return "cut";
+}

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1,0 +1,791 @@
+/* ===== Sign-in screen ===== */
+.ss-signin {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ss-bg-page);
+  overflow: hidden;
+  font-family: var(--font-quicksand), sans-serif;
+  color: var(--ss-text-primary);
+  isolation: isolate;
+}
+.ss-signin::before {
+  content: "";
+  position: absolute; inset: 0;
+  background: var(--ss-bg-blanket);
+  z-index: 0;
+}
+.ss-signin-card {
+  position: relative;
+  z-index: 2;
+  width: 420px;
+  padding: 44px 40px 36px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 28px;
+  box-shadow: var(--ss-shadow-lg), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  text-align: center;
+}
+.ss-signin-mark {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 18px;
+}
+.ss-signin-mark .ss-brand-script {
+  font-size: 64px;
+  margin: 0;
+  line-height: 0.85;
+}
+.ss-signin-mark .ss-brand-sub {
+  margin: 4px 0 0;
+  letter-spacing: 0.4em;
+  padding-left: 0;
+  font-size: 11px;
+}
+.ss-signin h2 {
+  font-family: var(--font-cormorant), serif;
+  font-size: 26px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 18px 0 6px;
+}
+.ss-signin .ss-signin-sub {
+  color: var(--ss-text-secondary);
+  font-size: 13.5px;
+  margin: 0 0 22px;
+  line-height: 1.5;
+}
+.ss-field {
+  display: flex; flex-direction: column;
+  gap: 6px; text-align: left;
+  margin-bottom: 14px;
+}
+.ss-field label {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: var(--ss-text-muted);
+}
+.ss-field input, .ss-field select, .ss-field textarea {
+  padding: 11px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel-strong);
+  color: var(--ss-text-primary);
+  font: inherit;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 13.5px;
+  outline: none;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+.ss-field input:focus, .ss-field select:focus, .ss-field textarea:focus {
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 4px rgba(233, 30, 158, 0.16);
+}
+.ss-field textarea { resize: none; min-height: 80px; }
+.ss-signin-btn {
+  width: 100%;
+  margin-top: 6px;
+  padding: 14px;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  justify-content: center;
+}
+.ss-signin-divider {
+  display: flex; align-items: center; gap: 12px;
+  margin: 22px 0 18px;
+  color: var(--ss-text-muted);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.ss-signin-divider::before, .ss-signin-divider::after {
+  content: "";
+  flex: 1; height: 1px;
+  background: var(--ss-line);
+}
+.ss-signin-foot {
+  font-size: 12px;
+  color: var(--ss-text-muted);
+  margin-top: 20px;
+}
+.ss-signin-foot a, .ss-signin-foot strong {
+  color: var(--ss-magenta-deep);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+.theme-twilight .ss-signin-foot a, .theme-twilight .ss-signin-foot strong { color: var(--ss-magenta); }
+
+.ss-dev-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(200, 155, 58, 0.18);
+  color: #9c742a;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+.theme-twilight .ss-dev-pill { background: rgba(230, 196, 119, 0.18); color: var(--ss-gold); }
+
+/* ===== Settings ===== */
+.ss-settings-grid {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 32px;
+}
+.ss-settings-nav {
+  display: flex; flex-direction: column; gap: 2px;
+  position: sticky; top: 14px;
+}
+.ss-settings-nav a {
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ss-text-secondary);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease;
+}
+.ss-settings-nav a.is-active {
+  color: var(--ss-text-heading);
+  background: var(--ss-magenta-pale);
+  font-weight: 600;
+}
+.ss-settings-section + .ss-settings-section { margin-top: 20px; }
+.ss-settings-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.ss-toggle {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--ss-line);
+}
+.ss-toggle:last-child { border-bottom: 0; }
+.ss-toggle-label {
+  font-family: var(--font-cormorant), serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-toggle-sub {
+  font-size: 12px;
+  color: var(--ss-text-muted);
+  margin-top: 2px;
+}
+.ss-switch {
+  width: 44px; height: 24px;
+  border-radius: 999px;
+  background: var(--ss-line);
+  position: relative;
+  cursor: pointer;
+  transition: background 180ms ease;
+  flex-shrink: 0;
+}
+.ss-switch.is-on {
+  background: linear-gradient(90deg, var(--ss-magenta), var(--ss-cyan));
+  box-shadow: var(--ss-glow);
+}
+.ss-switch::after {
+  content: "";
+  position: absolute;
+  top: 3px; left: 3px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+  transition: left 180ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.ss-switch.is-on::after { left: 23px; }
+
+/* ===== Services list ===== */
+.ss-svc-section {
+  margin-bottom: 36px;
+  padding: 24px 26px 28px;
+  border-radius: 22px;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(14px);
+  position: relative;
+  overflow: hidden;
+}
+.ss-svc-section::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: var(--ss-magenta);
+  opacity: 0.85;
+}
+.ss-svc-section.is-cut::before {
+  background: var(--ss-cyan);
+}
+.ss-svc-section-head {
+  margin-bottom: 20px;
+}
+.ss-svc-section-rule {
+  display: none;
+}
+.ss-svc-section-title {
+  display: flex; align-items: baseline; gap: 14px;
+}
+.ss-svc-section-num {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--ss-magenta-deep);
+  padding: 5px 9px;
+  border-radius: 6px;
+  background: var(--ss-magenta-pale);
+  align-self: center;
+}
+.ss-svc-section.is-cut .ss-svc-section-num {
+  color: var(--ss-cyan-deep);
+  background: var(--ss-cyan-pale);
+}
+.theme-twilight .ss-svc-section-num { color: var(--ss-magenta); }
+.theme-twilight .ss-svc-section.is-cut .ss-svc-section-num { color: var(--ss-cyan); }
+.ss-svc-section-title h3 {
+  font-family: var(--font-cormorant), serif;
+  font-size: 30px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 0;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+.ss-svc-section-count {
+  margin-left: auto;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--ss-text-muted);
+  text-transform: uppercase;
+}
+
+.ss-svc-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+.ss-svc-card {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 18px;
+  border-radius: 14px;
+  background: var(--ss-bg);
+  border: 1px solid var(--ss-line);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+.ss-svc-card:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--ss-shadow-sm);
+  border-color: var(--ss-line-strong);
+}
+.ss-svc-icon {
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  background: var(--ss-magenta-pale);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ss-magenta-deep);
+  flex-shrink: 0;
+}
+.ss-svc-section.is-cut .ss-svc-icon {
+  background: var(--ss-cyan-pale);
+  color: var(--ss-cyan-deep);
+}
+.theme-twilight .ss-svc-icon { color: var(--ss-magenta); }
+.theme-twilight .ss-svc-section.is-cut .ss-svc-icon { color: var(--ss-cyan); }
+.ss-svc-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 19px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.2;
+}
+.ss-svc-desc {
+  font-size: 12.5px;
+  color: var(--ss-text-secondary);
+  margin-top: 2px;
+}
+.ss-svc-meta {
+  text-align: right;
+}
+.ss-svc-price {
+  font-family: var(--font-cormorant), serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1;
+}
+.ss-svc-dur {
+  font-size: 11px;
+  color: var(--ss-text-muted);
+  margin-top: 4px;
+  letter-spacing: 0.06em;
+}
+
+/* ===== Messages thread ===== */
+.ss-thread {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 18px;
+  height: 720px;
+}
+.ss-thread-list {
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 20px;
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.ss-thread-search {
+  padding: 14px;
+  border-bottom: 1px solid var(--ss-line);
+}
+.ss-thread-search .ss-search { width: 100%; max-width: none; }
+.ss-thread-items { flex: 1; overflow-y: auto; }
+.ss-thread-item {
+  display: flex; gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px dashed var(--ss-line);
+  cursor: pointer;
+  transition: background 180ms ease;
+  position: relative;
+}
+.ss-thread-item:hover { background: var(--ss-magenta-pale); }
+.ss-thread-item.is-active {
+  background: var(--ss-magenta-pale);
+}
+.ss-thread-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 12px; bottom: 12px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: linear-gradient(180deg, var(--ss-magenta), var(--ss-cyan));
+}
+.ss-thread-unread {
+  position: absolute; right: 14px; top: 14px;
+  background: var(--ss-magenta);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 999px;
+}
+
+.ss-thread-view {
+  display: flex; flex-direction: column;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 20px;
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+}
+.ss-thread-view-head {
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--ss-line);
+  display: flex; align-items: center; gap: 12px;
+}
+.ss-thread-name { font-family: var(--font-cormorant), serif; font-size: 19px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-thread-num { font-size: 11.5px; color: var(--ss-text-muted); margin-top: 2px; }
+.ss-thread-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.ss-bubble {
+  max-width: 70%;
+  padding: 12px 16px;
+  border-radius: 18px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  position: relative;
+}
+.ss-bubble-them {
+  align-self: flex-start;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  color: var(--ss-text-primary);
+  border-bottom-left-radius: 6px;
+}
+.ss-bubble-us {
+  align-self: flex-end;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-magenta-deep));
+  color: white;
+  border-bottom-right-radius: 6px;
+  box-shadow: 0 6px 18px rgba(233, 30, 158, 0.28);
+}
+.ss-bubble-system {
+  align-self: center;
+  background: var(--ss-cyan-pale);
+  color: var(--ss-cyan-deep);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(30, 195, 217, 0.4);
+}
+.theme-twilight .ss-bubble-system { color: var(--ss-cyan); }
+.ss-bubble-time {
+  font-size: 10px;
+  color: var(--ss-text-muted);
+  margin-top: 4px;
+  letter-spacing: 0.08em;
+}
+.ss-bubble-us + .ss-bubble-time { text-align: right; }
+
+.ss-day-divider {
+  text-align: center;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  display: flex; align-items: center; gap: 12px;
+}
+.ss-day-divider::before, .ss-day-divider::after {
+  content: ""; flex: 1; height: 1px;
+  background: var(--ss-line);
+}
+
+.ss-thread-compose {
+  padding: 14px 18px;
+  border-top: 1px solid var(--ss-line);
+  display: flex; align-items: center; gap: 10px;
+  background: var(--ss-panel-strong);
+}
+.ss-thread-compose input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel-strong);
+  color: var(--ss-text-primary);
+  font-family: inherit;
+  font-size: 13.5px;
+  outline: none;
+}
+.ss-thread-compose input:focus {
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 4px rgba(233, 30, 158, 0.16);
+}
+
+/* ===== Single-client profile ===== */
+.ss-profile-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 24px;
+}
+.ss-profile-hero {
+  position: relative;
+  padding: 28px 24px;
+  border-radius: 22px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  box-shadow: var(--ss-shadow-md), inset 0 1px 0 var(--ss-panel-edge);
+  text-align: center;
+  overflow: hidden;
+}
+.ss-profile-hero::before {
+  content: "";
+  position: absolute;
+  top: -40px; left: 50%;
+  transform: translateX(-50%);
+  width: 220px; height: 220px;
+  border-radius: 50%;
+  filter: blur(48px);
+  background: radial-gradient(circle, var(--ss-magenta), transparent 60%);
+  opacity: 0.45;
+  z-index: 0;
+}
+.ss-profile-hero > * { position: relative; z-index: 1; }
+.ss-profile-photo {
+  width: 110px; height: 110px;
+  border-radius: 50%;
+  margin: 8px auto 14px;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-violet));
+  border: 3px solid var(--ss-panel-edge);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-cormorant), serif;
+  font-size: 38px;
+  font-weight: 600;
+  color: white;
+  box-shadow: 0 10px 30px rgba(233, 30, 158, 0.36);
+}
+.ss-profile-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.05;
+  margin: 0;
+}
+.ss-profile-since {
+  font-family: var(--font-great-vibes), cursive;
+  font-size: 18px;
+  color: var(--ss-cyan-deep);
+  margin: 4px 0 14px;
+}
+.theme-twilight .ss-profile-since { color: var(--ss-cyan); }
+.ss-profile-tags {
+  display: flex; gap: 6px; justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.ss-profile-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px dashed var(--ss-line);
+  text-align: left;
+}
+.ss-profile-meta dt {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin-bottom: 4px;
+}
+.ss-profile-meta dd {
+  margin: 0 0 10px;
+  font-size: 13px;
+  color: var(--ss-text-primary);
+}
+.ss-profile-actions {
+  display: flex; gap: 8px; justify-content: center;
+}
+
+.ss-profile-stats {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.ss-mini-stat {
+  padding: 16px;
+  border-radius: 14px;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  text-align: center;
+}
+.ss-mini-stat-v {
+  font-family: var(--font-cormorant), serif;
+  font-size: 26px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1;
+}
+.ss-mini-stat-l {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin-top: 6px;
+}
+
+.ss-history {
+  position: relative;
+  padding-left: 24px;
+}
+.ss-history::before {
+  content: "";
+  position: absolute;
+  left: 6px; top: 8px; bottom: 8px;
+  width: 2px;
+  background: linear-gradient(180deg, var(--ss-magenta), var(--ss-cyan));
+  border-radius: 999px;
+  opacity: 0.4;
+}
+.ss-history-entry {
+  position: relative;
+  padding: 10px 0 14px;
+  border-bottom: 1px dashed var(--ss-line);
+}
+.ss-history-entry:last-child { border-bottom: 0; }
+.ss-history-entry::before {
+  content: "";
+  position: absolute;
+  left: -22px; top: 14px;
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: var(--ss-magenta);
+  box-shadow: 0 0 0 3px var(--ss-bg-page);
+}
+.ss-history-row1 {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 12px;
+}
+.ss-history-svc {
+  font-family: var(--font-cormorant), serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-history-date { font-size: 12px; color: var(--ss-text-muted); }
+.ss-history-meta { font-size: 12.5px; color: var(--ss-text-secondary); margin-top: 2px; }
+.ss-history-meta strong { color: var(--ss-magenta-deep); font-weight: 600; }
+.theme-twilight .ss-history-meta strong { color: var(--ss-magenta); }
+.ss-history-note {
+  margin-top: 6px;
+  padding: 8px 12px;
+  background: var(--ss-magenta-pale);
+  border-radius: 10px;
+  font-size: 12px;
+  color: var(--ss-text-secondary);
+  font-style: italic;
+  border-left: 2px solid var(--ss-magenta);
+}
+
+/* ====================================================
+   Phase 3b — schedule page additions (toolbar, drag/
+   drop affordances, details panel, links).
+==================================================== */
+
+.ss-schedule-toolbar {
+  display: flex; align-items: center; justify-content: space-between;
+  margin: 0 0 16px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.ss-schedule-toolbar-group { display: flex; align-items: center; gap: 8px; }
+.ss-schedule-toolbar-meta {
+  margin-left: 12px;
+  color: var(--ss-text-secondary);
+  font-size: 13px;
+}
+
+.ss-schedule-error {
+  padding: 10px 14px;
+  margin: 0 0 16px;
+  border-radius: 10px;
+  background: rgba(212, 74, 110, 0.08);
+  border: 1px solid rgba(212, 74, 110, 0.32);
+  color: #842842;
+  font-size: 13px;
+}
+.theme-twilight .ss-schedule-error {
+  background: rgba(255, 72, 185, 0.10);
+  border-color: rgba(255, 72, 185, 0.36);
+  color: #ffd5e9;
+}
+
+/* Drag affordance: lift the dragged block, dim it while it's mid-flight,
+   then highlight the target cell. */
+.ss-cal-block.is-dragging {
+  opacity: 0.5;
+  cursor: grabbing;
+}
+.ss-cal-block { cursor: grab; }
+.ss-cal-block.is-selected {
+  outline: 2px solid var(--ss-magenta);
+  outline-offset: 1px;
+  box-shadow: var(--ss-shadow-md), var(--ss-glow);
+}
+.ss-cal-cell.is-drop-target {
+  background: var(--ss-magenta-pale);
+  outline: 1px dashed var(--ss-magenta);
+  outline-offset: -2px;
+}
+
+/* Slide-out details panel pinned to the right of the calendar. Stays in
+   normal flow on narrow viewports so it doesn't cover the grid; lifts to a
+   fixed sidebar on wider screens. */
+.ss-detail-panel {
+  position: fixed;
+  top: 70px; right: 24px;
+  width: 360px; max-width: calc(100vw - 48px);
+  z-index: 60;
+  background: var(--ss-panel-strong);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 18px;
+  padding: 22px 22px 18px;
+  box-shadow: var(--ss-shadow-lg);
+  animation: ss-detail-in 220ms ease both;
+}
+@keyframes ss-detail-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.ss-detail-close {
+  position: absolute; top: 12px; right: 12px;
+  width: 28px; height: 28px;
+  border: 0; background: transparent;
+  border-radius: 999px;
+  font-size: 22px; line-height: 1;
+  color: var(--ss-text-muted);
+  cursor: pointer;
+}
+.ss-detail-close:hover { background: var(--ss-magenta-pale); color: var(--ss-magenta-deep); }
+.ss-detail-title {
+  font-family: var(--font-cormorant), serif;
+  font-size: 24px; font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 4px 0 4px;
+}
+.ss-detail-sub {
+  font-size: 13.5px;
+  color: var(--ss-text-secondary);
+  margin: 0 0 8px;
+}
+.ss-detail-services {
+  font-size: 13px;
+  color: var(--ss-text-primary);
+  margin: 0 0 6px;
+}
+.ss-detail-meta { font-size: 12.5px; color: var(--ss-text-muted); margin: 0; }
+.ss-detail-section { margin-top: 14px; font-size: 13px; color: var(--ss-text-primary); }
+.ss-detail-section p { margin: 4px 0 0; }
+.ss-detail-label {
+  font-size: 11px; text-transform: uppercase;
+  letter-spacing: 0.18em; font-weight: 700;
+  color: var(--ss-text-muted);
+}
+.ss-detail-actions {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin-top: 18px;
+}
+.ss-detail-actions .ss-btn { font-size: 13px; padding: 8px 14px; }
+
+.ss-link {
+  color: var(--ss-magenta-deep);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.ss-link:hover { color: var(--ss-magenta); }

--- a/apps/web/src/styles/styles.css
+++ b/apps/web/src/styles/styles.css
@@ -1,0 +1,1950 @@
+/* ========================================================
+   Shear Simplicity — Tresses + Gentle Magic blend
+   Two themes: .theme-light (porcelain) and .theme-twilight
+   (plum dusk). Both use Tresses palette but borrow Ambon's
+   layered glass + drifting orbs + ornament.
+======================================================== */
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+/* ---- Decorative SVG flourishes (reused inline data URIs) ---- */
+.flourish {
+  display: block;
+  width: 100%;
+  height: 18px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  opacity: 0.85;
+}
+
+/* =====  THEME: SALON LIGHT (porcelain + cyan ornament) ===== */
+.theme-light {
+  --ss-bg-page: #f3fbfd;
+  --ss-bg-blanket:
+    radial-gradient(circle at 14% 8%, rgb(30 195 217 / 18%), transparent 42%),
+    radial-gradient(circle at 88% 14%, rgb(233 30 158 / 10%), transparent 46%),
+    radial-gradient(circle at 50% 110%, rgb(76 130 179 / 10%), transparent 60%),
+    linear-gradient(168deg, #f6fcfd 0%, #e6f4f8 52%, #f5fbfd 100%);
+
+  --ss-panel: rgba(255, 255, 255, 0.78);
+  --ss-panel-strong: rgba(255, 255, 255, 0.92);
+  --ss-panel-border: rgba(30, 195, 217, 0.20);
+  --ss-panel-edge: rgba(255, 255, 255, 0.85);
+
+  --ss-text-primary: #0f2630;
+  --ss-text-heading: #06424f;
+  --ss-text-bright: #042730;
+  --ss-text-secondary: #2d6776;
+  --ss-text-muted: #7aa3ad;
+
+  /* Primary now CYAN; accent ("magenta") tokens still used widely — retarget them to cyan/teal so existing styling reads cyan-dominant. */
+  --ss-magenta: #1ec3d9;       /* primary (was magenta) */
+  --ss-magenta-deep: #0892a8;
+  --ss-magenta-pale: #d9f1f5;
+  --ss-cyan: #e91e9e;          /* accent (was cyan) */
+  --ss-cyan-deep: #b6147c;
+  --ss-cyan-pale: #fce6f2;
+  --ss-violet: #4a82b3;
+  --ss-gold: #c89b3a;
+
+  --ss-line: rgba(30, 195, 217, 0.22);
+  --ss-line-strong: rgba(30, 195, 217, 0.36);
+  --ss-shadow-sm: 0 2px 10px rgba(8, 60, 80, 0.08);
+  --ss-shadow-md: 0 12px 32px rgba(8, 80, 100, 0.12);
+  --ss-shadow-lg: 0 22px 60px rgba(8, 80, 100, 0.16);
+  --ss-glow: 0 0 28px rgba(30, 195, 217, 0.30);
+
+  --ss-sidebar-bg: linear-gradient(176deg, #effafc 0%, #def0f4 100%);
+  --ss-sidebar-active: linear-gradient(94deg, rgba(30, 195, 217, 0.20), rgba(30, 195, 217, 0.10));
+}
+
+/* =====  THEME: SALON TWILIGHT (deep teal dusk + magenta glow) ===== */
+.theme-twilight {
+  --ss-bg-page: #061922;
+  --ss-bg-blanket:
+    radial-gradient(circle at 16% 10%, rgba(30, 195, 217, 0.26), transparent 44%),
+    radial-gradient(circle at 84% 14%, rgba(30, 195, 217, 0.18), transparent 50%),
+    radial-gradient(circle at 50% 110%, rgba(76, 140, 180, 0.20), transparent 60%),
+    linear-gradient(165deg, #082230 0%, #051820 48%, #0a2735 100%);
+
+  --ss-panel: rgba(14, 56, 70, 0.55);
+  --ss-panel-strong: rgba(14, 56, 70, 0.78);
+  --ss-panel-border: rgba(30, 195, 217, 0.26);
+  --ss-panel-edge: rgba(220, 245, 250, 0.10);
+
+  --ss-text-primary: #e1f0f4;
+  --ss-text-heading: #d6f4fa;
+  --ss-text-bright: #ffffff;
+  --ss-text-secondary: #a8c8d0;
+  --ss-text-muted: #6f8e98;
+
+  /* Primary CYAN; accent ("magenta" tokens) repurposed to cyan for dominance, with hot-pink kept as accent on cyan-prefixed tokens. */
+  --ss-magenta: #5cdcec;        /* primary (was magenta) */
+  --ss-magenta-deep: #1ec3d9;
+  --ss-magenta-pale: rgba(30, 195, 217, 0.16);
+  --ss-cyan: #ff48b9;           /* accent (was cyan) */
+  --ss-cyan-deep: #e91e9e;
+  --ss-cyan-pale: rgba(30, 195, 217, 0.18);
+  --ss-violet: #6fa6cc;
+  --ss-gold: #e6c477;
+
+  --ss-line: rgba(30, 195, 217, 0.26);
+  --ss-line-strong: rgba(30, 195, 217, 0.46);
+  --ss-shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.4);
+  --ss-shadow-md: 0 14px 36px rgba(0, 0, 0, 0.48);
+  --ss-shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.56);
+  --ss-glow: 0 0 32px rgba(30, 195, 217, 0.40);
+
+  --ss-sidebar-bg: linear-gradient(176deg, #0a2735 0%, #051a24 100%);
+  --ss-sidebar-active: linear-gradient(94deg, rgba(30, 195, 217, 0.32), rgba(30, 195, 217, 0.18));
+}
+
+/* ---- App frame (an "artboard" stage) ---- */
+.ss-app {
+  position: relative;
+  isolation: isolate;
+  width: 100%;
+  height: 100%;
+  background: var(--ss-bg-page);
+  color: var(--ss-text-primary);
+  font-family: var(--font-quicksand), "Nunito Sans", sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  overflow: hidden;
+  display: flex;
+}
+
+.ss-app::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--ss-bg-blanket);
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* drifting orbs */
+.ss-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.55;
+  z-index: 0;
+  pointer-events: none;
+  animation: ss-drift 14s ease-in-out infinite alternate;
+}
+.ss-orb-magenta {
+  top: -10%; right: -8%;
+  width: 380px; height: 380px;
+  background: radial-gradient(circle, var(--ss-magenta) 0%, transparent 65%);
+}
+.ss-orb-cyan {
+  bottom: -12%; left: 12%;
+  width: 340px; height: 340px;
+  background: radial-gradient(circle, var(--ss-cyan) 0%, transparent 65%);
+  animation-duration: 18s;
+  opacity: 0.42;
+}
+.ss-orb-violet {
+  top: 38%; left: 48%;
+  width: 280px; height: 280px;
+  background: radial-gradient(circle, var(--ss-violet) 0%, transparent 65%);
+  animation-duration: 22s;
+  opacity: 0.32;
+}
+.theme-light .ss-orb { opacity: 0.35; mix-blend-mode: multiply; filter: blur(80px); }
+.theme-light .ss-orb-magenta { opacity: 0.18; }
+.theme-light .ss-orb-cyan { opacity: 0.16; }
+.theme-light .ss-orb-violet { opacity: 0.12; }
+
+@keyframes ss-drift {
+  from { transform: translate3d(0, 0, 0) scale(1); }
+  to   { transform: translate3d(28px, 36px, 0) scale(1.08); }
+}
+
+/* tiny floating motes */
+.ss-motes {
+  position: absolute; inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  overflow: hidden;
+}
+.ss-mote {
+  position: absolute;
+  width: 4px; height: 4px;
+  border-radius: 50%;
+  background: var(--ss-magenta);
+  opacity: 0;
+  animation: ss-mote 9s linear infinite;
+  box-shadow: 0 0 8px currentColor;
+}
+.theme-light .ss-mote { background: var(--ss-magenta); opacity: 0; }
+@keyframes ss-mote {
+  0%   { transform: translateY(20px) scale(0.6); opacity: 0; }
+  10%  { opacity: 0.7; }
+  90%  { opacity: 0.55; }
+  100% { transform: translateY(-220px) scale(1.1); opacity: 0; }
+}
+
+/* ============= SIDEBAR ============= */
+.ss-sidebar {
+  position: relative;
+  z-index: 2;
+  width: 232px;
+  flex: 0 0 232px;
+  background: var(--ss-sidebar-bg);
+  border-right: 1px solid var(--ss-line);
+  display: flex;
+  flex-direction: column;
+  padding: 22px 14px 18px;
+}
+
+.ss-brand {
+  padding: 4px 8px 14px;
+  border-bottom: 1px solid var(--ss-line);
+  margin-bottom: 14px;
+  position: relative;
+}
+.ss-brand-script {
+  font-family: var(--font-great-vibes), cursive;
+  font-size: 38px;
+  line-height: 0.9;
+  color: var(--ss-magenta);
+  margin: 0;
+  letter-spacing: 0.01em;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+.theme-twilight .ss-brand-script { text-shadow: 0 0 20px rgba(30, 195, 217, 0.5); }
+.ss-brand-sub {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ss-cyan-deep);
+  margin: 4px 0 0;
+  padding-left: 6px;
+}
+.theme-twilight .ss-brand-sub { color: var(--ss-cyan); }
+
+.ss-brand-flourish {
+  position: absolute;
+  right: 6px; top: 18px;
+  width: 14px; height: 14px;
+  color: var(--ss-cyan);
+  opacity: 0.7;
+}
+
+.ss-nav {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex; flex-direction: column;
+  gap: 2px;
+}
+.ss-nav-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--ss-text-secondary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 180ms ease, color 180ms ease;
+  position: relative;
+}
+.ss-nav-item:hover {
+  color: var(--ss-text-heading);
+  background: var(--ss-magenta-pale);
+}
+.ss-nav-item.is-active {
+  color: var(--ss-text-heading);
+  background: var(--ss-sidebar-active);
+  font-weight: 600;
+  box-shadow: inset 0 1px 0 var(--ss-panel-edge);
+}
+.ss-nav-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -14px; top: 50%;
+  transform: translateY(-50%);
+  width: 3px; height: 18px;
+  border-radius: 0 3px 3px 0;
+  background: linear-gradient(180deg, var(--ss-magenta), var(--ss-cyan));
+}
+.ss-nav-icon {
+  width: 18px; height: 18px;
+  color: currentColor;
+  flex-shrink: 0;
+}
+
+.ss-nav-section {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--ss-text-muted);
+  padding: 14px 12px 6px;
+}
+
+.ss-sidebar-footer {
+  margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid var(--ss-line);
+  display: flex; align-items: center; gap: 10px;
+}
+.ss-avatar {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-cyan));
+  display: flex; align-items: center; justify-content: center;
+  color: white;
+  font-weight: 700;
+  font-size: 13px;
+  flex-shrink: 0;
+  box-shadow: 0 2px 8px rgba(30, 195, 217, 0.3);
+}
+.ss-user-meta {
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+.ss-user-name { font-size: 13px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-user-role { font-size: 11px; color: var(--ss-text-muted); }
+
+/* ============= MAIN ============= */
+.ss-main {
+  flex: 1;
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: auto;
+}
+
+.ss-topbar {
+  display: flex; align-items: center; gap: 16px;
+  padding: 14px 28px;
+  border-bottom: 1px solid var(--ss-line);
+  background: var(--ss-panel);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  position: sticky; top: 0; z-index: 10;
+}
+.ss-org-pill {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 7px 16px 7px 7px;
+  border-radius: 999px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-line);
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-org-mark {
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-violet));
+  display: flex; align-items: center; justify-content: center;
+  color: white;
+  font-family: var(--font-great-vibes), cursive;
+  font-size: 18px;
+  line-height: 1;
+  padding-bottom: 2px;
+}
+.ss-org-pill .ss-org-tag {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ss-text-muted);
+  letter-spacing: 0.04em;
+}
+
+.ss-search {
+  flex: 1;
+  max-width: 380px;
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel-strong);
+  color: var(--ss-text-secondary);
+  font-size: 13px;
+}
+.ss-search input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--ss-text-primary);
+  font: inherit;
+  font-family: var(--font-quicksand), sans-serif;
+}
+.ss-search input::placeholder { color: var(--ss-text-muted); }
+
+.ss-topbar-spacer { flex: 1; }
+
+.ss-icon-btn {
+  width: 38px; height: 38px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel-strong);
+  color: var(--ss-text-secondary);
+  cursor: pointer;
+  transition: color 180ms ease, background 180ms ease, transform 120ms ease;
+  position: relative;
+}
+.ss-icon-btn:hover { color: var(--ss-magenta); background: var(--ss-magenta-pale); }
+.ss-icon-btn:active { transform: scale(0.96); }
+.ss-icon-btn .ss-dot {
+  position: absolute; top: 6px; right: 8px;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--ss-magenta);
+  box-shadow: 0 0 10px var(--ss-magenta);
+}
+
+.ss-content {
+  padding: 28px 36px 60px;
+  max-width: 1280px;
+  width: 100%;
+}
+
+/* ============= PAGE HEADER ============= */
+.ss-page-head {
+  display: flex; flex-direction: column;
+  gap: 6px;
+  margin-bottom: 22px;
+}
+.ss-page-eyebrow {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--ss-cyan-deep);
+}
+.theme-twilight .ss-page-eyebrow { color: var(--ss-cyan); }
+.ss-page-title {
+  font-family: var(--font-cormorant), "Georgia", serif;
+  font-size: 38px;
+  line-height: 1.05;
+  color: var(--ss-text-heading);
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+}
+.ss-page-title .ss-script {
+  font-family: var(--font-great-vibes), cursive;
+  font-weight: 400;
+  color: var(--ss-magenta);
+  font-size: 1.15em;
+  margin-right: 0.08em;
+  vertical-align: -0.04em;
+}
+.ss-page-sub {
+  font-size: 14px;
+  color: var(--ss-text-secondary);
+  margin: 0;
+  max-width: 64ch;
+}
+
+/* ============= ORNAMENTAL DIVIDER ============= */
+.ss-divider {
+  display: flex; align-items: center; gap: 14px;
+  margin: 18px 0 14px;
+  color: var(--ss-line-strong);
+}
+.ss-divider-line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--ss-line-strong), transparent);
+}
+.ss-divider-mark {
+  display: inline-flex;
+  color: var(--ss-magenta);
+}
+.ss-divider-label {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+}
+
+/* ============= CARDS ============= */
+.ss-card {
+  position: relative;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 20px;
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  padding: 22px;
+  overflow: hidden;
+}
+.ss-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 0%, rgba(30, 195, 217, 0.06), transparent 60%);
+}
+
+.ss-card-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 12px; margin-bottom: 14px;
+  position: relative;
+}
+.ss-card-title {
+  font-family: var(--font-cormorant), serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 0;
+  letter-spacing: 0.005em;
+}
+.ss-card-meta {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+}
+
+/* ============= STATS ============= */
+.ss-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-bottom: 22px;
+}
+.ss-stat {
+  position: relative;
+  padding: 22px 24px 20px;
+  border-radius: 20px;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  overflow: hidden;
+}
+.ss-stat::before {
+  content: "";
+  position: absolute;
+  top: 0; right: 0;
+  width: 90px; height: 90px;
+  border-radius: 50%;
+  filter: blur(34px);
+  opacity: 0.45;
+  pointer-events: none;
+}
+.ss-stat.is-magenta::before { background: var(--ss-magenta); }
+.ss-stat.is-cyan::before { background: var(--ss-cyan); }
+.ss-stat.is-violet::before { background: var(--ss-violet); }
+
+.ss-stat-eyebrow {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--ss-text-muted);
+  margin-bottom: 14px;
+}
+.ss-stat-eyebrow svg { color: var(--ss-magenta); }
+.ss-stat.is-cyan .ss-stat-eyebrow svg { color: var(--ss-cyan-deep); }
+.theme-twilight .ss-stat.is-cyan .ss-stat-eyebrow svg { color: var(--ss-cyan); }
+.ss-stat.is-violet .ss-stat-eyebrow svg { color: var(--ss-violet); }
+
+.ss-stat-value {
+  font-family: var(--font-cormorant), serif;
+  font-size: 48px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1;
+  letter-spacing: -0.005em;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.ss-stat-value .ss-script-num {
+  font-family: var(--font-great-vibes), cursive;
+  font-size: 32px;
+  color: var(--ss-magenta);
+  font-weight: 400;
+  margin-right: 2px;
+  line-height: 1;
+}
+.ss-stat-value .ss-unit {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ss-text-muted);
+  letter-spacing: 0.06em;
+}
+.ss-stat-foot {
+  margin-top: 12px;
+  font-size: 12.5px;
+  color: var(--ss-text-secondary);
+  display: flex; align-items: center; gap: 6px;
+}
+.ss-stat-foot .ss-trend-up { color: var(--ss-cyan-deep); font-weight: 600; }
+.theme-twilight .ss-stat-foot .ss-trend-up { color: var(--ss-cyan); }
+
+/* ============= TIMELINE / SCHEDULE LIST ============= */
+.ss-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 20px;
+}
+@media (max-width: 1100px) {
+  .ss-grid { grid-template-columns: 1fr; }
+}
+
+.ss-timeline {
+  display: flex; flex-direction: column;
+  gap: 0;
+}
+.ss-timeline-row {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 16px;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--ss-line);
+  align-items: stretch;
+  position: relative;
+}
+.ss-timeline-row:last-child { border-bottom: 0; }
+
+.ss-timeline-time {
+  display: flex; flex-direction: column; align-items: flex-end;
+  padding-top: 4px;
+}
+.ss-timeline-time .ss-time-h {
+  font-family: var(--font-cormorant), serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1;
+}
+.ss-timeline-time .ss-time-m {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  color: var(--ss-text-muted);
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+
+.ss-appt {
+  display: flex; align-items: stretch; gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  box-shadow: var(--ss-shadow-sm);
+  position: relative;
+  overflow: hidden;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+.ss-appt:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--ss-shadow-md);
+}
+.ss-appt::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  background: linear-gradient(180deg, var(--ss-magenta), var(--ss-cyan));
+}
+.ss-appt.is-cyan::before { background: linear-gradient(180deg, var(--ss-cyan), var(--ss-cyan-deep)); }
+.ss-appt.is-violet::before { background: linear-gradient(180deg, var(--ss-violet), var(--ss-magenta)); }
+.ss-appt.is-gold::before { background: linear-gradient(180deg, var(--ss-gold), var(--ss-magenta-deep)); }
+
+.ss-appt-avatar {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ss-magenta-pale), var(--ss-cyan-pale));
+  border: 1px solid var(--ss-panel-edge);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-cormorant), serif;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ss-magenta-deep);
+  flex-shrink: 0;
+  margin-left: 6px;
+}
+.theme-twilight .ss-appt-avatar { color: var(--ss-magenta); }
+
+.ss-appt-body { flex: 1; min-width: 0; }
+.ss-appt-row1 {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 12px;
+}
+.ss-appt-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.2;
+}
+.ss-appt-dur {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 11px;
+  color: var(--ss-text-muted);
+  letter-spacing: 0.06em;
+}
+.ss-appt-row2 {
+  margin-top: 2px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12.5px;
+  color: var(--ss-text-secondary);
+}
+.ss-appt-service { color: var(--ss-magenta-deep); font-weight: 600; }
+.theme-twilight .ss-appt-service { color: var(--ss-magenta); }
+.ss-appt-stylist { color: var(--ss-text-secondary); }
+.ss-appt-divider {
+  width: 3px; height: 3px; border-radius: 50%;
+  background: var(--ss-text-muted);
+  display: inline-block;
+}
+
+.ss-status-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.ss-status-pill.is-confirmed { background: var(--ss-cyan-pale); color: var(--ss-cyan-deep); }
+.ss-status-pill.is-checked { background: rgba(125, 200, 130, 0.18); color: #4f8a52; }
+.theme-twilight .ss-status-pill.is-checked { background: rgba(125, 200, 130, 0.22); color: #9bd49d; }
+.ss-status-pill.is-pending { background: rgba(200, 155, 58, 0.18); color: #9c742a; }
+.theme-twilight .ss-status-pill.is-pending { background: rgba(230, 196, 119, 0.18); color: var(--ss-gold); }
+.ss-status-pill.is-progress { background: var(--ss-magenta-pale); color: var(--ss-magenta-deep); }
+.theme-twilight .ss-status-pill.is-progress { background: rgba(30, 195, 217, 0.20); color: var(--ss-magenta); }
+.ss-status-pill::before {
+  content: "";
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* ============= QUICK ACTIONS / SIDE PANELS ============= */
+.ss-side-block + .ss-side-block { margin-top: 18px; }
+
+.ss-quick-actions {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.ss-action {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 14px;
+  border-radius: 14px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+}
+.ss-action:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--ss-shadow-sm), var(--ss-glow);
+}
+.ss-action-icon {
+  width: 30px; height: 30px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--ss-magenta-pale), var(--ss-cyan-pale));
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ss-magenta-deep);
+}
+.theme-twilight .ss-action-icon { color: var(--ss-magenta); }
+.ss-action-title {
+  font-family: var(--font-cormorant), serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-action-sub {
+  font-size: 11.5px;
+  color: var(--ss-text-muted);
+}
+
+/* messages preview */
+.ss-msg {
+  display: flex; gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px dashed var(--ss-line);
+}
+.ss-msg:last-child { border-bottom: 0; }
+.ss-msg-avatar {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-violet));
+  display: flex; align-items: center; justify-content: center;
+  color: white;
+  font-family: var(--font-cormorant), serif;
+  font-size: 14px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.ss-msg-body { flex: 1; min-width: 0; }
+.ss-msg-row1 { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
+.ss-msg-name { font-family: var(--font-cormorant), serif; font-size: 15px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-msg-time { font-size: 11px; color: var(--ss-text-muted); }
+.ss-msg-text { font-size: 12.5px; color: var(--ss-text-secondary); margin-top: 2px; line-height: 1.45; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.ss-msg-text em { color: var(--ss-magenta-deep); font-style: italic; }
+.theme-twilight .ss-msg-text em { color: var(--ss-magenta); }
+
+/* ============= STAFF/CHAIR STRIP ============= */
+.ss-chair-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.ss-chair {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 14px;
+  border-radius: 14px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+}
+.ss-chair-head {
+  display: flex; align-items: center; gap: 10px;
+}
+.ss-chair-avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  color: white;
+  font-family: var(--font-cormorant), serif;
+  font-weight: 600;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.ss-chair-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.1;
+}
+.ss-chair-role { font-size: 11px; color: var(--ss-text-muted); letter-spacing: 0.04em; }
+.ss-chair-bar {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--ss-magenta-pale);
+  overflow: hidden;
+  margin-top: 4px;
+  position: relative;
+}
+.ss-chair-bar-fill {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--ss-magenta), var(--ss-cyan));
+}
+.ss-chair-stat {
+  display: flex; justify-content: space-between;
+  font-size: 11.5px;
+  color: var(--ss-text-secondary);
+}
+.ss-chair-stat strong { color: var(--ss-text-heading); font-weight: 600; }
+
+/* ============= CALENDAR (SCHEDULE PAGE) ============= */
+.ss-cal {
+  display: grid;
+  grid-template-columns: 56px repeat(4, 1fr);
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+}
+.ss-cal-h {
+  padding: 14px 12px;
+  border-bottom: 1px solid var(--ss-line);
+  display: flex; align-items: center; gap: 10px;
+  background: var(--ss-magenta-pale);
+  position: relative;
+}
+.ss-cal-h::before {
+  content: "";
+  position: absolute; left: 0; right: 0; top: 0;
+  height: 4px;
+  background: var(--ss-staff-grad, var(--ss-magenta));
+}
+.theme-twilight .ss-cal-h { background: rgba(30, 195, 217, 0.10); }
+.ss-cal-h.is-corner { background: transparent; border-right: 1px solid var(--ss-line); }
+.ss-cal-h.is-corner::before { display: none; }
+.ss-cal-h-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.1;
+}
+.ss-cal-h-role { font-size: 10.5px; color: var(--ss-text-muted); letter-spacing: 0.06em; }
+.ss-cal-time {
+  padding: 0 8px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ss-text-muted);
+  letter-spacing: 0.12em;
+  border-right: 1px solid var(--ss-line);
+  text-align: right;
+  display: flex; justify-content: flex-end;
+  align-items: flex-start;
+  padding-top: 2px;
+  height: 14px;
+  line-height: 1;
+}
+.ss-cal-time.is-hour {
+  border-top: 1px solid var(--ss-line);
+  color: var(--ss-text-secondary);
+  font-size: 11.5px;
+}
+.ss-cal-cell {
+  border-right: 1px solid var(--ss-line);
+  height: 14px;
+  position: relative;
+  padding: 1px 3px;
+}
+.ss-cal-cell.is-hour    { border-top: 1px solid var(--ss-line); }
+.ss-cal-cell.is-half    { border-top: 1px dotted var(--ss-line); }
+.ss-cal-cell.is-quarter { border-top: 1px dotted rgba(0,0,0,0); }
+.theme-twilight .ss-cal-cell.is-half { border-top-color: rgba(30, 195, 217, 0.18); }
+.ss-cal-cell:last-child, .ss-cal-h:last-child { border-right: 0; }
+
+.ss-cal-block {
+  position: absolute;
+  left: 4px; right: 4px;
+  z-index: 2;
+  border-radius: 6px;
+  padding: 3px 7px 3px 9px;
+  background: linear-gradient(135deg, rgba(30, 195, 217, 0.16), rgba(30, 195, 217, 0.08));
+  border: 1px solid rgba(30, 195, 217, 0.32);
+  border-left: 3px solid var(--ss-magenta);
+  box-shadow: var(--ss-shadow-sm);
+  overflow: hidden;
+  display: flex; flex-direction: column; gap: 0px;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+.theme-twilight .ss-cal-block {
+  background: linear-gradient(135deg, rgba(30, 195, 217, 0.30), rgba(30, 195, 217, 0.18));
+  border-color: rgba(30, 195, 217, 0.50);
+}
+.ss-cal-block:hover { transform: scale(1.01); box-shadow: var(--ss-shadow-md), var(--ss-glow); }
+
+/* ---- service color coding ---- */
+/* COLOR services: magenta/pink */
+.ss-cal-block.is-color {
+  background: linear-gradient(135deg, rgba(233, 30, 158, 0.18), rgba(233, 30, 158, 0.08));
+  border-color: rgba(233, 30, 158, 0.36);
+  border-left-color: #e91e9e;
+}
+.theme-twilight .ss-cal-block.is-color {
+  background: linear-gradient(135deg, rgba(233, 30, 158, 0.32), rgba(233, 30, 158, 0.16));
+  border-color: rgba(233, 30, 158, 0.50);
+  border-left-color: #ff48b9;
+}
+.ss-cal-block.is-color .ss-cal-block-svc { color: var(--ss-cyan-deep); }
+.theme-twilight .ss-cal-block.is-color .ss-cal-block-svc { color: var(--ss-cyan); }
+
+/* CUTS: cyan/teal */
+.ss-cal-block.is-cut {
+  background: linear-gradient(135deg, rgba(30, 195, 217, 0.20), rgba(30, 195, 217, 0.08));
+  border-color: rgba(30, 195, 217, 0.36);
+  border-left-color: var(--ss-magenta-deep);
+}
+.theme-twilight .ss-cal-block.is-cut {
+  background: linear-gradient(135deg, rgba(30, 195, 217, 0.32), rgba(30, 195, 217, 0.14));
+  border-color: rgba(30, 195, 217, 0.50);
+  border-left-color: var(--ss-magenta);
+}
+
+/* STYLING: peach/coral */
+.ss-cal-block.is-styling {
+  background: linear-gradient(135deg, rgba(232, 130, 120, 0.20), rgba(232, 130, 120, 0.08));
+  border-color: rgba(232, 130, 120, 0.36);
+  border-left-color: #d96b5e;
+}
+.theme-twilight .ss-cal-block.is-styling {
+  background: linear-gradient(135deg, rgba(245, 158, 138, 0.30), rgba(245, 158, 138, 0.12));
+  border-color: rgba(245, 158, 138, 0.46);
+  border-left-color: #f59e8a;
+}
+.ss-cal-block.is-styling .ss-cal-block-svc { color: #b04d40; }
+.theme-twilight .ss-cal-block.is-styling .ss-cal-block-svc { color: #f59e8a; }
+
+/* TREATMENTS: violet/blue */
+.ss-cal-block.is-treat {
+  background: linear-gradient(135deg, rgba(74, 130, 179, 0.20), rgba(74, 130, 179, 0.08));
+  border-color: rgba(74, 130, 179, 0.36);
+  border-left-color: var(--ss-violet);
+}
+.theme-twilight .ss-cal-block.is-treat {
+  background: linear-gradient(135deg, rgba(111, 166, 204, 0.30), rgba(111, 166, 204, 0.14));
+  border-color: rgba(111, 166, 204, 0.46);
+  border-left-color: var(--ss-violet);
+}
+
+/* BRIDAL & special: gold */
+.ss-cal-block.is-bridal {
+  background: linear-gradient(135deg, rgba(200, 155, 58, 0.22), rgba(200, 155, 58, 0.08));
+  border-color: rgba(200, 155, 58, 0.40);
+  border-left-color: var(--ss-gold);
+}
+.theme-twilight .ss-cal-block.is-bridal {
+  background: linear-gradient(135deg, rgba(230, 196, 119, 0.30), rgba(230, 196, 119, 0.12));
+  border-color: rgba(230, 196, 119, 0.46);
+  border-left-color: var(--ss-gold);
+}
+.ss-cal-block.is-bridal .ss-cal-block-svc { color: #9c742a; font-weight: 600; }
+.theme-twilight .ss-cal-block.is-bridal .ss-cal-block-svc { color: var(--ss-gold); }
+
+/* BLOCK / open chair: muted slate */
+.ss-cal-block.is-block {
+  background: repeating-linear-gradient(135deg,
+    rgba(122, 163, 173, 0.14) 0,
+    rgba(122, 163, 173, 0.14) 6px,
+    rgba(122, 163, 173, 0.06) 6px,
+    rgba(122, 163, 173, 0.06) 12px);
+  border-color: rgba(122, 163, 173, 0.34);
+  border-left-color: #7aa3ad;
+  box-shadow: none;
+}
+.theme-twilight .ss-cal-block.is-block {
+  background: repeating-linear-gradient(135deg,
+    rgba(168, 200, 208, 0.14) 0,
+    rgba(168, 200, 208, 0.14) 6px,
+    rgba(168, 200, 208, 0.04) 6px,
+    rgba(168, 200, 208, 0.04) 12px);
+  border-color: rgba(168, 200, 208, 0.30);
+  border-left-color: var(--ss-text-muted);
+}
+.ss-cal-block.is-block .ss-cal-block-name,
+.ss-cal-block.is-block .ss-cal-block-svc { color: var(--ss-text-muted); font-style: italic; }
+
+/* ---- legend ---- */
+.ss-cal-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 22px;
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  font-size: 11px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ss-text-secondary);
+}
+.ss-cal-legend-item { display: inline-flex; align-items: center; gap: 7px; }
+.ss-cal-legend-swatch {
+  width: 10px; height: 10px; border-radius: 3px; flex-shrink: 0;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.06) inset;
+}
+.ss-cal-legend-swatch.is-color   { background: linear-gradient(135deg, #e91e9e, #ff48b9); }
+.ss-cal-legend-swatch.is-cut     { background: linear-gradient(135deg, #1ec3d9, #0892a8); }
+.ss-cal-legend-swatch.is-styling { background: linear-gradient(135deg, #d96b5e, #f59e8a); }
+.ss-cal-legend-swatch.is-treat   { background: linear-gradient(135deg, #4a82b3, #6fa6cc); }
+.ss-cal-legend-swatch.is-bridal  { background: linear-gradient(135deg, #c89b3a, #e6c477); }
+.ss-cal-legend-swatch.is-block   { background: repeating-linear-gradient(135deg, #7aa3ad 0 3px, transparent 3px 6px), #c8d4d8; }
+.ss-cal-block-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ss-cal-block-svc {
+  font-size: 11px;
+  color: var(--ss-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ============= BUTTONS ============= */
+.ss-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel-strong);
+  color: var(--ss-text-primary);
+  transition: transform 120ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+.ss-btn:hover { box-shadow: var(--ss-shadow-sm); }
+.ss-btn:active { transform: scale(0.98); }
+.ss-btn-primary {
+  background: linear-gradient(94deg, var(--ss-magenta), var(--ss-magenta-deep));
+  color: white;
+  border-color: transparent;
+  box-shadow: 0 6px 18px rgba(30, 195, 217, 0.32);
+}
+.ss-btn-primary:hover {
+  box-shadow: 0 10px 26px rgba(30, 195, 217, 0.42), var(--ss-glow);
+}
+.ss-btn-ghost {
+  background: transparent;
+  border: 1px solid var(--ss-line);
+}
+
+/* ============= CLIENTS LIST ============= */
+.ss-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+.ss-table thead th {
+  text-align: left;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--ss-line);
+}
+.ss-table tbody tr {
+  transition: background 180ms ease;
+}
+.ss-table tbody tr:hover {
+  background: var(--ss-magenta-pale);
+}
+.ss-table td {
+  padding: 14px 12px;
+  border-bottom: 1px dashed var(--ss-line);
+  color: var(--ss-text-primary);
+  vertical-align: middle;
+}
+.ss-table td:first-child { display: flex; align-items: center; gap: 10px; }
+.ss-table .ss-client-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-table .ss-client-mute { color: var(--ss-text-muted); font-size: 12px; }
+.ss-tag {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+}
+.ss-tag.is-vip { background: linear-gradient(94deg, rgba(200, 155, 58, 0.22), rgba(30, 195, 217, 0.18)); color: var(--ss-magenta-deep); }
+.theme-twilight .ss-tag.is-vip { color: var(--ss-gold); }
+.ss-tag.is-new { background: var(--ss-cyan-pale); color: var(--ss-cyan-deep); }
+.theme-twilight .ss-tag.is-new { color: var(--ss-cyan); }
+.ss-tag.is-regular { background: var(--ss-magenta-pale); color: var(--ss-magenta-deep); }
+.theme-twilight .ss-tag.is-regular { color: var(--ss-magenta); }
+
+/* ============= ARTBOARD WRAPPER ============= */
+.artboard-frame {
+  width: 1280px;
+  height: 880px;
+  border-radius: 22px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px rgba(60, 18, 50, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+/* ============= SIGN-IN ============= */
+.ss-signin {
+  width: 100%; height: 100%;
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  background: var(--ss-bg-page);
+  font-family: var(--font-quicksand), sans-serif;
+  color: var(--ss-text-primary);
+  overflow: hidden;
+  isolation: isolate;
+}
+.ss-signin::before {
+  content: "";
+  position: absolute; inset: 0;
+  background: var(--ss-bg-blanket);
+  z-index: 0; pointer-events: none;
+}
+.ss-signin-hero {
+  flex: 1.15;
+  position: relative;
+  z-index: 1;
+  padding: 72px 72px 60px;
+  display: flex; flex-direction: column;
+  justify-content: space-between;
+}
+.ss-signin-hero::after {
+  content: "";
+  position: absolute;
+  right: -120px; top: 30%;
+  width: 480px; height: 480px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--ss-magenta), transparent 65%);
+  filter: blur(80px);
+  opacity: 0.32;
+  z-index: 0;
+}
+.theme-light .ss-signin-hero::after { opacity: 0.18; mix-blend-mode: multiply; }
+.ss-signin-hero > * { position: relative; z-index: 1; }
+
+.ss-signin-mark {
+  display: flex; align-items: baseline; gap: 8px;
+}
+.ss-signin-mark .ss-script-big {
+  font-family: var(--font-great-vibes), cursive;
+  font-size: 64px;
+  line-height: 0.9;
+  color: var(--ss-magenta);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.5);
+}
+.theme-twilight .ss-signin-mark .ss-script-big { text-shadow: 0 0 24px rgba(30, 195, 217, 0.5); }
+.ss-signin-mark .ss-mark-sub {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.36em;
+  text-transform: uppercase;
+  color: var(--ss-cyan-deep);
+  padding-bottom: 8px;
+}
+.theme-twilight .ss-signin-mark .ss-mark-sub { color: var(--ss-cyan); }
+
+.ss-signin-pitch {
+  max-width: 520px;
+}
+.ss-signin-pitch .ss-pitch-eyebrow {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin-bottom: 14px;
+}
+.ss-signin-pitch h2 {
+  font-family: var(--font-cormorant), serif;
+  font-size: 64px;
+  font-weight: 600;
+  line-height: 1.04;
+  color: var(--ss-text-heading);
+  margin: 0 0 16px;
+  letter-spacing: 0.005em;
+}
+.ss-signin-pitch h2 .ss-script {
+  font-family: var(--font-great-vibes), cursive;
+  color: var(--ss-magenta);
+  font-weight: 400;
+  font-size: 1.2em;
+  margin-right: 0.06em;
+  vertical-align: -0.04em;
+}
+.ss-signin-pitch p {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ss-text-secondary);
+  margin: 0;
+  max-width: 44ch;
+}
+
+.ss-signin-foot-row {
+  display: flex; gap: 24px; align-items: center;
+  font-size: 12px;
+  color: var(--ss-text-muted);
+  letter-spacing: 0.06em;
+}
+.ss-signin-foot-row .ss-foot-mark {
+  color: var(--ss-magenta);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+
+.ss-signin-card {
+  flex: 1;
+  z-index: 1;
+  display: flex; align-items: center; justify-content: center;
+  padding: 40px;
+}
+.ss-signin-form {
+  width: 100%; max-width: 420px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 24px;
+  padding: 36px 36px 30px;
+  box-shadow: var(--ss-shadow-lg), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  position: relative;
+}
+.ss-signin-form::before {
+  content: "";
+  position: absolute;
+  top: -1px; left: 24px; right: 24px;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--ss-magenta), var(--ss-cyan), transparent);
+  border-radius: 2px;
+  opacity: 0.7;
+}
+.ss-signin-title {
+  font-family: var(--font-cormorant), serif;
+  font-size: 30px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 0 0 6px;
+}
+.ss-signin-sub {
+  font-size: 13.5px;
+  color: var(--ss-text-muted);
+  margin: 0 0 22px;
+}
+
+.ss-field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
+.ss-field label {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+}
+.ss-input {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: var(--ss-bg-page);
+  border: 1px solid var(--ss-line);
+  transition: border 180ms ease, box-shadow 180ms ease;
+}
+.theme-twilight .ss-input { background: rgba(0,0,0,0.18); }
+.ss-input:focus-within {
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 4px rgba(30, 195, 217, 0.12);
+}
+.ss-input input {
+  flex: 1; border: 0; outline: 0; background: transparent;
+  font: inherit;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 14px;
+  color: var(--ss-text-primary);
+}
+.ss-input input::placeholder { color: var(--ss-text-muted); }
+.ss-input svg { color: var(--ss-text-muted); }
+
+.ss-form-meta {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 12.5px;
+  color: var(--ss-text-secondary);
+  margin: 4px 0 18px;
+}
+.ss-form-meta a { color: var(--ss-magenta-deep); text-decoration: none; font-weight: 600; }
+.theme-twilight .ss-form-meta a { color: var(--ss-magenta); }
+
+.ss-checkbox {
+  display: flex; align-items: center; gap: 8px;
+  cursor: pointer;
+}
+.ss-checkbox-box {
+  width: 16px; height: 16px;
+  border-radius: 5px;
+  border: 1.5px solid var(--ss-line-strong);
+  background: var(--ss-panel-strong);
+  display: flex; align-items: center; justify-content: center;
+}
+.ss-checkbox-box.is-on {
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-cyan));
+  border-color: transparent;
+}
+
+.ss-btn-block { width: 100%; justify-content: center; padding: 13px 18px; font-size: 14px; }
+
+.ss-divider-or {
+  display: flex; align-items: center; gap: 12px;
+  margin: 20px 0;
+  color: var(--ss-text-muted);
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+.ss-divider-or::before, .ss-divider-or::after {
+  content: ""; flex: 1; height: 1px;
+  background: linear-gradient(90deg, transparent, var(--ss-line-strong), transparent);
+}
+
+.ss-oauth-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+
+.ss-form-foot {
+  text-align: center;
+  font-size: 12.5px;
+  color: var(--ss-text-muted);
+  margin-top: 18px;
+}
+.ss-form-foot a { color: var(--ss-magenta-deep); text-decoration: none; font-weight: 600; }
+.theme-twilight .ss-form-foot a { color: var(--ss-magenta); }
+
+/* ============= SETTINGS ============= */
+.ss-settings-grid {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 28px;
+}
+.ss-settings-nav {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 2px;
+  position: sticky; top: 80px;
+}
+.ss-settings-nav li {
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 13.5px;
+  color: var(--ss-text-secondary);
+  cursor: pointer;
+}
+.ss-settings-nav li.is-active {
+  background: var(--ss-magenta-pale);
+  color: var(--ss-magenta-deep);
+  font-weight: 600;
+}
+.theme-twilight .ss-settings-nav li.is-active { color: var(--ss-magenta); }
+
+.ss-settings-section {
+  display: flex; flex-direction: column; gap: 18px;
+}
+.ss-form-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 14px 18px;
+}
+.ss-form-grid .ss-field { margin: 0; }
+.ss-form-grid .ss-full { grid-column: 1 / -1; }
+
+.ss-toggle {
+  width: 38px; height: 22px;
+  border-radius: 999px;
+  background: var(--ss-line-strong);
+  position: relative;
+  cursor: pointer;
+  transition: background 180ms ease;
+  flex-shrink: 0;
+}
+.ss-toggle::after {
+  content: "";
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 180ms ease;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+}
+.ss-toggle.is-on {
+  background: linear-gradient(94deg, var(--ss-magenta), var(--ss-cyan));
+}
+.ss-toggle.is-on::after { transform: translateX(16px); }
+
+.ss-toggle-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--ss-line);
+}
+.ss-toggle-row:last-child { border-bottom: 0; }
+.ss-toggle-meta { display: flex; flex-direction: column; gap: 2px; }
+.ss-toggle-title { font-family: var(--font-cormorant), serif; font-size: 16px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-toggle-sub { font-size: 12.5px; color: var(--ss-text-muted); }
+
+/* ============= SERVICES ============= */
+.ss-svc-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.ss-svc {
+  position: relative;
+  padding: 20px;
+  border-radius: 18px;
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  display: flex; flex-direction: column; gap: 10px;
+  overflow: hidden;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+.ss-svc:hover { transform: translateY(-2px); box-shadow: var(--ss-shadow-md), var(--ss-glow); }
+.ss-svc::before {
+  content: "";
+  position: absolute;
+  top: 0; right: 0;
+  width: 120px; height: 120px;
+  border-radius: 50%;
+  filter: blur(40px);
+  opacity: 0.3;
+  pointer-events: none;
+}
+.ss-svc.is-color::before { background: var(--ss-magenta); }
+.ss-svc.is-cut::before { background: var(--ss-cyan); }
+.ss-svc.is-treat::before { background: var(--ss-violet); }
+.ss-svc.is-bridal::before { background: var(--ss-gold); }
+
+.ss-svc-cat {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-magenta-deep);
+}
+.theme-twilight .ss-svc-cat { color: var(--ss-magenta); }
+.ss-svc.is-cut .ss-svc-cat { color: var(--ss-cyan-deep); }
+.theme-twilight .ss-svc.is-cut .ss-svc-cat { color: var(--ss-cyan); }
+.ss-svc.is-treat .ss-svc-cat { color: var(--ss-violet); }
+.ss-svc.is-bridal .ss-svc-cat { color: var(--ss-gold); }
+
+.ss-svc-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  line-height: 1.1;
+  margin: 0;
+}
+.ss-svc-desc {
+  font-size: 13px;
+  color: var(--ss-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+.ss-svc-foot {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px dashed var(--ss-line);
+}
+.ss-svc-price {
+  font-family: var(--font-cormorant), serif;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-svc-price .ss-script-num {
+  font-family: var(--font-great-vibes), cursive;
+  font-size: 22px;
+  color: var(--ss-magenta);
+  font-weight: 400;
+  margin-right: 1px;
+  vertical-align: -0.04em;
+}
+.ss-svc-dur { font-size: 12px; color: var(--ss-text-muted); }
+
+.ss-svc-cat-head {
+  display: flex; align-items: baseline; gap: 12px;
+  margin: 22px 0 12px;
+}
+.ss-svc-cat-head h3 {
+  font-family: var(--font-cormorant), serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 0;
+}
+.ss-svc-cat-head h3 .ss-script {
+  font-family: var(--font-great-vibes), cursive;
+  color: var(--ss-magenta);
+  font-weight: 400;
+  font-size: 1.2em;
+  margin-right: 4px;
+  vertical-align: -0.04em;
+}
+.ss-svc-cat-head .ss-cat-count { color: var(--ss-text-muted); font-size: 12px; }
+.ss-svc-cat-head .ss-cat-line {
+  flex: 1; height: 1px;
+  background: linear-gradient(90deg, var(--ss-line-strong), transparent);
+}
+
+/* ============= MESSAGE THREAD ============= */
+.ss-thread-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 18px;
+  height: calc(100% - 40px);
+}
+.ss-thread-list {
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 18px;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  display: flex; flex-direction: column;
+}
+.ss-thread-search {
+  padding: 14px;
+  border-bottom: 1px solid var(--ss-line);
+}
+.ss-thread-list-body {
+  flex: 1;
+  overflow-y: auto;
+}
+.ss-thread-item {
+  display: flex; gap: 10px;
+  padding: 14px;
+  border-bottom: 1px dashed var(--ss-line);
+  cursor: pointer;
+  transition: background 180ms ease;
+}
+.ss-thread-item:hover { background: var(--ss-magenta-pale); }
+.ss-thread-item.is-active {
+  background: linear-gradient(94deg, var(--ss-magenta-pale), var(--ss-cyan-pale));
+  border-left: 3px solid var(--ss-magenta);
+  padding-left: 11px;
+}
+.ss-thread-meta { flex: 1; min-width: 0; }
+.ss-thread-row1 { display: flex; justify-content: space-between; align-items: baseline; }
+.ss-thread-name { font-family: var(--font-cormorant), serif; font-size: 15.5px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-thread-time { font-size: 10.5px; color: var(--ss-text-muted); }
+.ss-thread-preview { font-size: 12px; color: var(--ss-text-secondary); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ss-thread-unread {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--ss-magenta);
+  margin-top: 14px;
+  flex-shrink: 0;
+}
+
+.ss-thread-pane {
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 18px;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  display: flex; flex-direction: column;
+}
+.ss-thread-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--ss-line);
+  background: linear-gradient(94deg, var(--ss-magenta-pale), transparent);
+}
+.theme-twilight .ss-thread-head { background: linear-gradient(94deg, rgba(30, 195, 217, 0.12), transparent); }
+.ss-thread-head-meta { flex: 1; }
+.ss-thread-head-name { font-family: var(--font-cormorant), serif; font-size: 20px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-thread-head-sub { font-size: 12px; color: var(--ss-text-muted); margin-top: 2px; }
+
+.ss-thread-body {
+  flex: 1;
+  padding: 22px;
+  overflow-y: auto;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.ss-day-divider {
+  display: flex; align-items: center; gap: 12px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin: 8px 0;
+}
+.ss-day-divider::before, .ss-day-divider::after {
+  content: ""; flex: 1; height: 1px;
+  background: linear-gradient(90deg, transparent, var(--ss-line), transparent);
+}
+.ss-bubble {
+  max-width: 70%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  position: relative;
+  box-shadow: var(--ss-shadow-sm);
+}
+.ss-bubble.is-them {
+  align-self: flex-start;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  color: var(--ss-text-primary);
+  border-bottom-left-radius: 4px;
+}
+.ss-bubble.is-us {
+  align-self: flex-end;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-magenta-deep));
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+.ss-bubble.is-system {
+  align-self: center;
+  background: var(--ss-cyan-pale);
+  color: var(--ss-cyan-deep);
+  border: 1px dashed var(--ss-cyan-deep);
+  font-size: 12px;
+  font-style: italic;
+  max-width: 60%;
+  text-align: center;
+}
+.theme-twilight .ss-bubble.is-system { color: var(--ss-cyan); border-color: var(--ss-cyan); }
+.ss-bubble-time {
+  display: block;
+  margin-top: 4px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  opacity: 0.7;
+}
+
+.ss-thread-compose {
+  padding: 14px 18px;
+  border-top: 1px solid var(--ss-line);
+  display: flex; gap: 10px;
+  align-items: center;
+}
+.ss-thread-compose .ss-input {
+  flex: 1;
+  border-radius: 999px;
+  padding: 10px 18px;
+}
+
+/* ============= CLIENT PROFILE ============= */
+.ss-profile-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 22px;
+}
+.ss-profile-side {
+  display: flex; flex-direction: column; gap: 18px;
+}
+.ss-profile-card {
+  background: var(--ss-panel);
+  border: 1px solid var(--ss-panel-border);
+  border-radius: 20px;
+  padding: 28px 24px;
+  text-align: center;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: var(--ss-shadow-sm), inset 0 1px 0 var(--ss-panel-edge);
+  position: relative;
+  overflow: hidden;
+}
+.ss-profile-card::before {
+  content: "";
+  position: absolute;
+  top: -40px; left: 50%;
+  transform: translateX(-50%);
+  width: 220px; height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--ss-magenta), transparent 65%);
+  filter: blur(50px);
+  opacity: 0.32;
+  pointer-events: none;
+}
+.theme-light .ss-profile-card::before { opacity: 0.18; }
+.ss-profile-card > * { position: relative; }
+
+.ss-profile-avatar {
+  width: 96px; height: 96px;
+  border-radius: 50%;
+  margin: 0 auto 14px;
+  background: linear-gradient(135deg, var(--ss-magenta), var(--ss-violet));
+  display: flex; align-items: center; justify-content: center;
+  color: white;
+  font-family: var(--font-cormorant), serif;
+  font-size: 36px;
+  font-weight: 600;
+  box-shadow: 0 6px 20px rgba(30, 195, 217, 0.32);
+  border: 3px solid var(--ss-panel-edge);
+}
+.ss-profile-name {
+  font-family: var(--font-cormorant), serif;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 0 0 4px;
+}
+.ss-profile-sub {
+  font-size: 12.5px;
+  color: var(--ss-text-muted);
+  letter-spacing: 0.06em;
+}
+.ss-profile-tags {
+  display: flex; gap: 6px; justify-content: center; margin: 14px 0 4px;
+}
+.ss-profile-quick {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-top: 18px;
+}
+.ss-profile-quick-stat {
+  text-align: center;
+  padding: 10px 4px;
+  border-radius: 10px;
+  background: var(--ss-magenta-pale);
+}
+.theme-twilight .ss-profile-quick-stat { background: rgba(30, 195, 217, 0.12); }
+.ss-profile-quick-stat .ss-pq-val {
+  font-family: var(--font-cormorant), serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  display: block;
+  line-height: 1;
+}
+.ss-profile-quick-stat .ss-pq-lbl {
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin-top: 4px;
+  display: block;
+}
+
+.ss-profile-detail {
+  font-size: 13px;
+  color: var(--ss-text-secondary);
+  display: flex; flex-direction: column; gap: 12px;
+  text-align: left;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--ss-line);
+}
+.ss-profile-detail .ss-pd-row {
+  display: flex; gap: 10px; align-items: center;
+}
+.ss-profile-detail svg { color: var(--ss-magenta); flex-shrink: 0; }
+.theme-twilight .ss-profile-detail svg { color: var(--ss-magenta); }
+
+.ss-profile-actions {
+  display: flex; flex-direction: column; gap: 8px;
+  margin-top: 16px;
+}
+.ss-profile-actions-row {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+}
+.ss-profile-actions-row .ss-btn {
+  justify-content: center;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.ss-profile-tabs {
+  display: flex; gap: 4px;
+  border-bottom: 1px solid var(--ss-line);
+  margin-bottom: 18px;
+}
+.ss-profile-tab {
+  padding: 12px 18px;
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--ss-text-muted);
+  cursor: pointer;
+  position: relative;
+  border-bottom: 2px solid transparent;
+}
+.ss-profile-tab.is-active {
+  color: var(--ss-magenta-deep);
+  border-bottom-color: var(--ss-magenta);
+}
+.theme-twilight .ss-profile-tab.is-active { color: var(--ss-magenta); }
+
+.ss-history {
+  display: flex; flex-direction: column; gap: 12px;
+}
+.ss-hist-item {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  gap: 16px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-panel-border);
+  align-items: center;
+}
+.ss-hist-date {
+  font-family: var(--font-cormorant), serif;
+  text-align: center;
+  line-height: 1;
+}
+.ss-hist-date .ss-hd-day {
+  display: block;
+  font-size: 26px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-hist-date .ss-hd-mo {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin-top: 4px;
+}
+.ss-hist-meta { font-size: 13px; color: var(--ss-text-secondary); }
+.ss-hist-svc { font-family: var(--font-cormorant), serif; font-size: 17px; font-weight: 600; color: var(--ss-text-heading); }
+.ss-hist-stylist { font-size: 12px; color: var(--ss-text-muted); margin-top: 2px; }
+.ss-hist-tot {
+  font-family: var(--font-cormorant), serif;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--ss-magenta-deep);
+}
+.theme-twilight .ss-hist-tot { color: var(--ss-magenta); }
+
+/* notes panel */
+.ss-notes {
+  background: var(--ss-magenta-pale);
+  border: 1px dashed var(--ss-line-strong);
+  border-radius: 14px;
+  padding: 18px 20px;
+  margin-bottom: 16px;
+  position: relative;
+}
+.theme-twilight .ss-notes { background: rgba(30, 195, 217, 0.08); }
+.ss-notes-title {
+  font-family: var(--font-cormorant), serif;
+  font-style: italic;
+  font-size: 16px;
+  color: var(--ss-magenta-deep);
+  margin-bottom: 6px;
+}
+.theme-twilight .ss-notes-title { color: var(--ss-magenta); }
+.ss-notes p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ss-text-primary);
+  line-height: 1.6;
+}

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,9 +1,122 @@
-// Seeds the dev fixture that DevAuthProvider returns.
-// Identity values come from .env so the seed and the auth provider agree.
+// Seeds the dev fixture that DevAuthProvider returns, plus a realistic day
+// of staff, services, clients, and appointments so the calendar has
+// something to render out of the box.
+//
+// Idempotent for the foundation rows (user / salon / membership / staff /
+// categories / services / clients) — re-running upserts in place. The
+// appointments block is destructive for the dev salon: every run clears
+// today's existing appointments (and their event rows) and inserts a fresh
+// realistic schedule anchored at the current date in the salon's timezone.
 
-import { PrismaClient, Role, MembershipStatus } from "@prisma/client";
+import {
+  ActorType,
+  AppointmentSource,
+  AppointmentStatus,
+  MembershipStatus,
+  PrismaClient,
+  Role,
+} from "@prisma/client";
 
 const prisma = new PrismaClient();
+
+const SALON_TZ = "America/New_York";
+
+interface StaffSeed {
+  slug: string;
+  displayName: string;
+  title: string;
+  color: string;
+}
+const STAFF_SEEDS: StaffSeed[] = [
+  { slug: "trina", displayName: "Trina Bellweather", title: "Owner · Master stylist", color: "#1ec3d9" },
+  { slug: "rae", displayName: "Rae Okonkwo", title: "Color specialist", color: "#0892a8" },
+  { slug: "felix", displayName: "Felix Marin", title: "Barber", color: "#4a82b3" },
+  { slug: "nia", displayName: "Nia Espinoza", title: "Junior stylist", color: "#5cdcec" },
+];
+
+interface CategorySeed {
+  name: string;
+  sortOrder: number;
+  services: ServiceSeed[];
+}
+interface ServiceSeed {
+  slug: string;
+  name: string;
+  defaultDurationMinutes: number;
+  defaultPriceCents: number;
+}
+const CATEGORY_SEEDS: CategorySeed[] = [
+  {
+    name: "Color",
+    sortOrder: 0,
+    services: [
+      { slug: "color-cut", name: "Color & Cut", defaultDurationMinutes: 120, defaultPriceCents: 18500 },
+      { slug: "balayage", name: "Balayage", defaultDurationMinutes: 180, defaultPriceCents: 28000 },
+      { slug: "color-refresh", name: "Color refresh", defaultDurationMinutes: 90, defaultPriceCents: 14000 },
+      { slug: "toner-refresh", name: "Toner refresh", defaultDurationMinutes: 45, defaultPriceCents: 6500 },
+    ],
+  },
+  {
+    name: "Cut & Style",
+    sortOrder: 1,
+    services: [
+      { slug: "womens-cut", name: "Women's cut", defaultDurationMinutes: 60, defaultPriceCents: 9500 },
+      { slug: "mens-cut", name: "Men's cut", defaultDurationMinutes: 45, defaultPriceCents: 5500 },
+      { slug: "trim", name: "Trim", defaultDurationMinutes: 30, defaultPriceCents: 3500 },
+      { slug: "beard-trim", name: "Beard trim", defaultDurationMinutes: 30, defaultPriceCents: 2500 },
+      { slug: "blowout", name: "Blowout", defaultDurationMinutes: 60, defaultPriceCents: 6500 },
+      { slug: "bridal-updo", name: "Bridal Updo", defaultDurationMinutes: 90, defaultPriceCents: 18000 },
+    ],
+  },
+];
+
+interface ClientSeed {
+  firstName: string;
+  lastName: string;
+  phone: string;
+  email: string;
+  notes?: string;
+}
+const CLIENT_SEEDS: ClientSeed[] = [
+  { firstName: "Mira",     lastName: "Castellanos", phone: "(415) 555-0192", email: "mira@example.com", notes: "Balayage, no parabens" },
+  { firstName: "Jules",    lastName: "Pham",        phone: "(415) 555-0144", email: "jules@example.com", notes: "Loves Rae" },
+  { firstName: "Aiyana",   lastName: "Brooks",      phone: "(415) 555-0288", email: "aiyana@example.com", notes: "Bridal — Aug 12" },
+  { firstName: "Saoirse",  lastName: "Lin",         phone: "(415) 555-0167", email: "saoirse@example.com", notes: "Sensitive scalp" },
+  { firstName: "Cosmo",    lastName: "Reyes",       phone: "(415) 555-0203", email: "cosmo@example.com", notes: "Quiet appointments" },
+  { firstName: "Devon",    lastName: "Ashworth",    phone: "(415) 555-0341", email: "devon@example.com", notes: "Cool tones only" },
+  { firstName: "Imani",    lastName: "Calderón",    phone: "(415) 555-0119", email: "imani@example.com", notes: "Standing 1st-Friday" },
+  { firstName: "Theo",     lastName: "Nakamura",    phone: "(415) 555-0476", email: "theo@example.com" },
+  { firstName: "Priya",    lastName: "Mehta",       phone: "(415) 555-0388", email: "priya@example.com" },
+  { firstName: "Aja",      lastName: "Hartley",     phone: "(415) 555-0512", email: "aja@example.com" },
+];
+
+// Each row plants one appointment on today: stylist slug, client first name,
+// list of service slugs, salon-local start hour:minute, status. Times are
+// expressed in the salon's local clock so the seeded day looks the same in
+// any timezone tsx happens to run in.
+interface ApptSeed {
+  staff: string;
+  client: string;
+  services: string[];
+  startHour: number;
+  startMinute: number;
+  status: AppointmentStatus;
+}
+const APPT_SEEDS: ApptSeed[] = [
+  { staff: "trina", client: "Mira",    services: ["color-cut"],     startHour: 9,  startMinute: 0,  status: AppointmentStatus.IN_PROGRESS },
+  { staff: "trina", client: "Aiyana",  services: ["bridal-updo"],   startHour: 12, startMinute: 30, status: AppointmentStatus.CONFIRMED },
+  { staff: "trina", client: "Devon",   services: ["color-cut"],     startHour: 16, startMinute: 0,  status: AppointmentStatus.SCHEDULED },
+
+  { staff: "rae",   client: "Jules",   services: ["balayage"],      startHour: 11, startMinute: 0,  status: AppointmentStatus.CONFIRMED },
+  { staff: "rae",   client: "Saoirse", services: ["toner-refresh"], startHour: 14, startMinute: 30, status: AppointmentStatus.SCHEDULED },
+
+  { staff: "felix", client: "Theo",    services: ["mens-cut"],      startHour: 10, startMinute: 0,  status: AppointmentStatus.CHECKED_IN },
+  { staff: "felix", client: "Cosmo",   services: ["mens-cut", "beard-trim"], startHour: 13, startMinute: 30, status: AppointmentStatus.SCHEDULED },
+  { staff: "felix", client: "Aja",     services: ["blowout"],       startHour: 16, startMinute: 0,  status: AppointmentStatus.SCHEDULED },
+
+  { staff: "nia",   client: "Imani",   services: ["color-refresh"], startHour: 10, startMinute: 0,  status: AppointmentStatus.CONFIRMED },
+  { staff: "nia",   client: "Priya",   services: ["womens-cut"],    startHour: 13, startMinute: 0,  status: AppointmentStatus.SCHEDULED },
+];
 
 async function main(): Promise<void> {
   const userId = required("DEV_USER_ID");
@@ -19,12 +132,12 @@ async function main(): Promise<void> {
 
   const salon = await prisma.salon.upsert({
     where: { id: salonId },
-    update: { slug: salonSlug, name: "Acme Salon (dev)" },
+    update: { slug: salonSlug, name: "Acme Salon (dev)", timezone: SALON_TZ },
     create: {
       id: salonId,
       slug: salonSlug,
       name: "Acme Salon (dev)",
-      timezone: "America/New_York",
+      timezone: SALON_TZ,
     },
   });
 
@@ -39,10 +152,281 @@ async function main(): Promise<void> {
     },
   });
 
+  // ─── Staff (upsert by salon + displayName via two-step lookup since there's
+  //     no natural composite unique on displayName).
+  const staffBySlug = new Map<string, { id: string; salonId: string }>();
+  for (const s of STAFF_SEEDS) {
+    const existing = await prisma.staffMember.findFirst({
+      where: { salonId: salon.id, displayName: s.displayName },
+      select: { id: true, salonId: true },
+    });
+    if (existing) {
+      await prisma.staffMember.update({
+        where: { id: existing.id },
+        data: { title: s.title, color: s.color, isActive: true },
+      });
+      staffBySlug.set(s.slug, existing);
+    } else {
+      const created = await prisma.staffMember.create({
+        data: {
+          salonId: salon.id,
+          displayName: s.displayName,
+          title: s.title,
+          color: s.color,
+          isActive: true,
+        },
+        select: { id: true, salonId: true },
+      });
+      staffBySlug.set(s.slug, created);
+    }
+  }
+
+  // ─── Categories + services (upsert by salonId + name / slug).
+  const serviceBySlug = new Map<
+    string,
+    {
+      id: string;
+      salonId: string;
+      name: string;
+      defaultDurationMinutes: number;
+      defaultPriceCents: number;
+      currency: string;
+    }
+  >();
+  for (const cat of CATEGORY_SEEDS) {
+    const category = await prisma.serviceCategory.upsert({
+      where: { salonId_name: { salonId: salon.id, name: cat.name } },
+      update: { sortOrder: cat.sortOrder },
+      create: { salonId: salon.id, name: cat.name, sortOrder: cat.sortOrder },
+    });
+    for (const svc of cat.services) {
+      const upserted = await prisma.service.upsert({
+        where: { salonId_slug: { salonId: salon.id, slug: svc.slug } },
+        update: {
+          name: svc.name,
+          categoryId: category.id,
+          defaultDurationMinutes: svc.defaultDurationMinutes,
+          defaultPriceCents: svc.defaultPriceCents,
+          isActive: true,
+        },
+        create: {
+          salonId: salon.id,
+          categoryId: category.id,
+          slug: svc.slug,
+          name: svc.name,
+          defaultDurationMinutes: svc.defaultDurationMinutes,
+          defaultPriceCents: svc.defaultPriceCents,
+          currency: "USD",
+          isActive: true,
+        },
+        select: {
+          id: true,
+          salonId: true,
+          name: true,
+          defaultDurationMinutes: true,
+          defaultPriceCents: true,
+          currency: true,
+        },
+      });
+      serviceBySlug.set(svc.slug, upserted);
+    }
+  }
+
+  // ─── Clients (upsert by salonId + phone since that's what the schema
+  //     uniques on).
+  const clientByFirst = new Map<string, { id: string; salonId: string }>();
+  for (const c of CLIENT_SEEDS) {
+    const upserted = await prisma.client.upsert({
+      where: { salonId_phone: { salonId: salon.id, phone: c.phone } },
+      update: {
+        firstName: c.firstName,
+        lastName: c.lastName,
+        displayName: `${c.firstName} ${c.lastName}`,
+        email: c.email,
+        notes: c.notes ?? null,
+      },
+      create: {
+        salonId: salon.id,
+        firstName: c.firstName,
+        lastName: c.lastName,
+        displayName: `${c.firstName} ${c.lastName}`,
+        phone: c.phone,
+        email: c.email,
+        notes: c.notes ?? null,
+      },
+      select: { id: true, salonId: true },
+    });
+    clientByFirst.set(c.firstName, upserted);
+  }
+
+  // ─── Today's appointments — destructive: clear what's there and rebuild.
+  //     Domain/outbox events for the cleared appointments stay in place
+  //     (append-only contract); we just nuke the appointment + service-link
+  //     rows so the calendar shows the fresh fixture.
+  const { fromUtc, toUtc } = todayBoundsInTimezone(SALON_TZ);
+  const existingAppointments = await prisma.appointment.findMany({
+    where: {
+      salonId: salon.id,
+      startAt: { gte: fromUtc, lt: toUtc },
+    },
+    select: { id: true },
+  });
+  if (existingAppointments.length > 0) {
+    const ids = existingAppointments.map((a) => a.id);
+    await prisma.appointmentService.deleteMany({
+      where: { salonId: salon.id, appointmentId: { in: ids } },
+    });
+    await prisma.appointment.deleteMany({
+      where: { salonId: salon.id, id: { in: ids } },
+    });
+  }
+
+  for (const a of APPT_SEEDS) {
+    const staff = staffBySlug.get(a.staff);
+    const client = clientByFirst.get(a.client);
+    if (!staff || !client) continue;
+
+    const services = a.services
+      .map((slug) => serviceBySlug.get(slug))
+      .filter((s): s is NonNullable<typeof s> => Boolean(s));
+    if (services.length === 0) continue;
+
+    const totalDuration = services.reduce(
+      (acc, s) => acc + s.defaultDurationMinutes,
+      0,
+    );
+    const startAt = utcInstantForLocalTime(a.startHour, a.startMinute, SALON_TZ);
+    const endAt = new Date(startAt.getTime() + totalDuration * 60_000);
+
+    const appointment = await prisma.appointment.create({
+      data: {
+        salonId: salon.id,
+        clientId: client.id,
+        staffMemberId: staff.id,
+        startAt,
+        endAt,
+        status: a.status,
+        source: AppointmentSource.STAFF,
+        createdById: user.id,
+        services: {
+          // salonId is propagated from the parent appointment via the
+          // composite FK — including it here errors at runtime.
+          create: services.map((svc, i) => ({
+            serviceId: svc.id,
+            serviceNameSnapshot: svc.name,
+            priceSnapshotCents: svc.defaultPriceCents,
+            durationSnapshotMinutes: svc.defaultDurationMinutes,
+            currencySnapshot: svc.currency,
+            sortOrder: i,
+          })),
+        },
+      },
+    });
+    await prisma.domainEvent.create({
+      data: {
+        salonId: salon.id,
+        aggregateType: "APPOINTMENT",
+        aggregateId: appointment.id,
+        eventType: "appointment.created",
+        payload: { seeded: true },
+        actorType: ActorType.SYSTEM,
+      },
+    });
+  }
+
   // eslint-disable-next-line no-console
   console.log(
-    `Seeded dev fixture: user=${user.id} salon=${salon.id} (${salon.slug})`,
+    [
+      `Seeded dev fixture:`,
+      `  user        ${user.id}`,
+      `  salon       ${salon.id} (${salon.slug}, ${SALON_TZ})`,
+      `  staff       ${staffBySlug.size}`,
+      `  services    ${serviceBySlug.size} across ${CATEGORY_SEEDS.length} categories`,
+      `  clients     ${clientByFirst.size}`,
+      `  appts today ${APPT_SEEDS.length}`,
+    ].join("\n"),
   );
+}
+
+// Build today's UTC window [00:00, next-day 00:00) in the given IANA timezone.
+// Implemented without date-fns-tz so the seed has zero extra deps — uses
+// Intl.DateTimeFormat to read the wall-clock components and then iteratively
+// refines the offset (handles DST).
+function todayBoundsInTimezone(timeZone: string): { fromUtc: Date; toUtc: Date } {
+  const now = new Date();
+  const parts = formatPartsInTz(now, timeZone);
+  const isoLocal = `${parts.year}-${parts.month}-${parts.day}T00:00:00`;
+  const fromUtc = utcFromLocalIso(isoLocal, timeZone);
+  const next = new Date(fromUtc.getTime() + 24 * 60 * 60 * 1000);
+  // DST days are 23 or 25 hours long — recompute the next midnight in TZ.
+  const nextParts = formatPartsInTz(next, timeZone);
+  const nextIsoLocal = `${nextParts.year}-${nextParts.month}-${nextParts.day}T00:00:00`;
+  const toUtc = utcFromLocalIso(nextIsoLocal, timeZone);
+  return { fromUtc, toUtc };
+}
+
+function utcInstantForLocalTime(hour: number, minute: number, timeZone: string): Date {
+  const now = new Date();
+  const parts = formatPartsInTz(now, timeZone);
+  const hh = String(hour).padStart(2, "0");
+  const mm = String(minute).padStart(2, "0");
+  const isoLocal = `${parts.year}-${parts.month}-${parts.day}T${hh}:${mm}:00`;
+  return utcFromLocalIso(isoLocal, timeZone);
+}
+
+// Convert "2026-04-29T14:30:00" interpreted as wall-clock time in the given
+// timezone to a UTC instant. Two-pass refinement handles the DST edge cases
+// where adding the offset from the naive guess produces a different offset.
+function utcFromLocalIso(isoLocal: string, timeZone: string): Date {
+  const guessAsUtc = new Date(isoLocal + "Z");
+  const offsetMs1 = tzOffsetMs(guessAsUtc, timeZone);
+  const refined = new Date(guessAsUtc.getTime() - offsetMs1);
+  const offsetMs2 = tzOffsetMs(refined, timeZone);
+  if (offsetMs2 === offsetMs1) return refined;
+  return new Date(guessAsUtc.getTime() - offsetMs2);
+}
+
+function tzOffsetMs(instant: Date, timeZone: string): number {
+  const parts = formatPartsInTz(instant, timeZone);
+  const localAsUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return localAsUtc - instant.getTime();
+}
+
+function formatPartsInTz(instant: Date, timeZone: string) {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(instant).reduce<Record<string, string>>(
+    (acc, p) => {
+      if (p.type !== "literal") acc[p.type] = p.value;
+      return acc;
+    },
+    {},
+  );
+  // hour:24 ("00".."23") — Intl quirk: "24" can show up at midnight.
+  if (parts.hour === "24") parts.hour = "00";
+  return parts as {
+    year: string;
+    month: string;
+    day: string;
+    hour: string;
+    minute: string;
+    second: string;
+  };
 }
 
 function required(name: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ importers:
       '@shearsimp/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       next:
         specifier: ^15.1.0
         version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1909,6 +1915,14 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -5523,6 +5537,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
+
+  date-fns@4.1.0: {}
 
   debug@2.6.9:
     dependencies:


### PR DESCRIPTION
## Summary

Brings in the **Trina's Tresses × Gentle Magic** aesthetic from the Claude Design handoff and ships the day-view calendar wired to the real `/appointments` API.

**Schedule view (`/schedule`)**
- 15-min grid (14px/slot, 56px/hour, 9 AM – 7 PM), one column per active stylist with per-stylist gradient header stripe.
- Service-color-coded blocks (Color · Cuts · Styling · Treatments · Bridal & special · Blocked) keyed off the salon's category names.
- **Drag-to-reschedule** via native HTML5 D&D. Drop snaps to the 15-min slot + column; conflicts surface as inline 409 messages.
- Click a block → slide-out details panel with status actions (confirm / check-in / start / no-show / complete / cancel) gated by the API-side state machine.
- Day prev/today/next nav; salon-timezone-aware day boundaries via `date-fns-tz`.

**Shell**
- New Sidebar + Topbar matching the design markup; orbs + motes layered via the `.ss-app` frame.
- Fonts (Cormorant Garamond, Quicksand, Great Vibes) loaded via `next/font/google` so the design CSS picks them up through `--font-*` variables.
- Existing pages (Dashboard / Clients / Staff / Services / Settings) still render under the new shell with their Phase 2 Tailwind styling — restyling those is the next phase.

**Build hygiene** (drive-by)
- Move `typedRoutes` out of `experimental` (Next 15.4 graduation).
- Add `not-found.tsx` + `global-error.tsx` so the app router owns its error boundaries explicitly.
- Note: a pre-existing Next 15.5 prerender bug for `/404` + `/500` still fails the production build (`<Html> should not be imported outside of pages/_document`). Dev server runs fine; production build fix is tracked separately.

**Deps added**: `date-fns`, `date-fns-tz` (salon-timezone day math).

## Test plan

- [x] `pnpm -r typecheck` — clean across all four projects
- [x] `pnpm --filter @shearsimp/web exec dotenv -e ../../.env -- next dev` — sign-in route returns 200
- [ ] **Manual UI dogfood** (couldn't fully exercise from agent — needs DB):
  - Calendar renders today's appointments with the right color coding
  - Drag a block to a new slot/column → API reschedules → UI refreshes
  - Drag onto a conflicting slot → red error banner with the API's 409 message
  - Click a block → status actions match the state machine (e.g. SCHEDULED shows Confirm/Check-in/No-show; CHECKED_IN shows Start; IN_PROGRESS shows Complete)
  - Day prev/today/next navigation respects the salon timezone (try with a non-`America/New_York` salon)