### PR TITLE
Phase 3e: book-appointment flow at /schedule/new

### DIFF
--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -20,6 +20,29 @@ function fail(e: unknown): ActionResult {
   return { ok: false, message: "Request failed" };
 }
 
+interface ClientSearchHit {
+  id: string;
+  displayName: string;
+  phone: string | null;
+  email: string | null;
+}
+
+// Server-side client search so the booking flow stays correct beyond the API
+// list cap (take: 200 on /clients). The same `q` parameter the GET /clients
+// endpoint already supports does the heavy lifting; we just forward it.
+export async function searchClientsAction(
+  q: string,
+): Promise<ClientSearchHit[]> {
+  const trimmed = q.trim();
+  try {
+    return await apiFetch<ClientSearchHit[]>("/clients", {
+      query: { q: trimmed.length > 0 ? trimmed : undefined },
+    });
+  } catch {
+    return [];
+  }
+}
+
 export async function createAppointmentAction(input: {
   clientId: string;
   staffMemberId: string;

--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -6,6 +6,8 @@ import { apiFetch, ApiError } from "@/lib/api";
 export interface ActionResult {
   ok: boolean;
   message?: string;
+  /** When the API returns a created resource we want to navigate to. */
+  appointmentId?: string;
 }
 
 function fail(e: unknown): ActionResult {
@@ -16,6 +18,36 @@ function fail(e: unknown): ActionResult {
     return { ok: false, message: e.message };
   }
   return { ok: false, message: "Request failed" };
+}
+
+export async function createAppointmentAction(input: {
+  clientId: string;
+  staffMemberId: string;
+  serviceIds: string[];
+  startAtIso: string;
+  notes?: string;
+  internalNotes?: string;
+}): Promise<ActionResult> {
+  try {
+    const created = await apiFetch<{ id: string }>("/appointments", {
+      method: "POST",
+      data: {
+        clientId: input.clientId,
+        staffMemberId: input.staffMemberId,
+        serviceIds: input.serviceIds,
+        startAt: input.startAtIso,
+        notes: input.notes && input.notes.length > 0 ? input.notes : undefined,
+        internalNotes:
+          input.internalNotes && input.internalNotes.length > 0
+            ? input.internalNotes
+            : undefined,
+      },
+    });
+    revalidatePath("/schedule");
+    return { ok: true, appointmentId: created.id };
+  } catch (e) {
+    return fail(e);
+  }
 }
 
 export async function rescheduleAppointment(input: {

--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-form.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-form.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import {
+  useMemo,
+  useState,
+  useTransition,
+  type FormEvent,
+} from "react";
+import { useRouter } from "next/navigation";
+import { Button, Card } from "@/components/form";
+import { instantAtMinutes } from "@/lib/salon-time";
+import { createAppointmentAction } from "../_actions";
+
+export interface BookStaff {
+  id: string;
+  displayName: string;
+  title: string | null;
+  color: string | null;
+  isActive: boolean;
+}
+
+export interface BookService {
+  id: string;
+  name: string;
+  defaultDurationMinutes: number;
+  defaultPriceCents: number;
+  currency: string;
+  isActive: boolean;
+  category: { id: string; name: string } | null;
+}
+
+export interface BookClient {
+  id: string;
+  displayName: string;
+  phone: string | null;
+  email: string | null;
+}
+
+interface Props {
+  timezone: string;
+  initialDate: string;
+  initialStaffId: string | null;
+  initialClientId: string | null;
+  staff: BookStaff[];
+  services: BookService[];
+  clients: BookClient[];
+}
+
+const SLOT_MIN = 15;
+const SLOT_START_MIN = 9 * 60;
+const SLOT_END_MIN = 19 * 60;
+const STAFF_GRADIENTS = [
+  "linear-gradient(135deg, #1ec3d9, #0892a8)",
+  "linear-gradient(135deg, #0892a8, #4a82b3)",
+  "linear-gradient(135deg, #4a82b3, #1ec3d9)",
+  "linear-gradient(135deg, #5cdcec, #0892a8)",
+  "linear-gradient(135deg, #1ec3d9, #6fa6cc)",
+];
+
+export function BookAppointmentForm({
+  timezone,
+  initialDate,
+  initialStaffId,
+  initialClientId,
+  staff,
+  services,
+  clients,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const [clientId, setClientId] = useState<string>(initialClientId ?? "");
+  const [clientQuery, setClientQuery] = useState("");
+  const [staffId, setStaffId] = useState<string>(initialStaffId ?? "");
+  const [serviceIds, setServiceIds] = useState<Set<string>>(new Set());
+  const [date, setDate] = useState<string>(initialDate);
+  const [minutes, setMinutes] = useState<number>(SLOT_START_MIN);
+  const [notes, setNotes] = useState("");
+  const [internalNotes, setInternalNotes] = useState("");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const filteredClients = useMemo(() => {
+    const q = clientQuery.trim().toLowerCase();
+    if (!q) return clients.slice(0, 50);
+    return clients
+      .filter(
+        (c) =>
+          c.displayName.toLowerCase().includes(q) ||
+          (c.phone ?? "").toLowerCase().includes(q) ||
+          (c.email ?? "").toLowerCase().includes(q),
+      )
+      .slice(0, 50);
+  }, [clientQuery, clients]);
+
+  const groupedServices = useMemo(() => groupByCategory(services), [services]);
+
+  const totalDuration = useMemo(
+    () =>
+      services
+        .filter((s) => serviceIds.has(s.id))
+        .reduce((acc, s) => acc + s.defaultDurationMinutes, 0),
+    [serviceIds, services],
+  );
+  const totalCents = useMemo(
+    () =>
+      services
+        .filter((s) => serviceIds.has(s.id))
+        .reduce((acc, s) => acc + s.defaultPriceCents, 0),
+    [serviceIds, services],
+  );
+  const currency =
+    services.find((s) => serviceIds.has(s.id))?.currency ?? "USD";
+
+  const slotOptions = useMemo(() => {
+    const out: Array<{ minutes: number; label: string }> = [];
+    for (let m = SLOT_START_MIN; m <= SLOT_END_MIN - SLOT_MIN; m += SLOT_MIN) {
+      out.push({ minutes: m, label: minutesToLabel(m) });
+    }
+    return out;
+  }, []);
+
+  const canSubmit =
+    !!clientId && !!staffId && serviceIds.size > 0 && !isPending;
+
+  function toggleService(id: string) {
+    setServiceIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setErrorMsg(null);
+    const startAtIso = instantAtMinutes(minutes, date, timezone).toISOString();
+    startTransition(async () => {
+      const result = await createAppointmentAction({
+        clientId,
+        staffMemberId: staffId,
+        serviceIds: Array.from(serviceIds),
+        startAtIso,
+        notes: notes.trim() || undefined,
+        internalNotes: internalNotes.trim() || undefined,
+      });
+      if (!result.ok) {
+        setErrorMsg(result.message ?? "Could not book appointment");
+        return;
+      }
+      router.push(`/schedule?date=${date}`);
+      router.refresh();
+    });
+  }
+
+  return (
+    <form className="ss-book-grid" onSubmit={onSubmit}>
+      <div className="ss-book-main">
+        <Card title="Client" meta={clientId ? clientName(clients, clientId) : "Required"}>
+          <input
+            type="search"
+            className="ss-book-search"
+            placeholder="Search by name, phone, or email…"
+            value={clientQuery}
+            onChange={(e) => setClientQuery(e.target.value)}
+          />
+          <div className="ss-book-client-list">
+            {filteredClients.length === 0 ? (
+              <p className="ss-empty" style={{ padding: 12 }}>
+                No clients match "{clientQuery}".
+              </p>
+            ) : (
+              filteredClients.map((c) => (
+                <button
+                  type="button"
+                  key={c.id}
+                  className={`ss-book-client-row${c.id === clientId ? " is-selected" : ""}`}
+                  onClick={() => setClientId(c.id)}
+                >
+                  <span className="ss-book-client-name">{c.displayName}</span>
+                  <span className="ss-book-client-meta">
+                    {[c.phone, c.email].filter(Boolean).join(" · ") || "—"}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </Card>
+
+        <Card title="Services" meta={`${serviceIds.size} selected`}>
+          {groupedServices.map((group) => (
+            <div key={group.name} className="ss-book-svc-group">
+              <div className="ss-book-svc-group-name">{group.name}</div>
+              {group.services.map((s) => {
+                const checked = serviceIds.has(s.id);
+                return (
+                  <label
+                    key={s.id}
+                    className={`ss-book-svc-row${checked ? " is-selected" : ""}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleService(s.id)}
+                    />
+                    <span className="ss-book-svc-name">{s.name}</span>
+                    <span className="ss-book-svc-meta">
+                      {s.defaultDurationMinutes} min ·{" "}
+                      {formatPrice(s.defaultPriceCents, s.currency)}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          ))}
+        </Card>
+
+        <Card title="Stylist" meta={staffId ? staffName(staff, staffId) : "Required"}>
+          <div className="ss-book-staff-grid">
+            {staff.map((s, i) => {
+              const selected = staffId === s.id;
+              return (
+                <button
+                  type="button"
+                  key={s.id}
+                  className={`ss-book-staff-card${selected ? " is-selected" : ""}`}
+                  onClick={() => setStaffId(s.id)}
+                >
+                  <div
+                    className="ss-chair-avatar"
+                    style={{
+                      background: s.color
+                        ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                        : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
+                    }}
+                  >
+                    {initialsOf(s.displayName)}
+                  </div>
+                  <div className="ss-book-staff-name">
+                    {s.displayName.split(" ")[0]}
+                  </div>
+                  {s.title && (
+                    <div className="ss-book-staff-role">{s.title}</div>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+
+        <Card title="Date & time">
+          <div className="ss-form-row">
+            <div className="ss-field">
+              <label htmlFor="book-date">Date</label>
+              <input
+                id="book-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value || initialDate)}
+              />
+            </div>
+            <div className="ss-field">
+              <label htmlFor="book-time">Start time</label>
+              <select
+                id="book-time"
+                value={minutes}
+                onChange={(e) => setMinutes(Number(e.target.value))}
+              >
+                {slotOptions.map((o) => (
+                  <option key={o.minutes} value={o.minutes}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {totalDuration > 0 && (
+            <p className="ss-book-end-hint">
+              Ends at {minutesToLabel(minutes + totalDuration)} ·{" "}
+              {totalDuration} min total
+            </p>
+          )}
+        </Card>
+
+        <Card title="Notes" meta="Optional">
+          <div className="ss-field">
+            <label htmlFor="book-notes">Visible to the client</label>
+            <textarea
+              id="book-notes"
+              rows={2}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              maxLength={4000}
+            />
+          </div>
+          <div className="ss-field">
+            <label htmlFor="book-internal">Internal only</label>
+            <textarea
+              id="book-internal"
+              rows={2}
+              value={internalNotes}
+              onChange={(e) => setInternalNotes(e.target.value)}
+              maxLength={4000}
+            />
+          </div>
+        </Card>
+      </div>
+
+      <aside className="ss-book-aside">
+        <Card title="Summary" meta="Review">
+          <SummaryRow label="Client">
+            {clientId ? clientName(clients, clientId) : "—"}
+          </SummaryRow>
+          <SummaryRow label="Stylist">
+            {staffId ? staffName(staff, staffId) : "—"}
+          </SummaryRow>
+          <SummaryRow label="Services">
+            {serviceIds.size === 0
+              ? "—"
+              : services
+                  .filter((s) => serviceIds.has(s.id))
+                  .map((s) => s.name)
+                  .join(", ")}
+          </SummaryRow>
+          <SummaryRow label="When">
+            {formatDateLabel(date)} · {minutesToLabel(minutes)}
+          </SummaryRow>
+          <SummaryRow label="Duration">
+            {totalDuration > 0 ? `${totalDuration} min` : "—"}
+          </SummaryRow>
+          <SummaryRow label="Price">
+            {totalCents > 0 ? formatPrice(totalCents, currency) : "—"}
+          </SummaryRow>
+
+          {errorMsg && <div className="ss-form-error" style={{ marginTop: 14 }}>{errorMsg}</div>}
+
+          <div className="ss-form-actions" style={{ marginTop: 18 }}>
+            <Button type="submit" disabled={!canSubmit}>
+              {isPending ? "Booking…" : "Book appointment"}
+            </Button>
+          </div>
+        </Card>
+      </aside>
+    </form>
+  );
+}
+
+function SummaryRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="ss-book-summary-row">
+      <span className="ss-book-summary-label">{label}</span>
+      <span className="ss-book-summary-value">{children}</span>
+    </div>
+  );
+}
+
+function groupByCategory(services: BookService[]) {
+  const map = new Map<string, { name: string; services: BookService[] }>();
+  for (const s of services) {
+    const name = s.category?.name ?? "Other";
+    const existing = map.get(name) ?? { name, services: [] };
+    existing.services.push(s);
+    map.set(name, existing);
+  }
+  return [...map.values()].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+  );
+}
+
+function clientName(clients: BookClient[], id: string): string {
+  return clients.find((c) => c.id === id)?.displayName ?? "—";
+}
+
+function staffName(staff: BookStaff[], id: string): string {
+  return staff.find((s) => s.id === id)?.displayName ?? "—";
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
+}
+
+function minutesToLabel(m: number): string {
+  const h = Math.floor(m / 60);
+  const min = m % 60;
+  const meridiem = h < 12 ? "AM" : "PM";
+  const display = ((h + 11) % 12) + 1;
+  const mm = min === 0 ? "" : `:${String(min).padStart(2, "0")}`;
+  return `${display}${mm} ${meridiem}`;
+}
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(cents / 100);
+}
+
+function formatDateLabel(iso: string): string {
+  // The HTML5 date input gives us YYYY-MM-DD with no timezone — formatting
+  // with the device locale is fine here since the actual UTC instant is
+  // computed via instantAtMinutes() at submit time.
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-form.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useEffect,
   useMemo,
   useState,
   useTransition,
@@ -9,7 +10,10 @@ import {
 import { useRouter } from "next/navigation";
 import { Button, Card } from "@/components/form";
 import { instantAtMinutes } from "@/lib/salon-time";
-import { createAppointmentAction } from "../_actions";
+import {
+  createAppointmentAction,
+  searchClientsAction,
+} from "../_actions";
 import {
   BookCalendar,
   type BookCalendarAppointment,
@@ -84,6 +88,11 @@ export function BookAppointmentForm({
 
   const [clientId, setClientId] = useState<string>(initialClientId ?? "");
   const [clientQuery, setClientQuery] = useState("");
+  // The displayed roster is server-driven so salons with more than the API's
+  // 200-row cap can still find clients beyond the first page via search.
+  // `clients` (the prop) seeds the initial list before any query is typed.
+  const [clientResults, setClientResults] = useState<BookClient[]>(clients);
+  const [, startClientSearch] = useTransition();
   const [staffId, setStaffId] = useState<string>(initialStaffId ?? "");
   const [serviceIds, setServiceIds] = useState<Set<string>>(new Set());
   const [date, setDate] = useState<string>(initialDate);
@@ -94,18 +103,28 @@ export function BookAppointmentForm({
   const [internalNotes, setInternalNotes] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  const filteredClients = useMemo(() => {
-    const q = clientQuery.trim().toLowerCase();
-    if (!q) return clients.slice(0, 50);
-    return clients
-      .filter(
-        (c) =>
-          c.displayName.toLowerCase().includes(q) ||
-          (c.phone ?? "").toLowerCase().includes(q) ||
-          (c.email ?? "").toLowerCase().includes(q),
-      )
-      .slice(0, 50);
-  }, [clientQuery, clients]);
+  // Debounce typing so we don't fire a server action on every keystroke.
+  // 220 ms is short enough to feel live and long enough to coalesce a
+  // full word's typing into one round-trip.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      startClientSearch(async () => {
+        const hits = await searchClientsAction(clientQuery);
+        setClientResults(hits);
+      });
+    }, 220);
+    return () => clearTimeout(handle);
+  }, [clientQuery]);
+
+  // The selected client may sit outside the current result page when a
+  // long-tail search trims the list — keep them visible at the top so the
+  // current selection is never silently dropped from the UI.
+  const displayClients = useMemo(() => {
+    if (!clientId) return clientResults;
+    if (clientResults.some((c) => c.id === clientId)) return clientResults;
+    const selected = clients.find((c) => c.id === clientId);
+    return selected ? [selected, ...clientResults] : clientResults;
+  }, [clientId, clientResults, clients]);
 
   const groupedServices = useMemo(() => groupByCategory(services), [services]);
 
@@ -168,7 +187,7 @@ export function BookAppointmentForm({
   return (
     <form className="ss-book-grid" onSubmit={onSubmit}>
       <div className="ss-book-main">
-        <Card title="Client" meta={clientId ? clientName(clients, clientId) : "Required"}>
+        <Card title="Client" meta={clientId ? clientName(displayClients, clientId) : "Required"}>
           <input
             type="search"
             className="ss-book-search"
@@ -177,12 +196,14 @@ export function BookAppointmentForm({
             onChange={(e) => setClientQuery(e.target.value)}
           />
           <div className="ss-book-client-list">
-            {filteredClients.length === 0 ? (
+            {displayClients.length === 0 ? (
               <p className="ss-empty" style={{ padding: 12 }}>
-                No clients match "{clientQuery}".
+                {clientQuery
+                  ? `No clients match "${clientQuery}".`
+                  : "No clients yet."}
               </p>
             ) : (
-              filteredClients.map((c) => (
+              displayClients.map((c) => (
                 <button
                   type="button"
                   key={c.id}
@@ -332,7 +353,7 @@ export function BookAppointmentForm({
       <aside className="ss-book-aside">
         <Card title="Summary" meta="Review">
           <SummaryRow label="Client">
-            {clientId ? clientName(clients, clientId) : "—"}
+            {clientId ? clientName(displayClients, clientId) : "—"}
           </SummaryRow>
           <SummaryRow label="Stylist">
             {staffId ? staffName(staff, staffId) : "—"}

--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-form.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-form.tsx
@@ -10,6 +10,10 @@ import { useRouter } from "next/navigation";
 import { Button, Card } from "@/components/form";
 import { instantAtMinutes } from "@/lib/salon-time";
 import { createAppointmentAction } from "../_actions";
+import {
+  BookCalendar,
+  type BookCalendarAppointment,
+} from "./book-calendar";
 
 export interface BookStaff {
   id: string;
@@ -44,11 +48,15 @@ interface Props {
   staff: BookStaff[];
   services: BookService[];
   clients: BookClient[];
+  /** "YYYY-MM" of the calendar's currently-loaded month. */
+  viewMonth: string;
+  prevMonthIso: string;
+  nextMonthIso: string;
+  todayIso: string;
+  /** Appointments overlapping `viewMonth`, fed to the calendar. */
+  monthAppointments: BookCalendarAppointment[];
 }
 
-const SLOT_MIN = 15;
-const SLOT_START_MIN = 9 * 60;
-const SLOT_END_MIN = 19 * 60;
 const STAFF_GRADIENTS = [
   "linear-gradient(135deg, #1ec3d9, #0892a8)",
   "linear-gradient(135deg, #0892a8, #4a82b3)",
@@ -65,6 +73,11 @@ export function BookAppointmentForm({
   staff,
   services,
   clients,
+  viewMonth,
+  prevMonthIso,
+  nextMonthIso,
+  todayIso,
+  monthAppointments,
 }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -74,7 +87,9 @@ export function BookAppointmentForm({
   const [staffId, setStaffId] = useState<string>(initialStaffId ?? "");
   const [serviceIds, setServiceIds] = useState<Set<string>>(new Set());
   const [date, setDate] = useState<string>(initialDate);
-  const [minutes, setMinutes] = useState<number>(SLOT_START_MIN);
+  // Null until the user picks an open slot — keeps the slot grid free of a
+  // pre-selected highlight on first arrival.
+  const [minutes, setMinutes] = useState<number | null>(null);
   const [notes, setNotes] = useState("");
   const [internalNotes, setInternalNotes] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -111,16 +126,12 @@ export function BookAppointmentForm({
   const currency =
     services.find((s) => serviceIds.has(s.id))?.currency ?? "USD";
 
-  const slotOptions = useMemo(() => {
-    const out: Array<{ minutes: number; label: string }> = [];
-    for (let m = SLOT_START_MIN; m <= SLOT_END_MIN - SLOT_MIN; m += SLOT_MIN) {
-      out.push({ minutes: m, label: minutesToLabel(m) });
-    }
-    return out;
-  }, []);
-
   const canSubmit =
-    !!clientId && !!staffId && serviceIds.size > 0 && !isPending;
+    !!clientId &&
+    !!staffId &&
+    serviceIds.size > 0 &&
+    minutes !== null &&
+    !isPending;
 
   function toggleService(id: string) {
     setServiceIds((prev) => {
@@ -133,7 +144,7 @@ export function BookAppointmentForm({
 
   function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!canSubmit) return;
+    if (!canSubmit || minutes === null) return;
     setErrorMsg(null);
     const startAtIso = instantAtMinutes(minutes, date, timezone).toISOString();
     startTransition(async () => {
@@ -249,33 +260,44 @@ export function BookAppointmentForm({
           </div>
         </Card>
 
-        <Card title="Date & time">
-          <div className="ss-form-row">
-            <div className="ss-field">
-              <label htmlFor="book-date">Date</label>
-              <input
-                id="book-date"
-                type="date"
-                value={date}
-                onChange={(e) => setDate(e.target.value || initialDate)}
-              />
-            </div>
-            <div className="ss-field">
-              <label htmlFor="book-time">Start time</label>
-              <select
-                id="book-time"
-                value={minutes}
-                onChange={(e) => setMinutes(Number(e.target.value))}
-              >
-                {slotOptions.map((o) => (
-                  <option key={o.minutes} value={o.minutes}>
-                    {o.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-          {totalDuration > 0 && (
+        <Card
+          title="When"
+          meta={
+            minutes !== null
+              ? `${formatDateLabel(date)} · ${minutesToLabel(minutes)}`
+              : "Pick a day, then a slot"
+          }
+        >
+          <BookCalendar
+            timezone={timezone}
+            selectedDate={date}
+            todayIso={todayIso}
+            selectedMinutes={minutes}
+            viewMonth={viewMonth}
+            prevMonthIso={prevMonthIso}
+            nextMonthIso={nextMonthIso}
+            monthAppointments={monthAppointments}
+            staff={staff}
+            selectedStaffId={staffId || null}
+            services={services}
+            selectedDurationMin={totalDuration}
+            onSelectDate={(iso) => {
+              setDate(iso);
+              setMinutes(null);
+            }}
+            onPickSlot={(iso, m, sId) => {
+              setDate(iso);
+              setMinutes(m);
+              if (!staffId) setStaffId(sId);
+            }}
+            onSelectStaff={(sId) => setStaffId(sId)}
+            onMonthChange={(yearMonth) => {
+              // Re-fetch via the URL so the server can hand us a new
+              // monthAppointments slice.
+              router.push(`/schedule/new?month=${yearMonth}&date=${date}`);
+            }}
+          />
+          {totalDuration > 0 && minutes !== null && (
             <p className="ss-book-end-hint">
               Ends at {minutesToLabel(minutes + totalDuration)} ·{" "}
               {totalDuration} min total
@@ -324,7 +346,9 @@ export function BookAppointmentForm({
                   .join(", ")}
           </SummaryRow>
           <SummaryRow label="When">
-            {formatDateLabel(date)} · {minutesToLabel(minutes)}
+            {minutes !== null
+              ? `${formatDateLabel(date)} · ${minutesToLabel(minutes)}`
+              : formatDateLabel(date)}
           </SummaryRow>
           <SummaryRow label="Duration">
             {totalDuration > 0 ? `${totalDuration} min` : "—"}

--- a/apps/web/src/app/(app)/schedule/_components/book-calendar.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-calendar.tsx
@@ -1,0 +1,788 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { format as formatTz, fromZonedTime } from "date-fns-tz";
+import { shiftIsoDate } from "@/lib/salon-time";
+import { categoryKind, type CategoryKind } from "@/lib/service-categories";
+import type {
+  BookService,
+  BookStaff,
+} from "./book-appointment-form";
+
+const DOWS = ["S", "M", "T", "W", "T", "F", "S"];
+const SLOT_MIN = 15;
+const SLOT_HEIGHT = 12;
+const SLOT_START_MIN = 9 * 60;
+const SLOT_END_MIN = 19 * 60;
+const TOTAL_SLOTS = (SLOT_END_MIN - SLOT_START_MIN) / SLOT_MIN;
+
+const STAFF_GRADIENTS = [
+  "linear-gradient(135deg, #1ec3d9, #0892a8)",
+  "linear-gradient(135deg, #0892a8, #4a82b3)",
+  "linear-gradient(135deg, #4a82b3, #1ec3d9)",
+  "linear-gradient(135deg, #5cdcec, #0892a8)",
+  "linear-gradient(135deg, #1ec3d9, #6fa6cc)",
+];
+
+// CategoryKind keys used in the design's color bars. We map our six kinds
+// onto the bar's five segments (block falls back to neutral so it doesn't
+// pollute the colored bar).
+type BarKind = "color" | "cut" | "treat" | "style" | "bridal";
+function barKind(k: CategoryKind): BarKind | null {
+  if (k === "color" || k === "cut" || k === "treat" || k === "bridal") return k;
+  if (k === "styling") return "style";
+  return null;
+}
+
+export interface BookCalendarAppointment {
+  id: string;
+  startAt: string;
+  endAt: string;
+  status:
+    | "SCHEDULED"
+    | "CONFIRMED"
+    | "CHECKED_IN"
+    | "IN_PROGRESS"
+    | "COMPLETED"
+    | "CANCELLED"
+    | "NO_SHOW";
+  client: { id: string; displayName: string };
+  staffMember: { id: string; displayName: string };
+  services: { serviceId: string; serviceNameSnapshot: string }[];
+}
+
+interface Props {
+  timezone: string;
+  /** YYYY-MM-DD currently selected. */
+  selectedDate: string;
+  /** YYYY-MM-DD highlighted as "today" in the salon's tz. */
+  todayIso: string;
+  /** Minutes-from-midnight currently chosen, or null if none yet. */
+  selectedMinutes: number | null;
+  /** YYYY-MM viewed in month mode. */
+  viewMonth: string;
+  /** "next" / "prev" month iso for nav links. */
+  prevMonthIso: string;
+  nextMonthIso: string;
+  /** Appointments overlapping the visible month — already filtered to
+   *  active statuses by the caller. */
+  monthAppointments: BookCalendarAppointment[];
+  staff: BookStaff[];
+  /** Currently picked stylist (when set, day view shows just that column). */
+  selectedStaffId: string | null;
+  /** Service catalog so we can color-code by category. */
+  services: BookService[];
+  /** Sum of selected service durations — used to gate which slots are open. */
+  selectedDurationMin: number;
+  /** Set salon-local date (YYYY-MM-DD); transitions to day mode. */
+  onSelectDate: (iso: string) => void;
+  /** Pick (date, minutes, optional staffId) by clicking an open slot. */
+  onPickSlot: (iso: string, minutes: number, staffId: string) => void;
+  /** Navigate to a different month (does not change the selected date). */
+  onMonthChange: (yearMonth: string) => void;
+  onSelectStaff?: (staffId: string) => void;
+}
+
+export function BookCalendar({
+  timezone,
+  selectedDate,
+  todayIso,
+  selectedMinutes,
+  viewMonth,
+  prevMonthIso,
+  nextMonthIso,
+  monthAppointments,
+  staff,
+  selectedStaffId,
+  services,
+  selectedDurationMin,
+  onSelectDate,
+  onPickSlot,
+  onMonthChange,
+  onSelectStaff,
+}: Props) {
+  const [mode, setMode] = useState<"month" | "day">("month");
+
+  const kindForServiceId = useMemo(() => {
+    const map = new Map<string, CategoryKind>();
+    for (const s of services) {
+      map.set(
+        s.id,
+        categoryKind({
+          categoryName: s.category?.name ?? null,
+          serviceName: s.name,
+        }),
+      );
+    }
+    return map;
+  }, [services]);
+
+  // Group appointments by salon-local date so the month grid can render
+  // per-cell mixes without re-walking the whole list each cell.
+  const apptsByDate = useMemo(() => {
+    const m = new Map<string, BookCalendarAppointment[]>();
+    for (const a of monthAppointments) {
+      const localDate = formatTz(new Date(a.startAt), "yyyy-MM-dd", {
+        timeZone: timezone,
+      });
+      const list = m.get(localDate) ?? [];
+      list.push(a);
+      m.set(localDate, list);
+    }
+    return m;
+  }, [monthAppointments, timezone]);
+
+  const selectedDayAppts = useMemo(
+    () => apptsByDate.get(selectedDate) ?? [],
+    [apptsByDate, selectedDate],
+  );
+
+  const monthCells = useMemo(
+    () => buildMonthCells(viewMonth, todayIso, selectedDate, apptsByDate, kindForServiceId),
+    [viewMonth, todayIso, selectedDate, apptsByDate, kindForServiceId],
+  );
+
+  // 7-day window centered on the selected date (Sunday-anchored in salon tz).
+  const weekDays = useMemo(
+    () => buildWeekDays(selectedDate, timezone, apptsByDate, kindForServiceId, todayIso),
+    [selectedDate, timezone, apptsByDate, kindForServiceId, todayIso],
+  );
+
+  const dateLabel = formatDateLabel(selectedDate, timezone);
+  const monthLabel = formatTz(
+    fromZonedTime(`${viewMonth}-01T12:00:00`, timezone),
+    "MMMM yyyy",
+    { timeZone: timezone },
+  );
+
+  function handlePickDate(iso: string) {
+    onSelectDate(iso);
+    setMode("day");
+  }
+
+  return (
+    <div className="bk-calendar">
+      {mode === "day" && (
+        <div className="bk-cal-crumbs">
+          <button
+            type="button"
+            className="bk-cal-back"
+            onClick={() => setMode("month")}
+          >
+            <span aria-hidden>←</span>
+            <span>{monthLabel}</span>
+          </button>
+          <span className="bk-cal-crumb-sep">/</span>
+          <span className="bk-cal-crumb-current">{dateLabel}</span>
+          <button
+            type="button"
+            className="bk-cal-month-link"
+            onClick={() => setMode("month")}
+          >
+            View month
+          </button>
+        </div>
+      )}
+
+      {mode === "month" ? (
+        <BookMonthGrid
+          cells={monthCells}
+          monthLabel={monthLabel}
+          prevMonthIso={prevMonthIso}
+          nextMonthIso={nextMonthIso}
+          onPick={handlePickDate}
+          onMonthChange={onMonthChange}
+        />
+      ) : (
+        <>
+          <BookWeekStrip
+            days={weekDays}
+            onPick={(iso) => onSelectDate(iso)}
+          />
+          <BookDayView
+            timezone={timezone}
+            selectedDate={selectedDate}
+            selectedMinutes={selectedMinutes}
+            selectedDurationMin={selectedDurationMin}
+            dateLabel={dateLabel}
+            staff={staff}
+            selectedStaffId={selectedStaffId}
+            appointments={selectedDayAppts}
+            kindForServiceId={kindForServiceId}
+            onPickSlot={(minutes, staffId) =>
+              onPickSlot(selectedDate, minutes, staffId)
+            }
+            onSelectStaff={onSelectStaff}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+interface MonthCell {
+  iso: string;
+  day: number;
+  out: boolean;
+  today: boolean;
+  selected: boolean;
+  mix: Partial<Record<BarKind, number>>;
+}
+
+function buildMonthCells(
+  viewMonth: string,
+  todayIso: string,
+  selectedDate: string,
+  apptsByDate: Map<string, BookCalendarAppointment[]>,
+  kindForServiceId: Map<string, CategoryKind>,
+): MonthCell[] {
+  // viewMonth is "YYYY-MM". Compute the calendar grid (always 6 rows × 7 cols
+  // to keep layout stable as months change shape).
+  const [yearStr, monthStr] = viewMonth.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr); // 1-12
+  const firstOfMonth = new Date(Date.UTC(year, month - 1, 1));
+  const startDow = firstOfMonth.getUTCDay(); // 0 = Sun
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const cells: MonthCell[] = [];
+  for (let i = 0; i < 42; i++) {
+    const offset = i - startDow;
+    const date = new Date(Date.UTC(year, month - 1, 1 + offset));
+    const y = date.getUTCFullYear();
+    const m = date.getUTCMonth() + 1;
+    const d = date.getUTCDate();
+    const iso = `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+    const out = m !== month;
+    const appts = apptsByDate.get(iso) ?? [];
+    const mix: Partial<Record<BarKind, number>> = {};
+    for (const a of appts) {
+      const kind =
+        a.services
+          .map((s) => kindForServiceId.get(s.serviceId))
+          .find((k): k is CategoryKind => Boolean(k)) ?? "cut";
+      const bk = barKind(kind);
+      if (bk) mix[bk] = (mix[bk] ?? 0) + 1;
+    }
+    cells.push({
+      iso,
+      day: d,
+      out,
+      today: !out && iso === todayIso,
+      selected: !out && iso === selectedDate,
+      mix,
+    });
+    // Stop after we've covered the last week containing the month's last day.
+    if (offset >= daysInMonth + (6 - ((startDow + daysInMonth - 1) % 7))) break;
+  }
+  return cells;
+}
+
+function BookMonthGrid({
+  cells,
+  monthLabel,
+  prevMonthIso,
+  nextMonthIso,
+  onPick,
+  onMonthChange,
+}: {
+  cells: MonthCell[];
+  monthLabel: string;
+  prevMonthIso: string;
+  nextMonthIso: string;
+  onPick: (iso: string) => void;
+  onMonthChange: (yearMonth: string) => void;
+}) {
+  return (
+    <div className="bk-month">
+      <div className="bk-month-head">
+        <button
+          type="button"
+          className="bk-cal-nav"
+          onClick={() => onMonthChange(prevMonthIso)}
+          aria-label="Previous month"
+        >
+          ‹
+        </button>
+        <div className="bk-cal-month">{monthLabel}</div>
+        <button
+          type="button"
+          className="bk-cal-nav"
+          onClick={() => onMonthChange(nextMonthIso)}
+          aria-label="Next month"
+        >
+          ›
+        </button>
+      </div>
+      <div className="bk-month-dows">
+        {DOWS.map((d, i) => (
+          <span key={i}>{d}</span>
+        ))}
+      </div>
+      <div className="bk-month-grid">
+        {cells.map((c) => {
+          const total = Object.values(c.mix).reduce((a, b) => a + (b ?? 0), 0);
+          const closed = !c.out && total === 0;
+          const cls = [
+            "bk-month-cell",
+            c.out && "is-out",
+            c.today && "is-today",
+            c.selected && "is-selected",
+            // Don't paint the hatched "closed" pattern — every day is bookable.
+          ]
+            .filter(Boolean)
+            .join(" ");
+          void closed;
+          return (
+            <button
+              key={c.iso}
+              type="button"
+              className={cls}
+              disabled={c.out}
+              onClick={() => !c.out && onPick(c.iso)}
+            >
+              <span className="bk-month-num">{c.day}</span>
+              {!c.out && total > 0 && (
+                <span className="bk-month-bar" aria-hidden>
+                  {(["color", "cut", "treat", "style", "bridal"] as BarKind[]).map(
+                    (k) => {
+                      const v = c.mix[k];
+                      if (!v) return null;
+                      return (
+                        <span
+                          key={k}
+                          className={`bk-month-seg is-${k}`}
+                          style={{ flex: v }}
+                        />
+                      );
+                    },
+                  )}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="bk-month-legend">
+        <span>
+          <i className="bk-month-sw is-color" /> Color
+        </span>
+        <span>
+          <i className="bk-month-sw is-cut" /> Cut
+        </span>
+        <span>
+          <i className="bk-month-sw is-treat" /> Treatment
+        </span>
+        <span>
+          <i className="bk-month-sw is-style" /> Styling
+        </span>
+        <span>
+          <i className="bk-month-sw is-bridal" /> Bridal
+        </span>
+      </div>
+    </div>
+  );
+}
+
+interface WeekDay {
+  iso: string;
+  day: number;
+  dow: string;
+  selected: boolean;
+  today: boolean;
+  monthLabel: string | null;
+  mix: Partial<Record<BarKind, number>>;
+}
+
+function buildWeekDays(
+  selectedDate: string,
+  timezone: string,
+  apptsByDate: Map<string, BookCalendarAppointment[]>,
+  kindForServiceId: Map<string, CategoryKind>,
+  todayIso: string,
+): WeekDay[] {
+  // Anchor at the Sunday on or before the selected date in salon tz.
+  const sel = fromZonedTime(`${selectedDate}T12:00:00`, timezone);
+  const dow = Number(formatTz(sel, "i", { timeZone: timezone })); // 1-7 Mon-Sun
+  // ISO 1..7: 1=Mon ... 7=Sun. We want Sunday-start.
+  const offsetToSunday = dow === 7 ? 0 : -dow;
+  const out: WeekDay[] = [];
+  for (let i = 0; i < 7; i++) {
+    const iso = shiftIsoDate(selectedDate, offsetToSunday + i, timezone);
+    const appts = apptsByDate.get(iso) ?? [];
+    const mix: Partial<Record<BarKind, number>> = {};
+    for (const a of appts) {
+      const kind =
+        a.services
+          .map((s) => kindForServiceId.get(s.serviceId))
+          .find((k): k is CategoryKind => Boolean(k)) ?? "cut";
+      const bk = barKind(kind);
+      if (bk) mix[bk] = (mix[bk] ?? 0) + 1;
+    }
+    const d = fromZonedTime(`${iso}T12:00:00`, timezone);
+    const day = Number(formatTz(d, "d", { timeZone: timezone }));
+    const dowLabel = formatTz(d, "EEE", { timeZone: timezone });
+    // Show a "May" eyebrow on the first day of a new month within the strip.
+    const monthLabel =
+      day === 1 ? formatTz(d, "MMM", { timeZone: timezone }) : null;
+    out.push({
+      iso,
+      day,
+      dow: dowLabel,
+      selected: iso === selectedDate,
+      today: iso === todayIso,
+      monthLabel,
+      mix,
+    });
+  }
+  return out;
+}
+
+function BookWeekStrip({
+  days,
+  onPick,
+}: {
+  days: WeekDay[];
+  onPick: (iso: string) => void;
+}) {
+  return (
+    <div className="bk-weekstrip">
+      {days.map((d) => {
+        const cls = [
+          "bk-weekstrip-day",
+          d.selected && "is-selected",
+          d.today && "is-today",
+        ]
+          .filter(Boolean)
+          .join(" ");
+        return (
+          <button
+            key={d.iso}
+            type="button"
+            className={cls}
+            onClick={() => onPick(d.iso)}
+          >
+            <span className="bk-weekstrip-dow">{d.dow}</span>
+            <span className="bk-weekstrip-num">
+              {d.monthLabel && <em>{d.monthLabel} </em>}
+              {d.day}
+            </span>
+            <span className="bk-weekstrip-bar" aria-hidden>
+              {(["color", "cut", "treat", "style", "bridal"] as BarKind[]).map(
+                (k) => {
+                  const v = d.mix[k];
+                  if (!v) return null;
+                  return (
+                    <span
+                      key={k}
+                      className={`bk-month-seg is-${k}`}
+                      style={{ flex: v }}
+                    />
+                  );
+                },
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function BookDayView({
+  timezone,
+  selectedDate,
+  selectedMinutes,
+  selectedDurationMin,
+  dateLabel,
+  staff,
+  selectedStaffId,
+  appointments,
+  kindForServiceId,
+  onPickSlot,
+  onSelectStaff,
+}: {
+  timezone: string;
+  selectedDate: string;
+  selectedMinutes: number | null;
+  selectedDurationMin: number;
+  dateLabel: string;
+  staff: BookStaff[];
+  selectedStaffId: string | null;
+  appointments: BookCalendarAppointment[];
+  kindForServiceId: Map<string, CategoryKind>;
+  onPickSlot: (minutes: number, staffId: string) => void;
+  onSelectStaff?: (staffId: string) => void;
+}) {
+  const visibleStaff = selectedStaffId
+    ? staff.filter((s) => s.id === selectedStaffId)
+    : staff;
+  // Build a per-stylist occupancy map keyed by slot index. A slot is
+  // "occupied" if it falls inside any active appointment for that stylist.
+  // Computing once per render is cheap (4 staff × 40 slots).
+  const occupancy = useMemo(
+    () => buildOccupancy(appointments, visibleStaff, timezone),
+    [appointments, visibleStaff, timezone],
+  );
+  const requiredSlots = Math.max(1, Math.ceil(selectedDurationMin / SLOT_MIN));
+
+  return (
+    <div
+      className="bk-day"
+      style={{ ["--bk-slot-h" as string]: `${SLOT_HEIGHT}px` } as React.CSSProperties}
+    >
+      <div className="bk-day-head">
+        <div className="bk-day-title">
+          <strong>{dateLabel}</strong>
+          <span className="bk-day-sub">
+            {selectedStaffId
+              ? `with ${staff.find((s) => s.id === selectedStaffId)?.displayName ?? "—"}`
+              : "All stylists — pick any open slot"}
+          </span>
+        </div>
+        <div className="bk-day-legend">
+          <span>
+            <i className="bk-month-sw is-color" /> Color
+          </span>
+          <span>
+            <i className="bk-month-sw is-cut" /> Cut
+          </span>
+          <span>
+            <i className="bk-month-sw is-treat" /> Treat
+          </span>
+          <span>
+            <i className="bk-month-sw is-style" /> Style
+          </span>
+          <span>
+            <i className="bk-month-sw is-bridal" /> Bridal
+          </span>
+        </div>
+      </div>
+      <div
+        className="bk-day-grid"
+        style={{
+          gridTemplateColumns: `44px repeat(${visibleStaff.length}, 1fr)`,
+        }}
+      >
+        <div className="bk-day-h-spacer" />
+        {visibleStaff.map((s, i) => (
+          <div
+            key={s.id}
+            className="bk-day-h"
+            style={
+              {
+                ["--bk-stylist-tint" as string]: s.color
+                  ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                  : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
+              } as React.CSSProperties
+            }
+          >
+            <span
+              className="bk-day-h-avatar"
+              style={{
+                background: s.color
+                  ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                  : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
+              }}
+            >
+              {initialsOf(s.displayName)}
+            </span>
+            <span className="bk-day-h-name">
+              {s.displayName.split(" ")[0]}
+            </span>
+          </div>
+        ))}
+
+        <div
+          className="bk-day-times"
+          style={{ gridRow: `2 / span ${TOTAL_SLOTS}` }}
+        >
+          {Array.from({ length: (SLOT_END_MIN - SLOT_START_MIN) / 60 }).map(
+            (_, i) => {
+              const m = SLOT_START_MIN + i * 60;
+              return (
+                <div
+                  key={i}
+                  className="bk-day-time"
+                  style={{ height: SLOT_HEIGHT * 4 }}
+                >
+                  {minutesLabel(m)}
+                </div>
+              );
+            },
+          )}
+        </div>
+
+        {visibleStaff.map((s, ci) => {
+          const occ = occupancy[ci] ?? [];
+          return (
+            <div
+              key={s.id}
+              className="bk-day-col"
+              style={{
+                gridRow: `2 / span ${TOTAL_SLOTS}`,
+                height: SLOT_HEIGHT * TOTAL_SLOTS,
+              }}
+            >
+              {Array.from({ length: (SLOT_END_MIN - SLOT_START_MIN) / 60 }).map(
+                (_, hi) => (
+                  <div
+                    key={`h${hi}`}
+                    className="bk-day-hour-line"
+                    style={{ top: hi * SLOT_HEIGHT * 4 }}
+                  />
+                ),
+              )}
+              {Array.from({ length: (SLOT_END_MIN - SLOT_START_MIN) / 60 }).map(
+                (_, hi) => (
+                  <div
+                    key={`hh${hi}`}
+                    className="bk-day-half-line"
+                    style={{ top: hi * SLOT_HEIGHT * 4 + SLOT_HEIGHT * 2 }}
+                  />
+                ),
+              )}
+
+              {/* Open slots — only render the start of a fits-the-duration
+                  window so we don't paint a slot you can't actually book. */}
+              {Array.from({ length: TOTAL_SLOTS }).map((_, slot) => {
+                if (occ[slot]) return null;
+                let fits = true;
+                for (let k = 0; k < requiredSlots; k++) {
+                  if (slot + k >= TOTAL_SLOTS || occ[slot + k]) {
+                    fits = false;
+                    break;
+                  }
+                }
+                if (!fits) return null;
+                const minutes = SLOT_START_MIN + slot * SLOT_MIN;
+                const isSelectedHere =
+                  selectedMinutes === minutes &&
+                  (!selectedStaffId || selectedStaffId === s.id);
+                return (
+                  <button
+                    key={`o${slot}`}
+                    type="button"
+                    className={`bk-day-open${isSelectedHere ? " is-picked" : ""}`}
+                    style={{
+                      top: slot * SLOT_HEIGHT,
+                      height: requiredSlots * SLOT_HEIGHT,
+                    }}
+                    aria-label={`Book ${minutesLabel(minutes)} with ${s.displayName}`}
+                    onClick={() => {
+                      onPickSlot(minutes, s.id);
+                      if (!selectedStaffId && onSelectStaff) {
+                        onSelectStaff(s.id);
+                      }
+                    }}
+                  />
+                );
+              })}
+
+              {/* Existing appointments — read-only, color-coded. */}
+              {appointments
+                .filter((a) => a.staffMember.id === s.id)
+                .map((a) => {
+                  const startMin = minutesFromIso(a.startAt, timezone);
+                  const endMin = minutesFromIso(a.endAt, timezone);
+                  if (
+                    endMin <= SLOT_START_MIN ||
+                    startMin >= SLOT_END_MIN
+                  ) {
+                    return null;
+                  }
+                  const top =
+                    Math.max(0, (startMin - SLOT_START_MIN) / SLOT_MIN) *
+                    SLOT_HEIGHT;
+                  const height =
+                    ((Math.min(endMin, SLOT_END_MIN) -
+                      Math.max(startMin, SLOT_START_MIN)) /
+                      SLOT_MIN) *
+                      SLOT_HEIGHT -
+                    1;
+                  const kind =
+                    a.services
+                      .map((sv) => kindForServiceId.get(sv.serviceId))
+                      .find((k): k is CategoryKind => Boolean(k)) ?? "cut";
+                  const bk = barKind(kind) ?? "cut";
+                  return (
+                    <div
+                      key={a.id}
+                      className={`bk-day-block is-${bk}`}
+                      style={{ top, height }}
+                    >
+                      <div className="bk-day-block-name">
+                        {a.client.displayName}
+                      </div>
+                      <div className="bk-day-block-svc">
+                        {a.services
+                          .map((sv) => sv.serviceNameSnapshot)
+                          .join(" · ")}
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function buildOccupancy(
+  appointments: BookCalendarAppointment[],
+  staff: BookStaff[],
+  timezone: string,
+): boolean[][] {
+  const out: boolean[][] = staff.map(() =>
+    Array(TOTAL_SLOTS).fill(false) as boolean[],
+  );
+  for (const a of appointments) {
+    if (a.status === "CANCELLED" || a.status === "NO_SHOW") continue;
+    const ci = staff.findIndex((s) => s.id === a.staffMember.id);
+    if (ci === -1) continue;
+    const startMin = minutesFromIso(a.startAt, timezone);
+    const endMin = minutesFromIso(a.endAt, timezone);
+    const startSlot = Math.max(
+      0,
+      Math.floor((startMin - SLOT_START_MIN) / SLOT_MIN),
+    );
+    const endSlot = Math.min(
+      TOTAL_SLOTS,
+      Math.ceil((endMin - SLOT_START_MIN) / SLOT_MIN),
+    );
+    for (let i = startSlot; i < endSlot; i++) {
+      const row = out[ci];
+      if (row) row[i] = true;
+    }
+  }
+  return out;
+}
+
+function minutesFromIso(iso: string, timezone: string): number {
+  const hm = formatTz(new Date(iso), "HH:mm", { timeZone: timezone });
+  const [h, m] = hm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minutesLabel(m: number): string {
+  const h = Math.floor(m / 60);
+  const meridiem = h < 12 ? "AM" : "PM";
+  const display = ((h + 11) % 12) + 1;
+  return `${display} ${meridiem}`;
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p.charAt(0).toUpperCase())
+    .join("");
+}
+
+function formatDateLabel(iso: string, timezone: string): string {
+  const d = fromZonedTime(`${iso}T12:00:00`, timezone);
+  return formatTz(d, "EEEE, MMMM d", { timeZone: timezone });
+}
+

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -284,6 +284,12 @@ export function ScheduleView({
           </Link>
           <span className="ss-schedule-toolbar-meta">{dayLabel}</span>
         </div>
+        <Link
+          href={`/schedule/new?date=${isoDate}`}
+          className="ss-btn ss-btn-primary"
+        >
+          + New booking
+        </Link>
       </div>
 
       {errorMsg && (

--- a/apps/web/src/app/(app)/schedule/new/page.tsx
+++ b/apps/web/src/app/(app)/schedule/new/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { apiFetch } from "@/lib/api";
+import { PageHeader } from "@/components/form";
+import { todayIsoInTimezone } from "@/lib/salon-time";
+import {
+  BookAppointmentForm,
+  type BookClient,
+  type BookService,
+  type BookStaff,
+} from "../_components/book-appointment-form";
+
+interface SettingsResponse {
+  timezone: string;
+}
+
+export default async function NewBookingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string; staff?: string; client?: string }>;
+}) {
+  const params = await searchParams;
+  const settings = await apiFetch<SettingsResponse>("/settings");
+  const tz = settings.timezone;
+  const initialDate = params.date ?? todayIsoInTimezone(tz);
+
+  const [staff, services, clients] = await Promise.all([
+    apiFetch<BookStaff[]>("/staff"),
+    apiFetch<BookService[]>("/services"),
+    apiFetch<BookClient[]>("/clients"),
+  ]);
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="Schedule"
+        title="Book an appointment"
+        description="Pick a client, services, stylist, and time. The schedule will reject conflicts."
+        action={
+          <Link href="/schedule" className="ss-link">
+            ← Back to schedule
+          </Link>
+        }
+      />
+
+      <BookAppointmentForm
+        timezone={tz}
+        initialDate={initialDate}
+        initialStaffId={params.staff ?? null}
+        initialClientId={params.client ?? null}
+        staff={staff.filter((s) => s.isActive)}
+        services={services.filter((s) => s.isActive)}
+        clients={clients}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/schedule/new/page.tsx
+++ b/apps/web/src/app/(app)/schedule/new/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { format as formatTz, fromZonedTime } from "date-fns-tz";
 import { apiFetch } from "@/lib/api";
 import { PageHeader } from "@/components/form";
 import { todayIsoInTimezone } from "@/lib/salon-time";
@@ -8,25 +9,51 @@ import {
   type BookService,
   type BookStaff,
 } from "../_components/book-appointment-form";
+import type { BookCalendarAppointment } from "../_components/book-calendar";
 
 interface SettingsResponse {
   timezone: string;
 }
 
+const VIEW_MONTH = /^\d{4}-\d{2}$/;
+
 export default async function NewBookingPage({
   searchParams,
 }: {
-  searchParams: Promise<{ date?: string; staff?: string; client?: string }>;
+  searchParams: Promise<{
+    date?: string;
+    staff?: string;
+    client?: string;
+    month?: string;
+  }>;
 }) {
   const params = await searchParams;
   const settings = await apiFetch<SettingsResponse>("/settings");
   const tz = settings.timezone;
-  const initialDate = params.date ?? todayIsoInTimezone(tz);
+  const todayIso = todayIsoInTimezone(tz);
+  const initialDate = params.date ?? todayIso;
 
-  const [staff, services, clients] = await Promise.all([
+  // Default the month view to whichever month the selected date sits in.
+  // If the caller passes ?month explicitly, it wins so the calendar can
+  // navigate independently of the picked date.
+  const fallbackMonth = initialDate.slice(0, 7);
+  const viewMonth =
+    params.month && VIEW_MONTH.test(params.month) ? params.month : fallbackMonth;
+
+  const monthBounds = monthRange(viewMonth, tz);
+  const prevMonthIso = shiftYearMonth(viewMonth, -1);
+  const nextMonthIso = shiftYearMonth(viewMonth, 1);
+
+  const [staff, services, clients, monthAppointments] = await Promise.all([
     apiFetch<BookStaff[]>("/staff"),
     apiFetch<BookService[]>("/services"),
     apiFetch<BookClient[]>("/clients"),
+    apiFetch<BookCalendarAppointment[]>("/appointments", {
+      query: {
+        from: monthBounds.fromUtc.toISOString(),
+        to: monthBounds.toUtc.toISOString(),
+      },
+    }),
   ]);
 
   return (
@@ -34,7 +61,7 @@ export default async function NewBookingPage({
       <PageHeader
         eyebrow="Schedule"
         title="Book an appointment"
-        description="Pick a client, services, stylist, and time. The schedule will reject conflicts."
+        description="Pick a client, services, and stylist, then choose an open slot. Conflicts are rejected by the API."
         action={
           <Link href="/schedule" className="ss-link">
             ← Back to schedule
@@ -50,7 +77,61 @@ export default async function NewBookingPage({
         staff={staff.filter((s) => s.isActive)}
         services={services.filter((s) => s.isActive)}
         clients={clients}
+        viewMonth={viewMonth}
+        prevMonthIso={prevMonthIso}
+        nextMonthIso={nextMonthIso}
+        todayIso={todayIso}
+        monthAppointments={monthAppointments}
       />
     </>
   );
+}
+
+// Compute the UTC window covering the salon-local calendar grid for a given
+// "YYYY-MM". We grab a buffer week on each side so the month view's leading /
+// trailing days from neighbor months still show their density bars.
+function monthRange(viewMonth: string, timezone: string) {
+  const [yearStr, monthStr] = viewMonth.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const firstOfMonth = `${viewMonth}-01`;
+  const fromAnchor = fromZonedTime(`${firstOfMonth}T12:00:00`, timezone);
+  // Walk back to the Sunday on or before the first.
+  const dow = Number(formatTz(fromAnchor, "i", { timeZone: timezone })); // 1..7 Mon..Sun
+  const offsetToSunday = dow === 7 ? 0 : -dow;
+  const fromUtc = fromZonedTime(
+    addDays(firstOfMonth, offsetToSunday) + "T00:00:00",
+    timezone,
+  );
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const lastOfMonth = `${viewMonth}-${String(lastDay).padStart(2, "0")}`;
+  const toAnchor = fromZonedTime(`${lastOfMonth}T12:00:00`, timezone);
+  const lastDow = Number(formatTz(toAnchor, "i", { timeZone: timezone }));
+  const offsetToSaturday = lastDow === 6 ? 1 : ((6 - lastDow) % 7) + 1;
+  const toUtc = fromZonedTime(
+    addDays(lastOfMonth, offsetToSaturday) + "T00:00:00",
+    timezone,
+  );
+  return { fromUtc, toUtc };
+}
+
+function shiftYearMonth(yearMonth: string, delta: number): string {
+  const [y, m] = yearMonth.split("-").map(Number);
+  if (!y || !m) return yearMonth;
+  const total = y * 12 + (m - 1) + delta;
+  const ny = Math.floor(total / 12);
+  const nm = (total % 12) + 1;
+  return `${ny}-${String(nm).padStart(2, "0")}`;
+}
+
+function addDays(iso: string, days: number): string {
+  // Calendar arithmetic on YYYY-MM-DD without crossing into a Date object —
+  // safe because we never reinterpret the result through any timezone.
+  const [y, m, d] = iso.split("-").map(Number);
+  const base = new Date(Date.UTC(y!, m! - 1, d!));
+  base.setUTCDate(base.getUTCDate() + days);
+  const ny = base.getUTCFullYear();
+  const nm = String(base.getUTCMonth() + 1).padStart(2, "0");
+  const nd = String(base.getUTCDate()).padStart(2, "0");
+  return `${ny}-${nm}-${nd}`;
 }

--- a/apps/web/src/app/(app)/schedule/new/page.tsx
+++ b/apps/web/src/app/(app)/schedule/new/page.tsx
@@ -16,6 +16,26 @@ interface SettingsResponse {
 }
 
 const VIEW_MONTH = /^\d{4}-\d{2}$/;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+// `?date=` from a hand-crafted URL flows straight into the form's selected
+// state and then into instantAtMinutes() at submit time — a malformed value
+// would throw there and abort the flow. Validate up front and quietly fall
+// back to today.
+function safeIsoDate(input: string | undefined, fallback: string): string {
+  if (!input || !ISO_DATE.test(input)) return fallback;
+  const [y, m, d] = input.split("-").map(Number);
+  if (!y || !m || !d) return fallback;
+  const date = new Date(Date.UTC(y, m - 1, d));
+  if (
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() !== m - 1 ||
+    date.getUTCDate() !== d
+  ) {
+    return fallback;
+  }
+  return input;
+}
 
 export default async function NewBookingPage({
   searchParams,
@@ -31,7 +51,7 @@ export default async function NewBookingPage({
   const settings = await apiFetch<SettingsResponse>("/settings");
   const tz = settings.timezone;
   const todayIso = todayIsoInTimezone(tz);
-  const initialDate = params.date ?? todayIso;
+  const initialDate = safeIsoDate(params.date, todayIso);
 
   // Default the month view to whichever month the selected date sits in.
   // If the caller passes ?month explicitly, it wins so the calendar can

--- a/apps/web/src/components/topbar.tsx
+++ b/apps/web/src/components/topbar.tsx
@@ -62,7 +62,7 @@ export function Topbar({
       </button>
 
       <Link
-        href="/schedule?new=1"
+        href="/schedule/new"
         className="ss-icon-btn"
         aria-label="New appointment"
       >

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1070,3 +1070,168 @@
   background: var(--ss-magenta-pale);
   color: var(--ss-magenta-deep);
 }
+
+/* ====================================================
+   Phase 3e — booking flow at /schedule/new.
+==================================================== */
+
+.ss-book-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 960px) {
+  .ss-book-grid { grid-template-columns: 1fr; }
+}
+.ss-book-main { display: flex; flex-direction: column; gap: 18px; }
+.ss-book-aside .ss-card { position: sticky; top: 24px; }
+
+/* Client picker: search box + scrollable list of result rows. */
+.ss-book-search {
+  width: 100%;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel-strong);
+  color: var(--ss-text-primary);
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 13.5px;
+  outline: none;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+.ss-book-search:focus {
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 4px rgba(30, 195, 217, 0.16);
+}
+.ss-book-client-list {
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex; flex-direction: column;
+  gap: 4px;
+}
+.ss-book-client-row {
+  display: flex; flex-direction: column;
+  align-items: stretch; text-align: left;
+  padding: 8px 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: var(--font-quicksand), sans-serif;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+.ss-book-client-row:hover {
+  background: var(--ss-magenta-pale);
+}
+.ss-book-client-row.is-selected {
+  background: var(--ss-sidebar-active);
+  border-color: var(--ss-line-strong);
+}
+.ss-book-client-name {
+  font-size: 13.5px; font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-book-client-meta {
+  font-size: 12px;
+  color: var(--ss-text-muted);
+}
+
+/* Service multi-select grouped by category. */
+.ss-book-svc-group + .ss-book-svc-group { margin-top: 16px; }
+.ss-book-svc-group-name {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+  margin-bottom: 6px;
+}
+.ss-book-svc-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+.ss-book-svc-row:hover { background: var(--ss-magenta-pale); }
+.ss-book-svc-row.is-selected { background: var(--ss-sidebar-active); }
+.ss-book-svc-row input[type="checkbox"] {
+  width: 16px; height: 16px;
+  accent-color: var(--ss-magenta);
+}
+.ss-book-svc-name {
+  flex: 1;
+  font-size: 13.5px;
+  color: var(--ss-text-primary);
+}
+.ss-book-svc-meta {
+  font-size: 12px;
+  color: var(--ss-text-muted);
+}
+
+/* Stylist picker: avatar tiles. */
+.ss-book-staff-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.ss-book-staff-card {
+  display: flex; flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--ss-line);
+  background: var(--ss-panel);
+  cursor: pointer;
+  font-family: var(--font-quicksand), sans-serif;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+.ss-book-staff-card:hover {
+  border-color: var(--ss-line-strong);
+  background: var(--ss-panel-strong);
+}
+.ss-book-staff-card.is-selected {
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 3px rgba(30, 195, 217, 0.16);
+}
+.ss-book-staff-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.ss-book-staff-role {
+  font-size: 11px;
+  color: var(--ss-text-muted);
+  text-align: center;
+}
+.ss-book-end-hint {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  color: var(--ss-text-secondary);
+}
+
+/* Summary side card. */
+.ss-book-summary-row {
+  display: flex; flex-direction: column;
+  gap: 2px;
+  padding: 10px 0;
+  border-top: 1px dashed var(--ss-line);
+}
+.ss-book-summary-row:first-of-type { border-top: 0; padding-top: 0; }
+.ss-book-summary-label {
+  font-family: var(--font-quicksand), sans-serif;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ss-text-muted);
+}
+.ss-book-summary-value {
+  font-size: 13.5px;
+  color: var(--ss-text-heading);
+  word-break: break-word;
+}

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1235,3 +1235,473 @@
   color: var(--ss-text-heading);
   word-break: break-word;
 }
+
+/* ====================================================
+   Phase 3e — month → day booking calendar.
+==================================================== */
+.bk-calendar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* breadcrumbs */
+.bk-cal-crumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--ss-text-muted);
+}
+.bk-cal-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 6px;
+  border-radius: 8px;
+  background: rgba(30, 195, 217, 0.10);
+  border: 1px solid rgba(30, 195, 217, 0.25);
+  color: var(--ss-magenta);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.bk-cal-back:hover { background: rgba(30, 195, 217, 0.18); }
+.bk-cal-crumb-sep { color: var(--ss-text-muted); }
+.bk-cal-crumb-current { color: var(--ss-text-heading); font-weight: 500; }
+.bk-cal-month-link {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--ss-magenta);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* month grid */
+.bk-month {
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 14px;
+  padding: 12px 14px;
+}
+.theme-twilight .bk-month { background: rgba(255, 255, 255, 0.04); }
+.bk-month-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.bk-month-dows {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-bottom: 6px;
+}
+.bk-month-dows span {
+  text-align: center;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ss-text-muted);
+}
+.bk-month-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-auto-rows: 56px;
+  gap: 2px;
+}
+.bk-month-cell {
+  position: relative;
+  background: rgba(255, 255, 255, 0.4);
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 8px;
+  padding: 6px 6px 8px;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: border-color 100ms ease, background 100ms ease, box-shadow 100ms ease;
+}
+.theme-twilight .bk-month-cell { background: rgba(255, 255, 255, 0.04); }
+.bk-month-cell:hover {
+  border-color: rgba(30, 195, 217, 0.45);
+  background: rgba(30, 195, 217, 0.06);
+}
+.bk-month-cell.is-out {
+  background: transparent;
+  border-color: transparent;
+  cursor: default;
+  opacity: 0.35;
+}
+.bk-month-cell.is-out:hover { background: transparent; border-color: transparent; }
+.bk-month-cell.is-today {
+  border-color: rgba(233, 30, 158, 0.45);
+}
+.bk-month-cell.is-today .bk-month-num {
+  color: #e91e9e;
+}
+.bk-month-cell.is-selected {
+  background: linear-gradient(180deg, rgba(30, 195, 217, 0.22), rgba(30, 195, 217, 0.08));
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 2px rgba(30, 195, 217, 0.18);
+}
+.bk-month-cell.is-closed {
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(15, 28, 47, 0.04) 0 4px,
+    transparent 4px 8px
+  );
+}
+.theme-twilight .bk-month-cell.is-closed {
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.05) 0 4px,
+    transparent 4px 8px
+  );
+}
+.bk-month-num {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.bk-month-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(15, 28, 47, 0.05);
+  overflow: hidden;
+  position: relative;
+}
+.theme-twilight .bk-month-bar { background: rgba(255, 255, 255, 0.06); }
+.bk-month-seg {
+  display: block;
+  min-width: 0;
+}
+.bk-month-seg.is-color  { background: linear-gradient(90deg, #e91e9e, #ff48b9); }
+.bk-month-seg.is-cut    { background: linear-gradient(90deg, #1ec3d9, #0892a8); }
+.bk-month-seg.is-treat  { background: linear-gradient(90deg, #b88dde, #8a5ec4); }
+.bk-month-seg.is-style  { background: linear-gradient(90deg, #ff9a76, #f57b56); }
+.bk-month-seg.is-bridal { background: linear-gradient(90deg, #d8b478, #a88052); }
+
+.bk-month-closed {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ss-text-muted);
+  background: transparent;
+}
+
+.bk-month-legend,
+.bk-day-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+  font-size: 11px;
+  color: var(--ss-text-muted);
+}
+.bk-month-legend span,
+.bk-day-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.bk-month-sw {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.bk-month-sw.is-color  { background: linear-gradient(135deg, #e91e9e, #ff48b9); }
+.bk-month-sw.is-cut    { background: linear-gradient(135deg, #1ec3d9, #0892a8); }
+.bk-month-sw.is-treat  { background: linear-gradient(135deg, #b88dde, #8a5ec4); }
+.bk-month-sw.is-style  { background: linear-gradient(135deg, #ff9a76, #f57b56); }
+.bk-month-sw.is-bridal { background: linear-gradient(135deg, #d8b478, #a88052); }
+
+/* week strip */
+.bk-weekstrip {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 12px;
+  padding: 8px;
+}
+.theme-twilight .bk-weekstrip { background: rgba(255, 255, 255, 0.04); }
+.bk-weekstrip-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 4px 8px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 100ms ease, border-color 100ms ease;
+}
+.bk-weekstrip-day:hover { background: rgba(0, 0, 0, 0.03); }
+.theme-twilight .bk-weekstrip-day:hover { background: rgba(255, 255, 255, 0.04); }
+.bk-weekstrip-day.is-today { border-color: rgba(233, 30, 158, 0.35); }
+.bk-weekstrip-day.is-selected {
+  background: linear-gradient(180deg, rgba(30, 195, 217, 0.22), rgba(30, 195, 217, 0.08));
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 1px rgba(30, 195, 217, 0.18);
+}
+.bk-weekstrip-day.is-closed { opacity: 0.4; cursor: default; }
+.bk-weekstrip-dow {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ss-text-muted);
+}
+.bk-weekstrip-num {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  font-variant-numeric: tabular-nums;
+}
+.bk-weekstrip-num em {
+  font-style: normal;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ss-text-muted);
+  margin-right: 2px;
+  vertical-align: 1px;
+}
+.bk-weekstrip-bar {
+  display: flex;
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: rgba(15, 28, 47, 0.06);
+  overflow: hidden;
+  margin-top: 2px;
+}
+.theme-twilight .bk-weekstrip-bar { background: rgba(255, 255, 255, 0.06); }
+
+/* day view */
+.bk-day {
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 14px;
+  padding: 12px 14px;
+}
+.theme-twilight .bk-day { background: rgba(255, 255, 255, 0.04); }
+.bk-day-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 10px;
+}
+.bk-day-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.bk-day-title strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.bk-day-sub {
+  font-size: 11.5px;
+  color: var(--ss-text-muted);
+}
+.bk-day-grid {
+  display: grid;
+  grid-template-rows: 28px;
+  position: relative;
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.theme-twilight .bk-day-grid { background: rgba(255, 255, 255, 0.04); }
+
+.bk-day-h-spacer {
+  border-bottom: 1px solid var(--ss-panel-edge);
+  background: rgba(15, 28, 47, 0.02);
+}
+.theme-twilight .bk-day-h-spacer { background: rgba(255, 255, 255, 0.03); }
+.bk-day-h {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--ss-panel-edge);
+  border-left: 1px solid var(--ss-panel-edge);
+  background: rgba(15, 28, 47, 0.02);
+  font-size: 11.5px;
+  position: relative;
+}
+.theme-twilight .bk-day-h { background: rgba(255, 255, 255, 0.03); }
+.bk-day-h::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: var(--bk-stylist-tint);
+}
+.bk-day-h-avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 600;
+  color: #fff;
+  flex: none;
+}
+.bk-day-h-name {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bk-day-times {
+  position: relative;
+  border-right: 1px solid var(--ss-panel-edge);
+  background: rgba(15, 28, 47, 0.015);
+}
+.theme-twilight .bk-day-times { background: rgba(255, 255, 255, 0.02); }
+.bk-day-time {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 2px 6px 0 0;
+  font-size: 10px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--ss-text-muted);
+  border-bottom: 1px solid var(--ss-panel-edge);
+  box-sizing: border-box;
+}
+
+.bk-day-col {
+  position: relative;
+  border-left: 1px solid var(--ss-panel-edge);
+}
+.bk-day-hour-line {
+  position: absolute;
+  left: 0; right: 0;
+  height: 1px;
+  background: var(--ss-panel-edge);
+}
+.bk-day-half-line {
+  position: absolute;
+  left: 0; right: 0;
+  height: 1px;
+  background: rgba(15, 28, 47, 0.05);
+}
+.theme-twilight .bk-day-half-line { background: rgba(255, 255, 255, 0.05); }
+
+.bk-day-open {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  background: transparent;
+  border: 1px dashed rgba(15, 28, 47, 0.18);
+  border-radius: 4px;
+  padding: 0;
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+.theme-twilight .bk-day-open { border-color: rgba(255, 255, 255, 0.18); }
+.bk-day-open:hover {
+  background: rgba(30, 195, 217, 0.10);
+  border-color: rgba(30, 195, 217, 0.5);
+  border-style: solid;
+}
+
+.bk-day-block {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  border-radius: 5px;
+  padding: 3px 6px;
+  font-size: 9.5px;
+  line-height: 1.15;
+  overflow: hidden;
+  border-left: 3px solid currentColor;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1px;
+}
+.bk-day-block.is-color {
+  color: #b6147c;
+  background: linear-gradient(135deg, rgba(233, 30, 158, 0.18), rgba(255, 72, 185, 0.10));
+}
+.bk-day-block.is-cut {
+  color: #0892a8;
+  background: linear-gradient(135deg, rgba(30, 195, 217, 0.20), rgba(8, 146, 168, 0.10));
+}
+.bk-day-block.is-treat {
+  color: #6c3fb0;
+  background: linear-gradient(135deg, rgba(184, 141, 222, 0.22), rgba(138, 94, 196, 0.10));
+}
+.bk-day-block.is-style {
+  color: #c25a32;
+  background: linear-gradient(135deg, rgba(255, 154, 118, 0.22), rgba(245, 123, 86, 0.10));
+}
+.bk-day-block.is-bridal {
+  color: #8a6432;
+  background: linear-gradient(135deg, rgba(216, 180, 120, 0.24), rgba(168, 128, 82, 0.12));
+}
+.bk-day-block.is-selected {
+  color: var(--ss-magenta);
+  background: linear-gradient(135deg, rgba(30, 195, 217, 0.32), rgba(30, 195, 217, 0.14));
+  border-left-color: var(--ss-magenta);
+  box-shadow: 0 0 0 1.5px rgba(30, 195, 217, 0.5), 0 4px 10px rgba(30, 195, 217, 0.18);
+  outline: 1px dashed rgba(30, 195, 217, 0.5);
+  outline-offset: -3px;
+}
+.theme-twilight .bk-day-block.is-color { color: #ff9ad9; }
+.theme-twilight .bk-day-block.is-cut { color: #5cdcec; }
+.theme-twilight .bk-day-block.is-treat { color: #c8a8e8; }
+.theme-twilight .bk-day-block.is-style { color: #ffb89e; }
+.theme-twilight .bk-day-block.is-bridal { color: #e8c890; }
+
+.bk-day-block-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--ss-text-heading);
+}
+.bk-day-block-svc {
+  font-size: 9px;
+  opacity: 0.85;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+


### PR DESCRIPTION
## Summary

A focused booking page wired to `POST /appointments`. Pick a client → services → stylist → date + time → notes → submit. The API's Phase-3a conflict detection surfaces inline as a 409 banner so two stylists can't double-book the same slot.

**Layout** — two-column `.ss-book-grid`:
- Left: stacked Cards for Client, Services, Stylist, Date & Time, Notes.
- Right: sticky Summary card with running totals (duration, price), inline error, and the primary CTA.

**Pickers**
- **Client** — search-as-you-type across name / phone / email; selectable rows with the design's hover/selected states.
- **Services** — grouped by category; multi-select checkboxes; total duration recomputes live so the end-time hint shows under the time picker.
- **Stylist** — tiles with the same gradient avatars the schedule uses.
- **Date / time** — native `<input type="date">` plus a select limited to the 9 AM – 7 PM, 15-min slot grid the calendar renders. Submit converts to UTC via `instantAtMinutes()` so DST is handled consistently with drag-to-reschedule.

**Entry points**
- Topbar's `+` icon now routes to `/schedule/new` (was a placeholder query-string).
- Schedule toolbar gets a `+ New booking` primary button anchored to the currently-viewed date.

**Deliberately deferred** from the design's full booking flow:
- Recurring appointments
- SMS confirmation preview
- Inline new-client creation (use `/clients/new`)
- Stylist-trained-for-service warnings (no skills model in the schema)
- Waitlist
- The fancy month-grid → day-grid drilldown — using simple date + time inputs for now

These can land as a follow-up if/when the use case shows up.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `next dev` starts and `/sign-in` returns 200.
- [ ] Manual UI dogfood (couldn't fully exercise from the agent — needs DB):
  - Topbar `+` and schedule's `+ New booking` route to `/schedule/new`.
  - Client search filters live; selecting one fills the summary.
  - Services toggle on/off; duration + price update.
  - Picking a stylist + date + time and submitting creates the appointment and lands you back on the schedule with the new block visible.
  - Booking into a slot that overlaps a real-time conflict surfaces the API's 409 message inline.