### PR TITLE
Phase 3d: restyle sign-in + client profile hero

### DIFF
--- a/apps/web/src/app/(app)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(app)/clients/[id]/page.tsx
@@ -241,9 +241,12 @@ function truncate(s: string, max: number): string {
 }
 
 function formatPrice(cents: number, currency: string): string {
+  // Format with the currency's natural minor units. Hardcoding
+  // maximumFractionDigits:0 truncates real cents (e.g., $54.99 → $55) and the
+  // services list elsewhere already shows full precision — this stays
+  // consistent with that.
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
-    maximumFractionDigits: 0,
   }).format(cents / 100);
 }

--- a/apps/web/src/app/(app)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(app)/clients/[id]/page.tsx
@@ -48,10 +48,25 @@ export default async function ClientDetailPage({
     return updateClientAction(id, state, formData);
   };
 
+  // Lifetime spend: sum every service snapshot across every visit. Currency
+  // is taken from the first service we see — a salon could in theory have
+  // multi-currency rows, but in that edge case the formatted total is still
+  // a reasonable approximation.
+  const lifetimeCents = client.appointments.reduce(
+    (acc, a) =>
+      acc + a.services.reduce((s, sv) => s + sv.priceSnapshotCents, 0),
+    0,
+  );
+  const currency =
+    client.appointments[0]?.services[0]?.currencySnapshot ?? "USD";
+  const lastVisit = client.appointments
+    .filter((a) => new Date(a.startAt).getTime() <= Date.now())
+    .sort((a, b) => b.startAt.localeCompare(a.startAt))[0];
+
   return (
     <>
       <PageHeader
-        eyebrow="Client"
+        eyebrow={`Clients · ${client.displayName}`}
         title={client.displayName}
         description={
           [client.phone, client.email].filter(Boolean).join(" · ") ||
@@ -64,58 +79,171 @@ export default async function ClientDetailPage({
         }
       />
 
-      <Card title="Profile" meta="Editable">
-        <ClientForm
-          action={action}
-          submitLabel="Save changes"
-          defaults={{
-            firstName: client.firstName,
-            lastName: client.lastName,
-            displayName: client.displayName,
-            email: client.email,
-            phone: client.phone,
-            notes: client.notes,
-          }}
-        />
-      </Card>
+      <div className="ss-profile-grid">
+        <div>
+          <div className="ss-profile-hero">
+            <div className="ss-profile-photo">
+              {initialsOf(client.displayName)}
+            </div>
+            <h3 className="ss-profile-name">{client.displayName}</h3>
+            <div className="ss-profile-since">
+              {client.appointments.length > 0
+                ? `${client.appointments.length} visit${client.appointments.length === 1 ? "" : "s"} on the books`
+                : "No appointments yet"}
+            </div>
 
-      <Card title="Appointment history" meta={`${client.appointments.length} on record`}>
-        {client.appointments.length === 0 ? (
-          <p className="ss-empty">No appointments yet.</p>
-        ) : (
-          <ul className="ss-history">
-            {client.appointments.map((a) => {
-              const pill = statusPill(a.status);
-              return (
-                <li key={a.id} className="ss-history-row">
-                  <div>
-                    <div className="ss-history-svc">
-                      {a.services
-                        .map((s) => s.serviceNameSnapshot)
-                        .join(" · ") || "—"}
-                    </div>
-                    <div className="ss-history-meta">
-                      With <strong>{a.staffMember.displayName}</strong>
-                    </div>
-                  </div>
-                  <div style={{ textAlign: "right" }}>
-                    <div className="ss-history-date">
-                      {new Date(a.startAt).toLocaleDateString(undefined, {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
-                    </div>
-                    <span className={`ss-status-pill ${pill.cls}`}>
-                      {pill.label}
-                    </span>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </Card>
+            {client.notes && (
+              <div className="ss-profile-tags">
+                <span className="ss-tag is-regular">{truncate(client.notes, 32)}</span>
+              </div>
+            )}
+
+            <div className="ss-profile-actions">
+              <Link href="/schedule" className="ss-btn ss-btn-primary ss-btn-block">
+                <PlusIcon /> Book
+              </Link>
+            </div>
+
+            <dl className="ss-profile-meta">
+              <div>
+                <dt>Phone</dt>
+                <dd>{client.phone ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>Email</dt>
+                <dd>{client.email ?? "—"}</dd>
+              </div>
+              <div>
+                <dt>First name</dt>
+                <dd>{client.firstName}</dd>
+              </div>
+              <div>
+                <dt>Last name</dt>
+                <dd>{client.lastName ?? "—"}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+
+        <div className="ss-profile-side">
+          <div className="ss-profile-stats">
+            <div className="ss-mini-stat">
+              <div className="ss-mini-stat-v">{client.appointments.length}</div>
+              <div className="ss-mini-stat-l">visits</div>
+            </div>
+            <div className="ss-mini-stat">
+              <div className="ss-mini-stat-v">
+                {formatPrice(lifetimeCents, currency)}
+              </div>
+              <div className="ss-mini-stat-l">lifetime</div>
+            </div>
+            <div className="ss-mini-stat">
+              <div className="ss-mini-stat-v">
+                {lastVisit
+                  ? new Date(lastVisit.startAt).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })
+                  : "—"}
+              </div>
+              <div className="ss-mini-stat-l">last visit</div>
+            </div>
+          </div>
+
+          <Card title="Profile" meta="Editable">
+            <ClientForm
+              action={action}
+              submitLabel="Save changes"
+              defaults={{
+                firstName: client.firstName,
+                lastName: client.lastName,
+                displayName: client.displayName,
+                email: client.email,
+                phone: client.phone,
+                notes: client.notes,
+              }}
+            />
+          </Card>
+
+          <Card
+            title="Appointment history"
+            meta={`${client.appointments.length} on record`}
+          >
+            {client.appointments.length === 0 ? (
+              <p className="ss-empty">No appointments yet.</p>
+            ) : (
+              <ul className="ss-history">
+                {client.appointments.map((a) => {
+                  const pill = statusPill(a.status);
+                  return (
+                    <li key={a.id} className="ss-history-row">
+                      <div>
+                        <div className="ss-history-svc">
+                          {a.services
+                            .map((s) => s.serviceNameSnapshot)
+                            .join(" · ") || "—"}
+                        </div>
+                        <div className="ss-history-meta">
+                          With <strong>{a.staffMember.displayName}</strong>
+                        </div>
+                      </div>
+                      <div style={{ textAlign: "right" }}>
+                        <div className="ss-history-date">
+                          {new Date(a.startAt).toLocaleDateString(undefined, {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          })}
+                        </div>
+                        <span className={`ss-status-pill ${pill.cls}`}>
+                          {pill.label}
+                        </span>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </Card>
+        </div>
+      </div>
     </>
   );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      width={13}
+      height={13}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+    >
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
 }

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { SignIn } from "@clerk/nextjs";
 import { getServerSession } from "@/lib/session";
 import { serverEnv } from "@/lib/env";
@@ -10,46 +11,101 @@ export default async function SignInPage() {
   const session = await getServerSession();
   if (session) redirect("/");
 
-  if (serverEnv.authProvider === "clerk") {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-zinc-50 p-6">
-        <SignIn routing="path" path="/sign-in" />
-      </main>
-    );
-  }
-
   return (
-    <main className="flex min-h-screen items-center justify-center bg-zinc-50 p-6">
-      <div className="w-full max-w-sm rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm">
-        <h1 className="text-xl font-semibold tracking-tight text-zinc-900">
-          Sign in
-        </h1>
-        <p className="mt-2 text-sm text-zinc-500">
-          Development identity provider. Set <code>AUTH_PROVIDER=clerk</code> to
-          use Clerk Organizations.
-        </p>
-        <form action="/api/dev-sign-in" method="post" className="mt-6">
-          <div className="rounded-md bg-zinc-50 px-4 py-3 text-xs leading-relaxed text-zinc-600 ring-1 ring-zinc-200">
-            <div>
-              <span className="font-medium text-zinc-700">Dev user:</span>{" "}
-              {serverEnv.devUserEmail}
-            </div>
-            <div>
-              <span className="font-medium text-zinc-700">Dev salon:</span>{" "}
-              {serverEnv.devSalonSlug}
-            </div>
-          </div>
-          <button
-            type="submit"
-            className="mt-4 w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-zinc-800"
-          >
-            Sign in as dev user
-          </button>
-        </form>
-        <p className="mt-4 text-xs text-zinc-400">
-          AUTH_PROVIDER={serverEnv.authProvider}
-        </p>
+    <div className="ss-signin" data-screen-label="signin">
+      <div className="ss-orb ss-orb-magenta" />
+      <div className="ss-orb ss-orb-cyan" />
+      <div className="ss-orb ss-orb-violet" />
+      <div className="ss-motes">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <span
+            key={i}
+            className="ss-mote"
+            style={{
+              left: `${10 + i * 11}%`,
+              bottom: 0,
+              animationDelay: `${i * 1.1}s`,
+              color: i % 2 ? "var(--ss-cyan)" : "var(--ss-magenta)",
+            }}
+          />
+        ))}
       </div>
-    </main>
+
+      <div className="ss-signin-card">
+        <div className="ss-signin-mark">
+          <h1 className="ss-brand-script">Shear</h1>
+          <p className="ss-brand-sub">Simplicity</p>
+        </div>
+
+        {serverEnv.authProvider === "clerk" ? (
+          <ClerkPanel />
+        ) : (
+          <DevPanel
+            email={serverEnv.devUserEmail}
+            slug={serverEnv.devSalonSlug}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ClerkPanel() {
+  return (
+    <>
+      <h2>Welcome back</h2>
+      <p className="ss-signin-sub">Sign in to your studio.</p>
+      {/* Clerk provides its own form chrome; the surrounding card supplies the
+          dreamy frame. */}
+      <SignIn routing="path" path="/sign-in" />
+    </>
+  );
+}
+
+function DevPanel({ email, slug }: { email: string; slug: string }) {
+  return (
+    <>
+      <h2>Welcome back</h2>
+      <p className="ss-signin-sub">
+        Open the studio with the seeded developer identity.
+      </p>
+
+      <div className="ss-dev-pill">
+        <Sparkle /> Dev mode
+      </div>
+
+      <form action="/api/dev-sign-in" method="post" className="ss-signin-dev-form">
+        <div className="ss-signin-dev-info">
+          <div>
+            <span className="ss-signin-dev-label">Studio</span>
+            <span>{slug}</span>
+          </div>
+          <div>
+            <span className="ss-signin-dev-label">User</span>
+            <span>{email}</span>
+          </div>
+        </div>
+        <button
+          type="submit"
+          className="ss-btn ss-btn-primary ss-signin-btn"
+        >
+          Open the studio →
+        </button>
+      </form>
+
+      <p className="ss-signin-foot">
+        Set <code className="ss-signin-code">AUTH_PROVIDER=clerk</code> to use
+        Clerk Organizations instead.{" "}
+        <Link href="/sign-up">Open a studio →</Link>
+      </p>
+    </>
+  );
+}
+
+function Sparkle() {
+  return (
+    <svg width={9} height={9} viewBox="0 0 12 12" fill="currentColor">
+      <path d="M6 0 L7 5 L12 6 L7 7 L6 12 L5 7 L0 6 L5 5 Z" />
+    </svg>
   );
 }

--- a/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -13,8 +13,19 @@ export default async function SignUpPage() {
   if (session) redirect("/");
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-zinc-50 p-6">
-      <SignUp routing="path" path="/sign-up" />
-    </main>
+    <div className="ss-signin" data-screen-label="signup">
+      <div className="ss-orb ss-orb-magenta" />
+      <div className="ss-orb ss-orb-cyan" />
+      <div className="ss-orb ss-orb-violet" />
+      <div className="ss-signin-card">
+        <div className="ss-signin-mark">
+          <h1 className="ss-brand-script">Shear</h1>
+          <p className="ss-brand-sub">Simplicity</p>
+        </div>
+        <h2>Open a studio</h2>
+        <p className="ss-signin-sub">Create your salon and invite your team.</p>
+        <SignUp routing="path" path="/sign-up" />
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -19,9 +19,18 @@
   z-index: 0;
 }
 .ss-signin-card {
+  /* Reset the older two-pane definition in styles.css that left
+     .ss-signin-card as display:flex / align-items:center — that turned the
+     card's children into row-flex items here. Force normal block flow so
+     the brand mark, headings, form, and footer stack vertically. */
+  display: block;
+  flex: none;
+  align-items: stretch;
+  justify-content: flex-start;
   position: relative;
   z-index: 2;
   width: 420px;
+  max-width: calc(100% - 32px);
   padding: 44px 40px 36px;
   background: var(--ss-panel-strong);
   border: 1px solid var(--ss-panel-border);

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1019,3 +1019,45 @@
   background: rgba(168, 200, 208, 0.14);
   color: var(--ss-text-muted);
 }
+
+/* ====================================================
+   Phase 3d — sign-in dev panel + profile hero polish.
+==================================================== */
+
+.ss-signin-dev-form {
+  display: flex; flex-direction: column; gap: 14px;
+  text-align: left;
+  margin-top: 6px;
+}
+.ss-signin-dev-info {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel);
+}
+.ss-signin-dev-info > div {
+  display: flex; flex-direction: column; gap: 2px;
+  font-size: 13px;
+  color: var(--ss-text-primary);
+  word-break: break-word;
+}
+.ss-signin-dev-label {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+}
+.ss-signin-code {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 11.5px;
+  background: var(--ss-magenta-pale);
+  color: var(--ss-magenta-deep);
+}


### PR DESCRIPTION
## Summary

Pulls the last two Tailwind-monochrome surfaces onto the Tresses design system.

**Sign-in / sign-up**
- Dreamy frame: orbs, motes, porcelain `.ss-signin-card`, Great-Vibes "Shear" wordmark.
- **Dev mode**: studio + user info in a soft framed grid, `.ss-dev-pill` above the CTA, and a footer hint linking to `/sign-up` with the `AUTH_PROVIDER=clerk` instruction.
- **Clerk mode**: same frame wrapped around Clerk's `<SignIn>` / `<SignUp>` components.

**Client profile**
- Two-column `.ss-profile-grid` — hero card on the left (gradient photo halo, name, dashed-grid contact meta, full-width "Book" CTA); right column stacks three mini stats (visits, lifetime spend, last visit) above the editable profile form and the appointment-history list.
- Lifetime spend sums `priceSnapshotCents` across every appointment's services using the salon's currency.

CSS additions (`.ss-signin-dev-form`, `.ss-signin-dev-info`, `.ss-signin-code`) cover the new dev panel; everything else reuses existing `.ss-*` classes that landed in 3b/3c.

Messages thread is deferred to Phase 4 alongside the SMS backend.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `next dev` returns 200 on `/sign-in` with the new `.ss-signin-card` markup.
- [ ] Manual UI dogfood (couldn't fully exercise from agent — needs DB):
  - Sign-in renders with orbs + porcelain card; dev-mode submit lands you on `/`.
  - In Clerk mode (`AUTH_PROVIDER=clerk`), the Clerk widget renders inside the dreamy frame.
  - Client profile shows the photo-halo hero, three mini stats, edit form, and history list.