### PR TITLE
Phase 3c: restyle dashboard + CRUD pages with the design system

### DIFF
--- a/apps/web/src/app/(app)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(app)/clients/[id]/page.tsx
@@ -45,73 +45,70 @@ export default async function ClientDetailPage({
   };
 
   return (
-    <div className="space-y-6">
-      <PageHeader title={client.displayName} description="Client profile" />
+    <>
+      <PageHeader
+        eyebrow="Client"
+        title={client.displayName}
+        description={
+          [client.phone, client.email].filter(Boolean).join(" · ") ||
+          "No contact info on file"
+        }
+        action={
+          <Link href="/clients" className="ss-link">
+            ← Back to clients
+          </Link>
+        }
+      />
 
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
-          Profile
-        </h2>
-        <Card>
-          <ClientForm
-            action={action}
-            submitLabel="Save changes"
-            defaults={{
-              firstName: client.firstName,
-              lastName: client.lastName,
-              displayName: client.displayName,
-              email: client.email,
-              phone: client.phone,
-              notes: client.notes,
-            }}
-          />
-        </Card>
-      </section>
+      <Card title="Profile" meta="Editable">
+        <ClientForm
+          action={action}
+          submitLabel="Save changes"
+          defaults={{
+            firstName: client.firstName,
+            lastName: client.lastName,
+            displayName: client.displayName,
+            email: client.email,
+            phone: client.phone,
+            notes: client.notes,
+          }}
+        />
+      </Card>
 
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
-          Appointment history
-        </h2>
-        <Card className={client.appointments.length === 0 ? undefined : "p-0"}>
-          {client.appointments.length === 0 ? (
-            <p className="text-sm text-zinc-500">
-              No appointments yet. Booking lands in Phase 3.
-            </p>
-          ) : (
-            <ul className="divide-y divide-zinc-200">
-              {client.appointments.map((a) => (
-                <li key={a.id} className="px-6 py-4">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <div className="text-sm font-medium text-zinc-900">
-                        {new Date(a.startAt).toLocaleString()}
-                      </div>
-                      <div className="text-xs text-zinc-500">
-                        With {a.staffMember.displayName} ·{" "}
-                        {a.services
-                          .map((s) => s.serviceNameSnapshot)
-                          .join(", ") || "No services"}
-                      </div>
-                    </div>
-                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
-                      {a.status}
-                    </span>
+      <Card title="Appointment history" meta={`${client.appointments.length} on record`}>
+        {client.appointments.length === 0 ? (
+          <p className="ss-empty">No appointments yet.</p>
+        ) : (
+          <ul className="ss-history">
+            {client.appointments.map((a) => (
+              <li key={a.id} className="ss-history-row">
+                <div>
+                  <div className="ss-history-svc">
+                    {a.services
+                      .map((s) => s.serviceNameSnapshot)
+                      .join(" · ") || "—"}
                   </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </Card>
-      </section>
-
-      <div>
-        <Link
-          href="/clients"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to clients
-        </Link>
-      </div>
-    </div>
+                  <div className="ss-history-meta">
+                    With <strong>{a.staffMember.displayName}</strong>
+                  </div>
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <div className="ss-history-date">
+                    {new Date(a.startAt).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </div>
+                  <span className="ss-status-pill is-confirmed">
+                    {a.status.toLowerCase().replace("_", " ")}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(app)/clients/[id]/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { apiFetch } from "@/lib/api";
 import { Card, PageHeader } from "@/components/form";
+import {
+  statusPill,
+  type AppointmentStatus,
+} from "@/lib/appointment-status";
 import { ClientForm } from "../_components/client-form";
 import { updateClientAction, type FormState } from "../_actions";
 
@@ -8,7 +12,7 @@ interface AppointmentRow {
   id: string;
   startAt: string;
   endAt: string;
-  status: string;
+  status: AppointmentStatus;
   staffMember: { id: string; displayName: string };
   services: Array<{
     serviceNameSnapshot: string;
@@ -80,32 +84,35 @@ export default async function ClientDetailPage({
           <p className="ss-empty">No appointments yet.</p>
         ) : (
           <ul className="ss-history">
-            {client.appointments.map((a) => (
-              <li key={a.id} className="ss-history-row">
-                <div>
-                  <div className="ss-history-svc">
-                    {a.services
-                      .map((s) => s.serviceNameSnapshot)
-                      .join(" · ") || "—"}
+            {client.appointments.map((a) => {
+              const pill = statusPill(a.status);
+              return (
+                <li key={a.id} className="ss-history-row">
+                  <div>
+                    <div className="ss-history-svc">
+                      {a.services
+                        .map((s) => s.serviceNameSnapshot)
+                        .join(" · ") || "—"}
+                    </div>
+                    <div className="ss-history-meta">
+                      With <strong>{a.staffMember.displayName}</strong>
+                    </div>
                   </div>
-                  <div className="ss-history-meta">
-                    With <strong>{a.staffMember.displayName}</strong>
+                  <div style={{ textAlign: "right" }}>
+                    <div className="ss-history-date">
+                      {new Date(a.startAt).toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </div>
+                    <span className={`ss-status-pill ${pill.cls}`}>
+                      {pill.label}
+                    </span>
                   </div>
-                </div>
-                <div style={{ textAlign: "right" }}>
-                  <div className="ss-history-date">
-                    {new Date(a.startAt).toLocaleDateString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    })}
-                  </div>
-                  <span className="ss-status-pill is-confirmed">
-                    {a.status.toLowerCase().replace("_", " ")}
-                  </span>
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </Card>

--- a/apps/web/src/app/(app)/clients/_components/client-form.tsx
+++ b/apps/web/src/app/(app)/clients/_components/client-form.tsx
@@ -34,9 +34,9 @@ export function ClientForm({
   );
   const errors = state?.errors ?? {};
   return (
-    <form action={formAction} className="space-y-5">
+    <form action={formAction} className="ss-form">
       <FormError message={state?.message} />
-      <div className="grid grid-cols-2 gap-4">
+      <div className="ss-form-row">
         <Field label="First name" name="firstName" error={errors.firstName}>
           <Input
             id="firstName"
@@ -68,7 +68,7 @@ export function ClientForm({
           maxLength={160}
         />
       </Field>
-      <div className="grid grid-cols-2 gap-4">
+      <div className="ss-form-row">
         <Field label="Phone" name="phone" error={errors.phone}>
           <Input
             id="phone"
@@ -97,7 +97,7 @@ export function ClientForm({
           maxLength={4000}
         />
       </Field>
-      <div>
+      <div className="ss-form-actions">
         <Button type="submit" disabled={pending}>
           {pending ? "Saving…" : submitLabel}
         </Button>

--- a/apps/web/src/app/(app)/clients/new/page.tsx
+++ b/apps/web/src/app/(app)/clients/new/page.tsx
@@ -5,19 +5,20 @@ import { createClientAction } from "../_actions";
 
 export default function NewClientPage() {
   return (
-    <div className="space-y-6">
-      <PageHeader title="New client" description="Add a client profile." />
+    <>
+      <PageHeader
+        eyebrow="Roster"
+        title="New client"
+        description="Add a client profile."
+        action={
+          <Link href="/clients" className="ss-link">
+            ← Back to clients
+          </Link>
+        }
+      />
       <Card>
         <ClientForm action={createClientAction} submitLabel="Create client" />
       </Card>
-      <div>
-        <Link
-          href="/clients"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to clients
-        </Link>
-      </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/clients/page.tsx
+++ b/apps/web/src/app/(app)/clients/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { apiFetch } from "@/lib/api";
-import { Button, Card, Input, PageHeader } from "@/components/form";
+import { Button, Card, PageHeader } from "@/components/form";
 
 interface Client {
   id: string;
@@ -9,6 +9,7 @@ interface Client {
   lastName: string | null;
   email: string | null;
   phone: string | null;
+  notes: string | null;
 }
 
 export default async function ClientsPage({
@@ -23,59 +24,126 @@ export default async function ClientsPage({
   });
 
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Roster"
         title="Clients"
-        description="Search by name, phone, or email."
+        description={
+          q
+            ? `Searching for "${q}"`
+            : `${clients.length} ${clients.length === 1 ? "client" : "clients"} in the studio.`
+        }
         action={
           <Link href="/clients/new">
-            <Button>New client</Button>
+            <Button>+ Add client</Button>
           </Link>
         }
       />
-      <Card>
-        <form className="flex gap-2" action="/clients">
-          <Input
+
+      <form className="ss-toolbar" action="/clients">
+        <div className="ss-search ss-toolbar-search">
+          <SearchIcon />
+          <input
             name="q"
             defaultValue={q}
-            placeholder="Search clients…"
-            className="flex-1"
+            placeholder="Search by name, phone, or email…"
           />
-          <Button type="submit" variant="secondary">
-            Search
-          </Button>
-        </form>
-      </Card>
+        </div>
+        <Button variant="secondary" type="submit">
+          Search
+        </Button>
+      </form>
+
       {clients.length === 0 ? (
         <Card>
-          <p className="text-sm text-zinc-500">
+          <p className="ss-empty">
             {q ? `No clients match "${q}".` : "No clients yet."}
           </p>
         </Card>
       ) : (
-        <Card className="p-0">
-          <ul className="divide-y divide-zinc-200">
-            {clients.map((c) => (
-              <li key={c.id}>
-                <Link
-                  href={`/clients/${c.id}`}
-                  className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-zinc-50"
-                >
-                  <div>
-                    <div className="text-sm font-medium text-zinc-900">
-                      {c.displayName}
+        <Card noPadding>
+          <table className="ss-table">
+            <thead>
+              <tr>
+                <th>Client</th>
+                <th>Phone</th>
+                <th>Email</th>
+                <th>Notes</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {clients.map((c) => (
+                <tr key={c.id}>
+                  <td>
+                    <div className="ss-msg-avatar" style={{ width: 36, height: 36, fontSize: 14 }}>
+                      {initialsOf(c.displayName)}
                     </div>
-                    <div className="text-xs text-zinc-500">
-                      {[c.phone, c.email].filter(Boolean).join(" · ") ||
-                        "No contact info"}
+                    <div>
+                      <div className="ss-client-name">
+                        <Link href={`/clients/${c.id}`} className="ss-link-plain">
+                          {c.displayName}
+                        </Link>
+                      </div>
+                      {c.firstName && c.lastName && (
+                        <div className="ss-client-mute">
+                          {c.firstName} {c.lastName}
+                        </div>
+                      )}
                     </div>
-                  </div>
-                </Link>
-              </li>
-            ))}
-          </ul>
+                  </td>
+                  <td>
+                    <span className="ss-client-mute">{c.phone ?? "—"}</span>
+                  </td>
+                  <td>
+                    <span className="ss-client-mute">{c.email ?? "—"}</span>
+                  </td>
+                  <td>
+                    <span className="ss-client-mute">
+                      {c.notes ? truncate(c.notes, 60) : "—"}
+                    </span>
+                  </td>
+                  <td style={{ textAlign: "right" }}>
+                    <Link href={`/clients/${c.id}`} className="ss-link">
+                      View
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </Card>
       )}
-    </div>
+    </>
   );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      width={15}
+      height={15}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 21l-4.35-4.35M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" />
+    </svg>
+  );
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
 }

--- a/apps/web/src/app/(app)/messages/page.tsx
+++ b/apps/web/src/app/(app)/messages/page.tsx
@@ -1,21 +1,19 @@
 import { EmptyState } from "@/components/empty-state";
+import { PageHeader } from "@/components/form";
 
 export default function MessagesPage() {
   return (
-    <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Messages
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          SMS confirmations, reminders, and client replies.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Conversations"
+        title="Messages"
+        description="SMS confirmations, reminders, and client replies."
+      />
       <EmptyState
-        title="Messaging coming in Phase 4"
+        title="Messaging arrives in Phase 4"
         body="Twilio-backed SMS confirmations, reminder jobs, and inbound reply logs land here. Requires A2P 10DLC registration before going live."
         phase="Phase 4"
       />
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,40 +1,300 @@
-import { EmptyState } from "@/components/empty-state";
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import {
+  dayWindow,
+  formatTimeInTimezone,
+  todayIsoInTimezone,
+} from "@/lib/salon-time";
 
-export default function DashboardPage() {
+interface SettingsResponse {
+  timezone: string;
+}
+
+interface DashboardAppointment {
+  id: string;
+  startAt: string;
+  status: "SCHEDULED" | "CONFIRMED" | "CHECKED_IN" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED" | "NO_SHOW";
+  client: { id: string; displayName: string };
+  staffMember: { id: string; displayName: string };
+  services: { serviceNameSnapshot: string; durationSnapshotMinutes: number }[];
+}
+
+interface StaffRow {
+  id: string;
+  displayName: string;
+  title: string | null;
+  color: string | null;
+  isActive: boolean;
+}
+
+const STATUS_PILL: Record<DashboardAppointment["status"], { cls: string; label: string }> = {
+  SCHEDULED:    { cls: "is-pending",   label: "scheduled" },
+  CONFIRMED:    { cls: "is-confirmed", label: "confirmed" },
+  CHECKED_IN:   { cls: "is-checked",   label: "checked in" },
+  IN_PROGRESS:  { cls: "is-progress",  label: "in progress" },
+  COMPLETED:    { cls: "is-checked",   label: "completed" },
+  CANCELLED:    { cls: "is-pending",   label: "cancelled" },
+  NO_SHOW:      { cls: "is-pending",   label: "no-show" },
+};
+
+// Per-stylist gradient palette so the dashboard avatars match the schedule
+// page's column headers.
+const STAFF_GRADIENTS = [
+  "linear-gradient(135deg, #1ec3d9, #0892a8)",
+  "linear-gradient(135deg, #0892a8, #4a82b3)",
+  "linear-gradient(135deg, #4a82b3, #1ec3d9)",
+  "linear-gradient(135deg, #5cdcec, #0892a8)",
+  "linear-gradient(135deg, #1ec3d9, #6fa6cc)",
+];
+
+export default async function DashboardPage() {
+  const settings = await apiFetch<SettingsResponse>("/settings");
+  const tz = settings.timezone;
+  const isoDate = todayIsoInTimezone(tz);
+  const window = dayWindow(isoDate, tz);
+
+  const [appointments, staff] = await Promise.all([
+    apiFetch<DashboardAppointment[]>("/appointments", {
+      query: {
+        from: window.fromUtc.toISOString(),
+        to: window.toUtc.toISOString(),
+      },
+    }),
+    apiFetch<StaffRow[]>("/staff"),
+  ]);
+
+  const visibleAppts = appointments
+    .filter((a) => a.status !== "CANCELLED" && a.status !== "NO_SHOW")
+    .sort((a, b) => a.startAt.localeCompare(b.startAt));
+  const activeStaff = staff.filter((s) => s.isActive);
+  const awaitingConfirmation = visibleAppts.filter(
+    (a) => a.status === "SCHEDULED",
+  ).length;
+  const firstAppt = visibleAppts[0];
+
+  const dateLine = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    timeZone: tz,
+  }).format(new Date());
+
   return (
-    <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          Dashboard
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500">
-          Today's appointments, recent activity, and quick actions live here
-          once Phase 3 lands.
+    <>
+      <header className="ss-page-head">
+        <div className="ss-page-eyebrow">{dateLine}</div>
+        <h2 className="ss-page-title">Today</h2>
+        <p className="ss-page-sub">
+          {visibleAppts.length === 0
+            ? "No appointments on the books today."
+            : `${visibleAppts.length} appointment${visibleAppts.length === 1 ? "" : "s"} today` +
+              (awaitingConfirmation > 0
+                ? `, ${awaitingConfirmation} awaiting confirmation`
+                : "") +
+              (firstAppt
+                ? `. First in at ${formatTimeInTimezone(new Date(firstAppt.startAt), tz)}.`
+                : ".")}
         </p>
       </header>
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <Card label="Today's appointments" value="—" />
-        <Card label="New clients (7d)" value="—" />
-        <Card label="Revenue (today)" value="—" />
+
+      <div className="ss-stats-grid">
+        <div className="ss-stat is-magenta">
+          <div className="ss-stat-eyebrow">Today</div>
+          <div className="ss-stat-value">
+            <span>{visibleAppts.length}</span>
+            <span className="ss-unit">appointments</span>
+          </div>
+          <div className="ss-stat-foot">
+            {awaitingConfirmation > 0
+              ? `${awaitingConfirmation} awaiting confirmation`
+              : "All confirmed"}
+          </div>
+        </div>
+        <div className="ss-stat is-cyan">
+          <div className="ss-stat-eyebrow">Staff</div>
+          <div className="ss-stat-value">
+            <span>{activeStaff.length}</span>
+            <span className="ss-unit">stylists on the roster</span>
+          </div>
+          <div className="ss-stat-foot">
+            <Link href="/staff" className="ss-link">
+              Manage staff →
+            </Link>
+          </div>
+        </div>
+        <div className="ss-stat is-violet">
+          <div className="ss-stat-eyebrow">Quick action</div>
+          <div className="ss-stat-value">
+            <span style={{ fontFamily: "var(--font-cormorant), serif", fontSize: 28 }}>
+              Book
+            </span>
+          </div>
+          <div className="ss-stat-foot">
+            <Link href="/schedule" className="ss-link">
+              Open the schedule →
+            </Link>
+          </div>
+        </div>
       </div>
-      <EmptyState
-        title="Nothing to show yet"
-        body="Once you have appointments, clients, and services, this dashboard will pull live numbers from the API."
-        phase="Phase 3"
-      />
-    </div>
+
+      <div className="ss-grid">
+        <div className="ss-card">
+          <div className="ss-card-head">
+            <h3 className="ss-card-title">Today's schedule</h3>
+            <span className="ss-card-meta">
+              {visibleAppts.length} appointment{visibleAppts.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          {visibleAppts.length === 0 ? (
+            <p className="ss-empty">
+              Nothing booked yet. Open the{" "}
+              <Link href="/schedule" className="ss-link">
+                schedule
+              </Link>{" "}
+              to add an appointment.
+            </p>
+          ) : (
+            <div className="ss-timeline">
+              {visibleAppts.map((a) => {
+                const start = new Date(a.startAt);
+                const hour = formatTimeInTimezone(start, tz);
+                const [h, m] = hour.split(":");
+                const meridiem = m.split(" ")[1] ?? "";
+                const minutes = m.split(" ")[0] ?? "00";
+                const totalMin = a.services.reduce(
+                  (acc, s) => acc + s.durationSnapshotMinutes,
+                  0,
+                );
+                const pill = STATUS_PILL[a.status];
+                const services = a.services
+                  .map((s) => s.serviceNameSnapshot)
+                  .join(" · ");
+                return (
+                  <Link
+                    key={a.id}
+                    href={`/schedule?date=${isoDate}`}
+                    className="ss-timeline-row"
+                  >
+                    <div className="ss-timeline-time">
+                      <span className="ss-time-h">{h}</span>
+                      <span className="ss-time-m">
+                        {minutes === "00" ? meridiem : minutes}
+                      </span>
+                    </div>
+                    <div className="ss-appt is-cyan">
+                      <div className="ss-appt-avatar">
+                        {initialsOf(a.client.displayName)}
+                      </div>
+                      <div className="ss-appt-body">
+                        <div className="ss-appt-row1">
+                          <div className="ss-appt-name">
+                            {a.client.displayName}
+                          </div>
+                          <span className="ss-appt-dur">{totalMin} min</span>
+                        </div>
+                        <div className="ss-appt-row2">
+                          <span className="ss-appt-service">{services}</span>
+                          <span className="ss-appt-divider" />
+                          <span className="ss-appt-stylist">
+                            with {a.staffMember.displayName.split(" ")[0]}
+                          </span>
+                          <span style={{ flex: 1 }} />
+                          <span className={`ss-status-pill ${pill.cls}`}>
+                            {pill.label}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="ss-card ss-side-block">
+            <div className="ss-card-head">
+              <h3 className="ss-card-title">Quick actions</h3>
+              <span className="ss-card-meta">Shortcuts</span>
+            </div>
+            <div className="ss-quick-actions">
+              <Link className="ss-action" href="/schedule">
+                <span className="ss-action-title">Schedule</span>
+              </Link>
+              <Link className="ss-action" href="/clients">
+                <span className="ss-action-title">Clients</span>
+              </Link>
+              <Link className="ss-action" href="/staff">
+                <span className="ss-action-title">Staff</span>
+              </Link>
+              <Link className="ss-action" href="/services">
+                <span className="ss-action-title">Services</span>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {activeStaff.length > 0 && (
+        <>
+          <div className="ss-divider">
+            <div className="ss-divider-line" />
+            <span className="ss-divider-label">Staff</span>
+            <div className="ss-divider-line" />
+          </div>
+          <div className="ss-chair-strip">
+            {activeStaff.map((s, i) => {
+              const booked = visibleAppts.filter(
+                (a) => a.staffMember.id === s.id,
+              ).length;
+              const total = Math.max(visibleAppts.length, 1);
+              const pct = Math.round((booked / total) * 100);
+              return (
+                <div key={s.id} className="ss-chair">
+                  <div className="ss-chair-head">
+                    <div
+                      className="ss-chair-avatar"
+                      style={{
+                        background: s.color
+                          ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                          : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
+                      }}
+                    >
+                      {initialsOf(s.displayName)}
+                    </div>
+                    <div>
+                      <div className="ss-chair-name">{s.displayName}</div>
+                      {s.title && (
+                        <div className="ss-chair-role">{s.title}</div>
+                      )}
+                    </div>
+                  </div>
+                  <div className="ss-chair-bar">
+                    <div
+                      className="ss-chair-bar-fill"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <div className="ss-chair-stat">
+                    <span>{booked} of today's appts</span>
+                    <strong>{pct}%</strong>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </>
   );
 }
 
-function Card({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
-      <div className="text-xs font-medium uppercase tracking-wide text-zinc-500">
-        {label}
-      </div>
-      <div className="mt-2 text-2xl font-semibold tracking-tight text-zinc-900">
-        {value}
-      </div>
-    </div>
-  );
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
 }

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -5,6 +5,10 @@ import {
   formatTimeInTimezone,
   todayIsoInTimezone,
 } from "@/lib/salon-time";
+import {
+  statusPill,
+  type AppointmentStatus,
+} from "@/lib/appointment-status";
 
 interface SettingsResponse {
   timezone: string;
@@ -13,7 +17,7 @@ interface SettingsResponse {
 interface DashboardAppointment {
   id: string;
   startAt: string;
-  status: "SCHEDULED" | "CONFIRMED" | "CHECKED_IN" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED" | "NO_SHOW";
+  status: AppointmentStatus;
   client: { id: string; displayName: string };
   staffMember: { id: string; displayName: string };
   services: { serviceNameSnapshot: string; durationSnapshotMinutes: number }[];
@@ -26,16 +30,6 @@ interface StaffRow {
   color: string | null;
   isActive: boolean;
 }
-
-const STATUS_PILL: Record<DashboardAppointment["status"], { cls: string; label: string }> = {
-  SCHEDULED:    { cls: "is-pending",   label: "scheduled" },
-  CONFIRMED:    { cls: "is-confirmed", label: "confirmed" },
-  CHECKED_IN:   { cls: "is-checked",   label: "checked in" },
-  IN_PROGRESS:  { cls: "is-progress",  label: "in progress" },
-  COMPLETED:    { cls: "is-checked",   label: "completed" },
-  CANCELLED:    { cls: "is-pending",   label: "cancelled" },
-  NO_SHOW:      { cls: "is-pending",   label: "no-show" },
-};
 
 // Per-stylist gradient palette so the dashboard avatars match the schedule
 // page's column headers.
@@ -165,7 +159,7 @@ export default async function DashboardPage() {
                   (acc, s) => acc + s.durationSnapshotMinutes,
                   0,
                 );
-                const pill = STATUS_PILL[a.status];
+                const pill = statusPill(a.status);
                 const services = a.services
                   .map((s) => s.serviceNameSnapshot)
                   .join(" · ");

--- a/apps/web/src/app/(app)/services/[id]/page.tsx
+++ b/apps/web/src/app/(app)/services/[id]/page.tsx
@@ -38,9 +38,18 @@ export default async function ServiceDetailPage({
   };
 
   return (
-    <div className="space-y-6">
-      <PageHeader title={service.name} description={service.slug} />
-      <Card>
+    <>
+      <PageHeader
+        eyebrow="Service"
+        title={service.name}
+        description={service.slug}
+        action={
+          <Link href="/services" className="ss-link">
+            ← Back to services
+          </Link>
+        }
+      />
+      <Card title="Edit" meta={service.isActive ? "Active" : "Inactive"}>
         <ServiceForm
           action={action}
           categories={categories}
@@ -57,14 +66,6 @@ export default async function ServiceDetailPage({
           }}
         />
       </Card>
-      <div>
-        <Link
-          href="/services"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to services
-        </Link>
-      </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/services/_components/category-form.tsx
+++ b/apps/web/src/app/(app)/services/_components/category-form.tsx
@@ -15,8 +15,8 @@ export function CategoryCreateForm({
   );
   const errors = state?.errors ?? {};
   return (
-    <form action={formAction} className="flex items-end gap-3">
-      <div className="flex-1">
+    <form action={formAction} className="ss-form">
+      <div className="ss-form-row">
         <Field label="Category name" name="name" error={errors.name}>
           <Input
             id="name"
@@ -26,8 +26,6 @@ export function CategoryCreateForm({
             maxLength={80}
           />
         </Field>
-      </div>
-      <div className="w-28">
         <Field label="Order" name="sortOrder" error={errors.sortOrder}>
           <Input
             id="sortOrder"
@@ -38,13 +36,15 @@ export function CategoryCreateForm({
           />
         </Field>
       </div>
-      <Button type="submit" disabled={pending}>
-        {pending ? "Adding…" : "Add"}
-      </Button>
-      {state?.message && !errors._ && (
-        <span className="text-xs text-emerald-700">{state.message}</span>
-      )}
-      <FormError message={errors._} />
+      <div className="ss-form-actions">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Adding…" : "Add category"}
+        </Button>
+        {state?.message && !errors._ && (
+          <span className="ss-form-success-inline">{state.message}</span>
+        )}
+        <FormError message={errors._} />
+      </div>
     </form>
   );
 }

--- a/apps/web/src/app/(app)/services/_components/service-form.tsx
+++ b/apps/web/src/app/(app)/services/_components/service-form.tsx
@@ -49,7 +49,7 @@ export function ServiceForm({
       ? (defaults.defaultPriceCents / 100).toFixed(2)
       : "";
   return (
-    <form action={formAction} className="space-y-5">
+    <form action={formAction} className="ss-form">
       <FormError message={state?.message} />
       <Field label="Name" name="name" error={errors.name}>
         <Input
@@ -89,7 +89,7 @@ export function ServiceForm({
           ))}
         </Select>
       </Field>
-      <div className="grid grid-cols-2 gap-4">
+      <div className="ss-form-row">
         <Field
           label="Default duration"
           name="defaultDurationMinutes"
@@ -138,7 +138,7 @@ export function ServiceForm({
         label="Active (bookable)"
         defaultChecked={defaults?.isActive ?? true}
       />
-      <div>
+      <div className="ss-form-actions">
         <Button type="submit" disabled={pending}>
           {pending ? "Saving…" : submitLabel}
         </Button>

--- a/apps/web/src/app/(app)/services/categories/page.tsx
+++ b/apps/web/src/app/(app)/services/categories/page.tsx
@@ -14,45 +14,36 @@ export default async function ServiceCategoriesPage() {
   const categories = await apiFetch<Category[]>("/service-categories");
 
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Menu"
         title="Service categories"
         description="Group services for the booking screen and reports."
+        action={
+          <Link href="/services" className="ss-link">
+            ← Back to services
+          </Link>
+        }
       />
-      <Card>
+      <Card title="Add a category">
         <CategoryCreateForm action={createCategoryAction} />
       </Card>
-      {categories.length === 0 ? (
-        <Card>
-          <p className="text-sm text-zinc-500">No categories yet.</p>
-        </Card>
-      ) : (
-        <Card className="p-0">
-          <ul className="divide-y divide-zinc-200">
+      <Card title="Categories" meta={`${categories.length} total`} noPadding>
+        {categories.length === 0 ? (
+          <p className="ss-empty" style={{ padding: 24 }}>
+            No categories yet.
+          </p>
+        ) : (
+          <ul className="ss-stack-list">
             {categories.map((c) => (
-              <li
-                key={c.id}
-                className="flex items-center justify-between px-6 py-3"
-              >
-                <span className="text-sm font-medium text-zinc-900">
-                  {c.name}
-                </span>
-                <span className="text-xs text-zinc-500">
-                  Order {c.sortOrder}
-                </span>
+              <li key={c.id}>
+                <span className="ss-list-name">{c.name}</span>
+                <span className="ss-list-meta">Order {c.sortOrder}</span>
               </li>
             ))}
           </ul>
-        </Card>
-      )}
-      <div>
-        <Link
-          href="/services"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to services
-        </Link>
-      </div>
-    </div>
+        )}
+      </Card>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/services/new/page.tsx
+++ b/apps/web/src/app/(app)/services/new/page.tsx
@@ -7,10 +7,16 @@ import { createServiceAction } from "../_actions";
 export default async function NewServicePage() {
   const categories = await apiFetch<CategoryOption[]>("/service-categories");
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Menu"
         title="New service"
         description="Add a service to the catalog."
+        action={
+          <Link href="/services" className="ss-link">
+            ← Back to services
+          </Link>
+        }
       />
       <Card>
         <ServiceForm
@@ -19,14 +25,6 @@ export default async function NewServicePage() {
           submitLabel="Create service"
         />
       </Card>
-      <div>
-        <Link
-          href="/services"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to services
-        </Link>
-      </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/services/page.tsx
+++ b/apps/web/src/app/(app)/services/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { apiFetch } from "@/lib/api";
 import { Button, Card, PageHeader } from "@/components/form";
+import { categoryKind, type CategoryKind } from "@/lib/service-categories";
 
 interface Category {
   id: string;
@@ -22,12 +23,16 @@ export default async function ServicesPage() {
   const services = await apiFetch<ServiceRow[]>("/services");
 
   // Group by category for the list view; uncategorized lands at the bottom.
-  const groups = new Map<string, { name: string; services: ServiceRow[] }>();
+  const groups = new Map<
+    string,
+    { name: string; kind: CategoryKind; services: ServiceRow[] }
+  >();
   const uncat: ServiceRow[] = [];
   for (const s of services) {
     if (s.category) {
       const g = groups.get(s.category.id) ?? {
         name: s.category.name,
+        kind: categoryKind({ categoryName: s.category.name }),
         services: [],
       };
       g.services.push(s);
@@ -36,91 +41,113 @@ export default async function ServicesPage() {
       uncat.push(s);
     }
   }
+  const sortedGroups = [...groups.values()].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+  );
 
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Menu"
         title="Services"
-        description="The catalog of bookable services."
+        description={`${services.length} bookable service${services.length === 1 ? "" : "s"}.`}
         action={
-          <div className="flex gap-2">
+          <div style={{ display: "flex", gap: 8 }}>
             <Link href="/services/categories">
               <Button variant="secondary">Categories</Button>
             </Link>
             <Link href="/services/new">
-              <Button>New service</Button>
+              <Button>+ New service</Button>
             </Link>
           </div>
         }
       />
+
       {services.length === 0 ? (
         <Card>
-          <p className="text-sm text-zinc-500">
+          <p className="ss-empty">
             No services yet. Add one to start booking appointments.
           </p>
         </Card>
       ) : (
-        <div className="space-y-6">
-          {[...groups.values()]
-            .map((g) => ({ ...g, sortKey: g.name.toLowerCase() }))
-            .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
-            .map((g) => (
-              <ServiceGroup
-                key={g.name}
-                title={g.name}
-                services={g.services}
-              />
-            ))}
+        <>
+          {sortedGroups.map((g) => (
+            <ServiceSection
+              key={g.name}
+              title={g.name}
+              kind={g.kind}
+              services={g.services}
+            />
+          ))}
           {uncat.length > 0 && (
-            <ServiceGroup title="Uncategorized" services={uncat} />
+            <ServiceSection title="Uncategorized" kind="cut" services={uncat} />
           )}
-        </div>
+        </>
       )}
-    </div>
+    </>
   );
 }
 
-function ServiceGroup({
+function ServiceSection({
   title,
+  kind,
   services,
 }: {
   title: string;
+  kind: CategoryKind;
   services: ServiceRow[];
 }) {
   return (
-    <section className="space-y-3">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
-        {title}
-      </h2>
-      <Card className="p-0">
-        <ul className="divide-y divide-zinc-200">
-          {services.map((s) => (
-            <li key={s.id}>
-              <Link
-                href={`/services/${s.id}`}
-                className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-zinc-50"
-              >
-                <div>
-                  <div className="text-sm font-medium text-zinc-900">
-                    {s.name}
-                  </div>
-                  <div className="text-xs text-zinc-500">{s.slug}</div>
-                </div>
-                <div className="flex items-center gap-4 text-sm text-zinc-600">
-                  <span>{s.defaultDurationMinutes} min</span>
-                  <span>{formatPrice(s.defaultPriceCents, s.currency)}</span>
-                  {!s.isActive && (
-                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
-                      Inactive
-                    </span>
-                  )}
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </Card>
+    <section className={`ss-svc-section is-${kind}`}>
+      <header className="ss-svc-section-head">
+        <div className="ss-svc-section-rule" />
+        <div className="ss-svc-section-title">
+          <h3>{title}</h3>
+          <span className="ss-svc-section-count">
+            {services.length} service{services.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      </header>
+      <div className="ss-svc-grid">
+        {services.map((s) => (
+          <Link key={s.id} href={`/services/${s.id}`} className="ss-svc-card">
+            <div className="ss-svc-icon">
+              <ScissorsIcon />
+            </div>
+            <div>
+              <div className="ss-svc-name">{s.name}</div>
+              <div className="ss-svc-desc">{s.slug}</div>
+            </div>
+            <div className="ss-svc-meta">
+              <div className="ss-svc-price">
+                {formatPrice(s.defaultPriceCents, s.currency)}
+              </div>
+              <div className="ss-svc-dur">{s.defaultDurationMinutes} min</div>
+              {!s.isActive && (
+                <div className="ss-svc-inactive">Inactive</div>
+              )}
+            </div>
+          </Link>
+        ))}
+      </div>
     </section>
+  );
+}
+
+function ScissorsIcon() {
+  return (
+    <svg
+      width={22}
+      height={22}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M14.121 14.121 20 20M5.636 18.364a3 3 0 1 1 4.243-4.243 3 3 0 0 1-4.243 4.243Zm0-12.728a3 3 0 1 1 4.243 4.243 3 3 0 0 1-4.243-4.243Zm6.364 6.364L20 4" />
+    </svg>
   );
 }
 

--- a/apps/web/src/app/(app)/settings/_components/settings-form.tsx
+++ b/apps/web/src/app/(app)/settings/_components/settings-form.tsx
@@ -28,12 +28,10 @@ export function SettingsForm({
   );
   const errors = state?.errors ?? {};
   return (
-    <form action={formAction} className="space-y-5">
-      <FormError message={state?.message} />
+    <form action={formAction} className="ss-form">
+      <FormError message={state?.errors?._ ?? (state?.errors ? state?.message : undefined)} />
       {state?.message && !state.errors && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
-          {state.message}
-        </div>
+        <div className="ss-form-success">{state.message}</div>
       )}
       <Field label="Salon name" name="name" error={errors.name}>
         <Input
@@ -67,7 +65,7 @@ export function SettingsForm({
           ))}
         </Select>
       </Field>
-      <div>
+      <div className="ss-form-actions">
         <Button type="submit" disabled={pending}>
           {pending ? "Saving…" : "Save settings"}
         </Button>

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -12,12 +12,13 @@ interface SalonSettings {
 export default async function SettingsPage() {
   const settings = await apiFetch<SalonSettings>("/settings");
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Studio"
         title="Settings"
         description="Salon profile and timezone. Business hours, branding, and integrations land later."
       />
-      <Card>
+      <Card title="Studio profile" meta="Public">
         <SettingsForm
           defaults={{
             name: settings.name,
@@ -26,6 +27,6 @@ export default async function SettingsPage() {
           }}
         />
       </Card>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/staff/[id]/page.tsx
+++ b/apps/web/src/app/(app)/staff/[id]/page.tsx
@@ -51,48 +51,35 @@ export default async function StaffDetailPage({
   };
 
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Stylist"
         title={staff.displayName}
         description={staff.title ?? "Stylist"}
+        action={
+          <Link href="/staff" className="ss-link">
+            ← Back to staff
+          </Link>
+        }
       />
 
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
-          Profile
-        </h2>
-        <Card>
-          <StaffForm
-            action={updateAction}
-            submitLabel="Save changes"
-            defaults={{
-              displayName: staff.displayName,
-              title: staff.title,
-              color: staff.color,
-              bio: staff.bio,
-              isActive: staff.isActive,
-            }}
-          />
-        </Card>
-      </section>
+      <Card title="Profile" meta={staff.isActive ? "Active" : "Inactive"}>
+        <StaffForm
+          action={updateAction}
+          submitLabel="Save changes"
+          defaults={{
+            displayName: staff.displayName,
+            title: staff.title,
+            color: staff.color,
+            bio: staff.bio,
+            isActive: staff.isActive,
+          }}
+        />
+      </Card>
 
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">
-          Working hours
-        </h2>
-        <Card>
-          <WorkingHoursForm action={hoursAction} initial={staff.workingHours} />
-        </Card>
-      </section>
-
-      <div>
-        <Link
-          href="/staff"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to staff
-        </Link>
-      </div>
-    </div>
+      <Card title="Working hours" meta="Per weekday">
+        <WorkingHoursForm action={hoursAction} initial={staff.workingHours} />
+      </Card>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/staff/_components/staff-form.tsx
+++ b/apps/web/src/app/(app)/staff/_components/staff-form.tsx
@@ -34,7 +34,7 @@ export function StaffForm({
   );
   const errors = state?.errors ?? {};
   return (
-    <form action={formAction} className="space-y-5">
+    <form action={formAction} className="ss-form">
       <FormError message={state?.message} />
       <Field label="Display name" name="displayName" error={errors.displayName}>
         <Input
@@ -82,7 +82,7 @@ export function StaffForm({
         label="Active (shows on the schedule)"
         defaultChecked={defaults?.isActive ?? true}
       />
-      <div>
+      <div className="ss-form-actions">
         <Button type="submit" disabled={pending}>
           {pending ? "Saving…" : submitLabel}
         </Button>

--- a/apps/web/src/app/(app)/staff/_components/working-hours-form.tsx
+++ b/apps/web/src/app/(app)/staff/_components/working-hours-form.tsx
@@ -34,15 +34,13 @@ export function WorkingHoursForm({
   );
 
   return (
-    <form action={formAction} className="space-y-4">
+    <form action={formAction} className="ss-form">
       <FormError message={state?.errors?._ ?? state?.errors?.windows} />
       {state?.message && !state.errors && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
-          {state.message}
-        </div>
+        <div className="ss-form-success">{state.message}</div>
       )}
       <input type="hidden" name="windows" value={JSON.stringify(allWindows)} />
-      <div className="space-y-2">
+      <div className="ss-hours-grid">
         {DAY_LABELS.map((label, day) => (
           <DayRow
             key={day}
@@ -80,9 +78,11 @@ export function WorkingHoursForm({
           />
         ))}
       </div>
-      <Button type="submit" disabled={pending}>
-        {pending ? "Saving…" : "Save working hours"}
-      </Button>
+      <div className="ss-form-actions">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : "Save working hours"}
+        </Button>
+      </div>
     </form>
   );
 }
@@ -103,14 +103,12 @@ function DayRow({
   onRemove: (idx: number) => void;
 }) {
   return (
-    <div className="flex items-start gap-3 rounded-md border border-zinc-200 bg-white p-3">
-      <div className="w-12 pt-2 text-sm font-medium text-zinc-700">{label}</div>
-      <div className="flex-1 space-y-2">
-        {windows.length === 0 && (
-          <div className="text-sm text-zinc-400">Closed</div>
-        )}
+    <div className="ss-hours-row">
+      <div className="ss-hours-label">{label}</div>
+      <div className="ss-hours-windows">
+        {windows.length === 0 && <div className="ss-hours-closed">Closed</div>}
         {windows.map((w, idx) => (
-          <div key={idx} className="flex items-center gap-2">
+          <div key={idx} className="ss-hours-window">
             <input
               type="time"
               value={minutesToHHMM(w.startMinutesFromMidnight)}
@@ -121,9 +119,9 @@ function DayRow({
                   startMinutesFromMidnight: hhmmToMinutes(e.target.value),
                 })
               }
-              className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm"
+              className="ss-hours-input"
             />
-            <span className="text-sm text-zinc-400">to</span>
+            <span className="ss-hours-sep">to</span>
             <input
               type="time"
               value={minutesToHHMM(w.endMinutesFromMidnight)}
@@ -134,23 +132,19 @@ function DayRow({
                   endMinutesFromMidnight: hhmmToMinutes(e.target.value),
                 })
               }
-              className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-sm"
+              className="ss-hours-input"
             />
             <button
               type="button"
               onClick={() => onRemove(idx)}
-              className="ml-2 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-600 hover:bg-zinc-50"
+              className="ss-btn ss-btn-ghost ss-btn-tiny"
             >
               Remove
             </button>
           </div>
         ))}
       </div>
-      <button
-        type="button"
-        onClick={onAdd}
-        className="rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-50"
-      >
+      <button type="button" onClick={onAdd} className="ss-btn ss-btn-ghost ss-btn-tiny">
         + window
       </button>
     </div>

--- a/apps/web/src/app/(app)/staff/new/page.tsx
+++ b/apps/web/src/app/(app)/staff/new/page.tsx
@@ -5,22 +5,20 @@ import { createStaffAction } from "../_actions";
 
 export default function NewStaffPage() {
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Team"
         title="New stylist"
         description="Add a stylist to the schedule."
+        action={
+          <Link href="/staff" className="ss-link">
+            ← Back to staff
+          </Link>
+        }
       />
       <Card>
         <StaffForm action={createStaffAction} submitLabel="Create stylist" />
       </Card>
-      <div>
-        <Link
-          href="/staff"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
-          ← Back to staff
-        </Link>
-      </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/staff/page.tsx
+++ b/apps/web/src/app/(app)/staff/page.tsx
@@ -12,58 +12,65 @@ interface StaffRow {
 
 export default async function StaffPage() {
   const staff = await apiFetch<StaffRow[]>("/staff");
+  const active = staff.filter((s) => s.isActive);
+  const inactive = staff.filter((s) => !s.isActive);
 
   return (
-    <div className="space-y-6">
+    <>
       <PageHeader
+        eyebrow="Team"
         title="Staff"
-        description="Stylists, working hours, and roles."
+        description={`${active.length} active${inactive.length > 0 ? `, ${inactive.length} inactive` : ""}.`}
         action={
           <Link href="/staff/new">
-            <Button>New stylist</Button>
+            <Button>+ New stylist</Button>
           </Link>
         }
       />
+
       {staff.length === 0 ? (
         <Card>
-          <p className="text-sm text-zinc-500">
+          <p className="ss-empty">
             No staff yet. Add your first stylist to start scheduling.
           </p>
         </Card>
       ) : (
-        <Card className="p-0">
-          <ul className="divide-y divide-zinc-200">
-            {staff.map((s) => (
-              <li key={s.id}>
-                <Link
-                  href={`/staff/${s.id}`}
-                  className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-zinc-50"
+        <div className="ss-chair-strip">
+          {staff.map((s) => (
+            <Link key={s.id} href={`/staff/${s.id}`} className="ss-chair">
+              <div className="ss-chair-head">
+                <div
+                  className="ss-chair-avatar"
+                  style={{
+                    background: s.color
+                      ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                      : "linear-gradient(135deg, #1ec3d9, #0892a8)",
+                  }}
                 >
-                  <div className="flex items-center gap-3">
-                    <div
-                      className="h-3 w-3 rounded-full border border-zinc-200"
-                      style={{ backgroundColor: s.color ?? "#e5e7eb" }}
-                    />
-                    <div>
-                      <div className="text-sm font-medium text-zinc-900">
-                        {s.displayName}
-                      </div>
-                      {s.title && (
-                        <div className="text-xs text-zinc-500">{s.title}</div>
-                      )}
-                    </div>
-                  </div>
-                  {!s.isActive && (
-                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
-                      Inactive
-                    </span>
-                  )}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </Card>
+                  {initialsOf(s.displayName)}
+                </div>
+                <div>
+                  <div className="ss-chair-name">{s.displayName}</div>
+                  {s.title && <div className="ss-chair-role">{s.title}</div>}
+                </div>
+              </div>
+              <div className="ss-chair-stat">
+                <span>{s.isActive ? "Active" : "Inactive"}</span>
+                <strong>Edit →</strong>
+              </div>
+            </Link>
+          ))}
+        </div>
       )}
-    </div>
+    </>
   );
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
 }

--- a/apps/web/src/components/empty-state.tsx
+++ b/apps/web/src/components/empty-state.tsx
@@ -10,17 +10,15 @@ export function EmptyState({
   phase?: string;
 }) {
   return (
-    <div className="rounded-2xl border border-zinc-200 bg-white p-10 shadow-sm">
-      <div className="mx-auto max-w-md text-center">
+    <div className="ss-card ss-empty-card">
+      <div className="ss-empty-inner">
         {phase && (
-          <div className="mb-3 flex justify-center">
+          <div className="ss-empty-tag">
             <PhaseTag phase={phase} />
           </div>
         )}
-        <h2 className="text-lg font-semibold tracking-tight text-zinc-900">
-          {title}
-        </h2>
-        <p className="mt-2 text-sm leading-relaxed text-zinc-500">{body}</p>
+        <h2 className="ss-empty-title">{title}</h2>
+        <p className="ss-empty-body">{body}</p>
       </div>
     </div>
   );

--- a/apps/web/src/components/form.tsx
+++ b/apps/web/src/components/form.tsx
@@ -1,5 +1,6 @@
-// Lightweight form primitives. Tailwind classes inline to keep the component
-// surface obvious — when there are 5 of these the styling is the value.
+// Form primitives that render the Tresses design system. Each one is a thin
+// wrapper around `.ss-*` classes — pages don't need to know the class names,
+// they just compose <Field>/<Input>/<Button>/<Card>.
 
 interface FieldProps {
   label: string;
@@ -11,62 +12,32 @@ interface FieldProps {
 
 export function Field({ label, name, hint, error, children }: FieldProps) {
   return (
-    <div className="space-y-1.5">
-      <label
-        htmlFor={name}
-        className="block text-sm font-medium text-zinc-800"
-      >
-        {label}
-      </label>
+    <div className="ss-field">
+      <label htmlFor={name}>{label}</label>
       {children}
-      {hint && !error && (
-        <p className="text-xs text-zinc-500">{hint}</p>
-      )}
-      {error && <p className="text-xs text-red-600">{error}</p>}
+      {hint && !error && <p className="ss-field-hint">{hint}</p>}
+      {error && <p className="ss-field-error">{error}</p>}
     </div>
   );
 }
 
-export function Input(
-  props: React.InputHTMLAttributes<HTMLInputElement>,
-) {
-  return (
-    <input
-      {...props}
-      className={
-        "block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 " +
-        (props.className ?? "")
-      }
-    />
-  );
+export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  // Inputs/selects/textareas inherit shape from .ss-field input/select/textarea
+  // — the className escape hatch is rarely needed. Keep it forwarded for the
+  // few places that want a width override.
+  return <input {...props} />;
 }
 
 export function Textarea(
   props: React.TextareaHTMLAttributes<HTMLTextAreaElement>,
 ) {
-  return (
-    <textarea
-      {...props}
-      className={
-        "block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 " +
-        (props.className ?? "")
-      }
-    />
-  );
+  return <textarea {...props} />;
 }
 
 export function Select(
   props: React.SelectHTMLAttributes<HTMLSelectElement>,
 ) {
-  return (
-    <select
-      {...props}
-      className={
-        "block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 " +
-        (props.className ?? "")
-      }
-    />
-  );
+  return <select {...props} />;
 }
 
 export function Checkbox({
@@ -74,13 +45,9 @@ export function Checkbox({
   ...props
 }: { label: string } & React.InputHTMLAttributes<HTMLInputElement>) {
   return (
-    <label className="inline-flex items-center gap-2 text-sm text-zinc-800">
-      <input
-        type="checkbox"
-        {...props}
-        className="h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-500"
-      />
-      {label}
+    <label className="ss-checkbox">
+      <input type="checkbox" {...props} />
+      <span>{label}</span>
     </label>
   );
 }
@@ -92,69 +59,68 @@ export function Button(
 ) {
   const { variant = "primary", className, ...rest } = props;
   const palette =
-    variant === "primary"
-      ? "bg-zinc-900 text-white hover:bg-zinc-800"
-      : "bg-white text-zinc-800 border border-zinc-300 hover:bg-zinc-50";
+    variant === "primary" ? "ss-btn ss-btn-primary" : "ss-btn ss-btn-ghost";
   return (
     <button
       {...rest}
-      className={
-        "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed " +
-        palette +
-        " " +
-        (className ?? "")
-      }
+      className={`${palette}${className ? " " + className : ""}`}
     />
   );
 }
 
 export function FormError({ message }: { message: string | null | undefined }) {
   if (!message) return null;
-  return (
-    <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-      {message}
-    </div>
-  );
+  return <div className="ss-form-error">{message}</div>;
 }
 
 export function PageHeader({
   title,
   description,
+  eyebrow,
   action,
 }: {
   title: string;
   description?: string;
+  eyebrow?: string;
   action?: React.ReactNode;
 }) {
   return (
-    <header className="flex items-start justify-between gap-4">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
-          {title}
-        </h1>
-        {description && (
-          <p className="mt-1 text-sm text-zinc-500">{description}</p>
-        )}
-      </div>
-      {action && <div className="shrink-0">{action}</div>}
-    </header>
+    <div className="ss-page-head-row">
+      <header className="ss-page-head">
+        {eyebrow && <div className="ss-page-eyebrow">{eyebrow}</div>}
+        <h2 className="ss-page-title">{title}</h2>
+        {description && <p className="ss-page-sub">{description}</p>}
+      </header>
+      {action && <div className="ss-page-head-action">{action}</div>}
+    </div>
   );
 }
 
 export function Card({
   children,
   className,
+  title,
+  meta,
+  noPadding,
 }: {
   children: React.ReactNode;
   className?: string;
+  title?: string;
+  meta?: string;
+  // Some lists want a flush card (e.g. tables) — toggle this and the inner
+  // padding goes away.
+  noPadding?: boolean;
 }) {
   return (
     <div
-      className={
-        "rounded-xl border border-zinc-200 bg-white p-6 shadow-sm " +
-        (className ?? "")
-      }
+      className={`ss-card${noPadding ? " is-flush" : ""}${className ? " " + className : ""}`}
     >
+      {(title || meta) && (
+        <div className="ss-card-head">
+          {title && <h3 className="ss-card-title">{title}</h3>}
+          {meta && <span className="ss-card-meta">{meta}</span>}
+        </div>
+      )}
       {children}
     </div>
   );

--- a/apps/web/src/components/phase-tag.tsx
+++ b/apps/web/src/components/phase-tag.tsx
@@ -1,7 +1,3 @@
 export function PhaseTag({ phase }: { phase: string }) {
-  return (
-    <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 ring-1 ring-amber-200">
-      {phase}
-    </span>
-  );
+  return <span className="ss-phase-tag">{phase}</span>;
 }

--- a/apps/web/src/lib/appointment-status.ts
+++ b/apps/web/src/lib/appointment-status.ts
@@ -1,0 +1,34 @@
+// Single source of truth for how each appointment status renders. Used by
+// the schedule view, the dashboard timeline, and the client-history list so
+// a CANCELLED row never picks up confirmed-styling and an IN_PROGRESS row
+// always reads as in-progress, etc.
+
+export type AppointmentStatus =
+  | "SCHEDULED"
+  | "CONFIRMED"
+  | "CHECKED_IN"
+  | "IN_PROGRESS"
+  | "COMPLETED"
+  | "CANCELLED"
+  | "NO_SHOW";
+
+interface PillStyle {
+  /** CSS modifier on `.ss-status-pill` (defined in styles.css + extras). */
+  cls: string;
+  /** Human label for the pill. */
+  label: string;
+}
+
+const PILLS: Record<AppointmentStatus, PillStyle> = {
+  SCHEDULED:   { cls: "is-pending",   label: "scheduled" },
+  CONFIRMED:   { cls: "is-confirmed", label: "confirmed" },
+  CHECKED_IN:  { cls: "is-checked",   label: "checked in" },
+  IN_PROGRESS: { cls: "is-progress",  label: "in progress" },
+  COMPLETED:   { cls: "is-checked",   label: "completed" },
+  CANCELLED:   { cls: "is-cancelled", label: "cancelled" },
+  NO_SHOW:     { cls: "is-cancelled", label: "no-show" },
+};
+
+export function statusPill(status: AppointmentStatus): PillStyle {
+  return PILLS[status];
+}

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -789,3 +789,220 @@
   text-underline-offset: 2px;
 }
 .ss-link:hover { color: var(--ss-magenta); }
+
+/* ====================================================
+   Phase 3c — restyled CRUD pages: forms, list helpers,
+   page headers, empty states, links.
+==================================================== */
+
+.ss-page-head-row {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 24px;
+  flex-wrap: wrap;
+}
+.ss-page-head-row .ss-page-head { margin: 0; flex: 1; min-width: 240px; }
+.ss-page-head-action { padding-top: 6px; }
+
+.ss-toolbar {
+  display: flex; align-items: center; gap: 10px;
+  margin: 0 0 18px;
+  flex-wrap: wrap;
+}
+.ss-toolbar-search { max-width: 360px; flex: 1; min-width: 220px; }
+
+.ss-empty {
+  margin: 0;
+  padding: 24px;
+  color: var(--ss-text-secondary);
+  font-size: 13.5px;
+  text-align: center;
+}
+.ss-empty-card { padding: 36px 24px; text-align: center; }
+.ss-empty-inner { max-width: 440px; margin: 0 auto; }
+.ss-empty-tag { display: flex; justify-content: center; margin-bottom: 12px; }
+.ss-empty-title {
+  font-family: var(--font-cormorant), serif;
+  font-size: 22px; font-weight: 600;
+  color: var(--ss-text-heading);
+  margin: 0 0 6px;
+}
+.ss-empty-body {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--ss-text-secondary);
+  line-height: 1.55;
+}
+
+.ss-phase-tag {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--ss-magenta-deep);
+  background: var(--ss-magenta-pale);
+  border-radius: 999px;
+}
+
+/* Form layout. Replaces the Tailwind `space-y-5` / `grid-cols-2` patterns
+   the Phase 2 pages used so all the CRUD forms inherit the same look. */
+.ss-form { display: flex; flex-direction: column; gap: 0; }
+.ss-form > .ss-field { margin-bottom: 14px; }
+.ss-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.ss-form-row > .ss-field { margin-bottom: 14px; }
+@media (max-width: 720px) {
+  .ss-form-row { grid-template-columns: 1fr; gap: 0; }
+}
+.ss-form-actions {
+  display: flex; align-items: center; gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+.ss-form-error {
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(212, 74, 110, 0.08);
+  border: 1px solid rgba(212, 74, 110, 0.32);
+  color: #842842;
+  font-size: 13px;
+  margin-bottom: 14px;
+}
+.ss-form-success {
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(93, 176, 117, 0.10);
+  border: 1px solid rgba(93, 176, 117, 0.30);
+  color: #2e6b3d;
+  font-size: 13px;
+  margin-bottom: 14px;
+}
+.ss-form-success-inline {
+  font-size: 12.5px;
+  color: #2e6b3d;
+}
+.ss-field-hint {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  color: var(--ss-text-muted);
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 400;
+}
+.ss-field-error {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  color: #b8254a;
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 500;
+}
+
+.ss-checkbox {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13.5px;
+  color: var(--ss-text-primary);
+  font-family: var(--font-quicksand), sans-serif;
+  cursor: pointer;
+  margin-bottom: 14px;
+}
+.ss-checkbox input[type="checkbox"] {
+  width: 16px; height: 16px;
+  accent-color: var(--ss-magenta);
+}
+
+/* Working-hours editor. */
+.ss-hours-grid { display: flex; flex-direction: column; gap: 8px; }
+.ss-hours-row {
+  display: flex; align-items: flex-start; gap: 14px;
+  padding: 12px;
+  background: var(--ss-panel-strong);
+  border: 1px solid var(--ss-line);
+  border-radius: 12px;
+}
+.ss-hours-label {
+  width: 44px;
+  padding-top: 6px;
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ss-text-secondary);
+}
+.ss-hours-windows { flex: 1; display: flex; flex-direction: column; gap: 8px; }
+.ss-hours-closed { font-size: 12.5px; color: var(--ss-text-muted); padding-top: 6px; }
+.ss-hours-window { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ss-hours-input {
+  padding: 6px 10px;
+  font-size: 13px;
+  border-radius: 8px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel);
+  color: var(--ss-text-primary);
+  font-family: var(--font-quicksand), sans-serif;
+}
+.ss-hours-input:focus {
+  outline: none;
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 3px rgba(30, 195, 217, 0.16);
+}
+.ss-hours-sep { font-size: 12.5px; color: var(--ss-text-muted); }
+.ss-btn-tiny { padding: 6px 10px; font-size: 12px; }
+
+/* Card variant: flush table inside. */
+.ss-card.is-flush { padding: 0; }
+.ss-card.is-flush .ss-card-head {
+  padding: 18px 22px 0;
+}
+.ss-card.is-flush > .ss-table { margin-top: 0; }
+.ss-card.is-flush > .ss-stack-list,
+.ss-card.is-flush > .ss-history { padding: 0; }
+
+/* Plain bullet-less list for category management. */
+.ss-stack-list {
+  list-style: none; margin: 0; padding: 0;
+}
+.ss-stack-list li {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 22px;
+  border-top: 1px solid var(--ss-line);
+  font-size: 13.5px;
+}
+.ss-stack-list li:first-child { border-top: 0; }
+.ss-list-name { color: var(--ss-text-heading); font-weight: 500; }
+.ss-list-meta { color: var(--ss-text-muted); font-size: 12px; }
+
+/* Appointment history list (client profile). */
+.ss-history { list-style: none; margin: 0; padding: 0; }
+.ss-history-row {
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 16px;
+  padding: 14px 0;
+  border-top: 1px solid var(--ss-line);
+}
+.ss-history-row:first-child { border-top: 0; }
+
+/* Inactive badge on service cards. */
+.ss-svc-inactive {
+  font-size: 10.5px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.16em;
+  color: var(--ss-text-muted);
+  margin-top: 4px;
+}
+
+/* Plain link variant for inline names in lists — no underline by default. */
+.ss-link-plain {
+  color: var(--ss-text-heading);
+  text-decoration: none;
+}
+.ss-link-plain:hover { color: var(--ss-magenta-deep); }
+
+/* Quick-actions tweak: original CSS expected an icon — we only have a label,
+   so center it. */
+.ss-action {
+  text-decoration: none;
+}
+.ss-action .ss-action-title { width: 100%; text-align: center; }

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1006,3 +1006,16 @@
   text-decoration: none;
 }
 .ss-action .ss-action-title { width: 100%; text-align: center; }
+
+/* Cancelled / no-show: muted neutral so a CANCELLED appointment in the
+   client history doesn't visually read as confirmed. */
+.ss-status-pill.is-cancelled {
+  background: rgba(122, 163, 173, 0.18);
+  color: var(--ss-text-muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+.theme-twilight .ss-status-pill.is-cancelled {
+  background: rgba(168, 200, 208, 0.14);
+  color: var(--ss-text-muted);
+}


### PR DESCRIPTION
## Summary

Brings every Phase 2 page onto the Tresses design classes so they match the dreamy shell that 3b shipped.

- **Dashboard** — live: today's appointment timeline (.ss-appt blocks with status pills), three stat cards (today / staff / quick action), per-stylist booked-percent strip.
- **Clients** — `.ss-table` inside an `.ss-card` with the search bar; client detail page is an editable profile card + appointment history list.
- **Staff** — chair strip on the list page (gradient avatars), keeping the existing per-stylist edit + working-hours editor flow but with design styling.
- **Services** — the `.ss-svc-section` pattern (color-coded by category kind via the same `categoryKind` mapper the schedule view uses); categories management with `.ss-stack-list`.
- **Settings** — studio-profile card under the new form layout.
- **form.tsx primitives** now wrap `.ss-*` classes (`.ss-field`, `.ss-btn-*`, `.ss-card` with optional `title`/`meta`). Pages don't need to know the design class names; existing call sites just kept working. Tailwind grid/space-y patterns swap to `.ss-form` / `.ss-form-row` / `.ss-form-actions` / `.ss-form-success`.
- **empty-state + phase-tag** also moved off Tailwind onto the design classes.

CSS additions land in `styles-extra.css` — none of the existing styles were touched.

## Test plan

- [x] `pnpm -r typecheck` clean across all packages.
- [x] `next dev` starts and `/sign-in` returns 200.
- [ ] Manual UI dogfood (couldn't fully exercise from the agent — needs DB):
  - Dashboard renders today's seeded appointments with the right status pills and stylist breakdown.
  - Clients list shows the search bar + table; clicking a row opens the editable profile.
  - Staff list shows the chair strip; clicking a stylist opens profile + working hours.
  - Services list groups by category with color-coded section heads.
  - Settings page saves timezone + name.
  - All forms (new client / new staff / new service / edit settings) submit and surface field-level errors.