### PR TITLE
Phase 4a: messaging backend (confirmation SMS via outbox)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,17 +143,37 @@ on `/schedule` (`?book=1` query state, so back/forward and shareable URLs work).
 
 **Risks:** time zones. Store everything UTC; render in salon's `timezone`. DST edge cases at the salon-hour boundary.
 
-## Phase 4 — Messaging (SMS) ⬜
+## Phase 4 — Messaging (SMS) 🚧
 
 Outbound first, inbound second. Reminder jobs separate from confirmations.
 
-- Twilio adapter behind a `MessagingProvider` interface (mirror the auth pattern)
-- Outbox worker: on `appointment.created` send confirmation SMS; idempotent on `Message.providerMessageId`
-- Reminder jobs (BullMQ): scheduled at appointment creation, cancelled on reschedule/cancel
+### Phase 4a — Messaging backend 🚧
+
+- `MessagingProvider` interface, switchable on `MESSAGING_PROVIDER` env
+  (`dev` logs and returns a fake sid; `twilio` uses the official SDK)
+- Outbox worker now actually dispatches: `appointment.created` → confirmation SMS
+- Idempotent on `Message.outboxEventId` (new schema column) so retries don't double-send
+- Inbound webhook `POST /webhooks/twilio/sms` with HMAC signature validation,
+  deduped on `processed_webhook_events.(source, externalEventId)`, routes
+  inbound messages to the salon by sender phone (single-shared-number caveat — see 4b)
+- Message body templated per appointment in the salon's timezone, includes STOP instruction
+- Vitest coverage for the formatter + handler flow control (send / dedup / cancelled / no phone / send failure)
+
+**Out of scope (intentional):** reminder scheduling, reschedule/cancel SMS, message-history UI, per-salon Twilio numbers, deep-link tokens. Those land in 4b.
+
+### Phase 4b — Reminders + per-salon numbers + history UI ⬜
+
+- BullMQ-backed reminder jobs scheduled at appointment creation, cancelled on reschedule/cancel
+- Per-salon Twilio numbers stored on `Salon` so inbound routes by `To` instead of by sender phone
+- Reschedule / cancel notifications (new outbox event types and handlers)
 - Cancellation / reschedule deep links signed with short-lived tokens
-- Inbound webhook (Twilio → API) logs to `messages` and appends `message.sms_received`
-- Message history per client
-- **A2P 10DLC compliance work** documented separately: brand registration, campaign approval. Without it, US carriers will filter or block.
+- Message history per client (UI)
+- Switch outbox worker from poll-and-update to BullMQ leasing with proper heartbeat
+
+### A2P 10DLC compliance — separate workstream
+
+- Brand registration, campaign approval. Without it, US carriers will filter or block.
+- Terms / privacy policy live at `docs/sms-terms.md` and `docs/privacy-policy.md`.
 
 **Risks:** Twilio webhook signature validation, replay protection. Long messages segmenting cost-of-delivery surprises.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "svix": "1",
+    "twilio": "^5.4.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { AppointmentsModule } from "./appointments/appointments.module";
 import { OutboxModule } from "./outbox/outbox.module";
 import { SettingsModule } from "./settings/settings.module";
 import { WebhooksModule } from "./webhooks/webhooks.module";
+import { MessagingModule } from "./messaging/messaging.module";
 
 // AuthGuard runs first; TenantGuard depends on the identity it attaches to
 // the request. Order matters: Nest evaluates global guards in registration
@@ -28,6 +29,7 @@ import { WebhooksModule } from "./webhooks/webhooks.module";
     ServicesModule,
     ClientsModule,
     AppointmentsModule,
+    MessagingModule,
     OutboxModule,
     SettingsModule,
     WebhooksModule,

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -28,20 +28,49 @@ const schema = z
     // Next.js to expose it to the browser); the API reads the same value.
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().optional(),
     CLERK_WEBHOOK_SECRET: z.string().optional(),
+
+    // Phase 4a — messaging.
+    MESSAGING_PROVIDER: z.enum(["dev", "twilio"]).default("dev"),
+    TWILIO_ACCOUNT_SID: z.string().optional(),
+    TWILIO_AUTH_TOKEN: z.string().optional(),
+    // Single from-number for all salons in 4a. Per-salon numbers land in 4b
+    // along with the salon-settings UI.
+    TWILIO_FROM_NUMBER: z.string().optional(),
+    // Public origin Twilio POSTs webhooks to (used to reconstruct the URL
+    // for signature verification when behind a proxy that rewrites the host).
+    // Optional: when unset we trust the request's own host header.
+    TWILIO_WEBHOOK_PUBLIC_URL: z.string().url().optional(),
   })
   .superRefine((env, ctx) => {
-    if (env.AUTH_PROVIDER !== "clerk") return;
-    for (const key of [
-      "CLERK_SECRET_KEY",
-      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
-      "CLERK_WEBHOOK_SECRET",
-    ] as const) {
-      if (!env[key]) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: [key],
-          message: `${key} is required when AUTH_PROVIDER=clerk`,
-        });
+    if (env.AUTH_PROVIDER === "clerk") {
+      for (const key of [
+        "CLERK_SECRET_KEY",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "CLERK_WEBHOOK_SECRET",
+      ] as const) {
+        if (!env[key]) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key],
+            message: `${key} is required when AUTH_PROVIDER=clerk`,
+          });
+        }
+      }
+    }
+
+    if (env.MESSAGING_PROVIDER === "twilio") {
+      for (const key of [
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_AUTH_TOKEN",
+        "TWILIO_FROM_NUMBER",
+      ] as const) {
+        if (!env[key]) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key],
+            message: `${key} is required when MESSAGING_PROVIDER=twilio`,
+          });
+        }
       }
     }
   });

--- a/apps/api/src/messaging/dev-messaging.provider.ts
+++ b/apps/api/src/messaging/dev-messaging.provider.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
+import { env } from "../env";
+import type {
+  MessagingProvider,
+  SendSmsArgs,
+  SendSmsResult,
+  ValidateInboundArgs,
+} from "./messaging-provider.interface";
+
+/**
+ * Local-development messaging provider. Logs every outbound SMS to the API log
+ * and returns a synthetic sid prefixed `dev_` so it never collides with a
+ * real Twilio sid (`SM...`).
+ *
+ * Inbound signature validation is a no-op — local testing simulates Twilio
+ * webhooks via curl, which can't sign with the production auth token. Refuses
+ * to run when NODE_ENV=production so this can't accidentally ship.
+ */
+@Injectable()
+export class DevMessagingProvider implements MessagingProvider {
+  private readonly logger = new Logger(DevMessagingProvider.name);
+
+  async sendSms(args: SendSmsArgs): Promise<SendSmsResult> {
+    if (env.NODE_ENV === "production") {
+      throw new Error("DevMessagingProvider must not run in production");
+    }
+    const sid = `dev_${randomUUID()}`;
+    this.logger.log(
+      `[dev-sms] from=${args.from} to=${args.to} sid=${sid} body=${JSON.stringify(args.body)}`,
+    );
+    return { providerMessageId: sid, status: "SENT" };
+  }
+
+  validateInboundSignature(_args: ValidateInboundArgs): boolean {
+    if (env.NODE_ENV === "production") {
+      throw new Error("DevMessagingProvider must not run in production");
+    }
+    return true;
+  }
+}

--- a/apps/api/src/messaging/messaging-provider.interface.ts
+++ b/apps/api/src/messaging/messaging-provider.interface.ts
@@ -1,0 +1,41 @@
+export const MESSAGING_PROVIDER = Symbol("MessagingProvider");
+
+export interface SendSmsArgs {
+  to: string;
+  from: string;
+  body: string;
+}
+
+export interface SendSmsResult {
+  providerMessageId: string;
+  /** Provider-reported status at the time the API call returned. The terminal
+   *  state (DELIVERED / FAILED) usually arrives later via a status callback. */
+  status: "QUEUED" | "SENT" | "DELIVERED" | "FAILED";
+}
+
+export interface ValidateInboundArgs {
+  /** The header the provider used to sign the request (Twilio: X-Twilio-Signature). */
+  signature: string;
+  /** Full request URL the provider POSTed to, exactly as it was hit (no rewriting). */
+  url: string;
+  /** Form fields from the body, used to compute the expected HMAC. */
+  params: Record<string, string>;
+}
+
+/**
+ * Pluggable SMS delivery + inbound verification, mirroring the AuthProvider
+ * pattern. Implementations:
+ *  - DevMessagingProvider: never calls a real network — logs to the API log
+ *    and returns a fake sid. Inbound signature check is a no-op so a curl can
+ *    simulate Twilio webhooks locally.
+ *  - TwilioMessagingProvider: real outbound via the Twilio REST API and real
+ *    HMAC-SHA1 signature verification on inbound webhooks.
+ *
+ * Throws on send failure so the outbox worker can retry. Idempotency is the
+ * worker's responsibility (it inserts a Message row keyed by outboxEventId
+ * before this is called).
+ */
+export interface MessagingProvider {
+  sendSms(args: SendSmsArgs): Promise<SendSmsResult>;
+  validateInboundSignature(args: ValidateInboundArgs): boolean;
+}

--- a/apps/api/src/messaging/messaging.module.ts
+++ b/apps/api/src/messaging/messaging.module.ts
@@ -1,0 +1,35 @@
+import { Global, Module, type Provider } from "@nestjs/common";
+import { PrismaModule } from "../prisma/prisma.module";
+import { env } from "../env";
+import { MESSAGING_PROVIDER } from "./messaging-provider.interface";
+import { DevMessagingProvider } from "./dev-messaging.provider";
+import { TwilioMessagingProvider } from "./twilio-messaging.provider";
+import { SmsHandlersService } from "./sms-handlers.service";
+
+const messagingProviderFactory: Provider = {
+  provide: MESSAGING_PROVIDER,
+  useFactory: () => {
+    switch (env.MESSAGING_PROVIDER) {
+      case "dev":
+        return new DevMessagingProvider();
+      case "twilio":
+        return new TwilioMessagingProvider();
+    }
+  },
+};
+
+// Global so the OutboxWorker (in OutboxModule) and the Twilio webhook controller
+// (in WebhooksModule) can both inject MESSAGING_PROVIDER + SmsHandlersService
+// without re-importing.
+@Global()
+@Module({
+  imports: [PrismaModule],
+  providers: [
+    messagingProviderFactory,
+    DevMessagingProvider,
+    TwilioMessagingProvider,
+    SmsHandlersService,
+  ],
+  exports: [MESSAGING_PROVIDER, SmsHandlersService],
+})
+export class MessagingModule {}

--- a/apps/api/src/messaging/messaging.module.ts
+++ b/apps/api/src/messaging/messaging.module.ts
@@ -6,6 +6,11 @@ import { DevMessagingProvider } from "./dev-messaging.provider";
 import { TwilioMessagingProvider } from "./twilio-messaging.provider";
 import { SmsHandlersService } from "./sms-handlers.service";
 
+// Only the selected provider is constructed. Listing both classes in
+// `providers` would have Nest eagerly instantiate them on bootstrap, and
+// TwilioMessagingProvider's constructor throws when its env vars are absent
+// — which would crash startup in any dev/test env that left the Twilio
+// creds unset.
 const messagingProviderFactory: Provider = {
   provide: MESSAGING_PROVIDER,
   useFactory: () => {
@@ -24,12 +29,7 @@ const messagingProviderFactory: Provider = {
 @Global()
 @Module({
   imports: [PrismaModule],
-  providers: [
-    messagingProviderFactory,
-    DevMessagingProvider,
-    TwilioMessagingProvider,
-    SmsHandlersService,
-  ],
+  providers: [messagingProviderFactory, SmsHandlersService],
   exports: [MESSAGING_PROVIDER, SmsHandlersService],
 })
 export class MessagingModule {}

--- a/apps/api/src/messaging/sms-formatter.ts
+++ b/apps/api/src/messaging/sms-formatter.ts
@@ -1,0 +1,54 @@
+interface AppointmentForSms {
+  startAt: Date;
+  staffFirstName: string;
+  serviceNames: string[];
+  durationMinutes: number;
+  clientFirstName: string;
+  salonName: string;
+  salonTimezone: string;
+}
+
+/**
+ * Templated confirmation SMS body. Kept short so it fits in one segment when
+ * possible (160 GSM-7 chars). Includes a STOP instruction per A2P 10DLC
+ * carrier requirements — the SMS terms doc at docs/sms-terms.md is the
+ * canonical contract this body needs to honour.
+ */
+export function formatConfirmationSms(input: AppointmentForSms): string {
+  const date = formatDateLabel(input.startAt, input.salonTimezone);
+  const time = formatTimeLabel(input.startAt, input.salonTimezone);
+  const services = input.serviceNames.join(", ");
+  const dur = input.durationMinutes;
+  return (
+    `${input.salonName}: Hi ${input.clientFirstName}, you're booked ` +
+    `${date} at ${time} with ${input.staffFirstName} (${services}, ${dur} min). ` +
+    `Reply STOP to opt out.`
+  );
+}
+
+export function firstName(displayName: string): string {
+  // The displayName is "First Last" / "First" / "First M. Last" — anything
+  // before the first whitespace is the bit we'd address the client by.
+  const trimmed = displayName.trim();
+  if (!trimmed) return "there";
+  const idx = trimmed.indexOf(" ");
+  return idx === -1 ? trimmed : trimmed.slice(0, idx);
+}
+
+function formatDateLabel(instant: Date, timeZone: string): string {
+  // "Wed Apr 30" — short to keep the body inside one SMS segment.
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(instant);
+}
+
+function formatTimeLabel(instant: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(instant);
+}

--- a/apps/api/src/messaging/sms-handlers.service.ts
+++ b/apps/api/src/messaging/sms-handlers.service.ts
@@ -151,7 +151,7 @@ export class SmsHandlersService {
       });
       messageRowId = created.id;
     } catch (err) {
-      if (isUniqueConstraintError(err, "messages_outboxEventId_key")) {
+      if (isOutboxEventDedupConflict(err)) {
         const existing = await this.prisma.message.findUnique({
           where: { outboxEventId: event.id },
         });
@@ -194,14 +194,24 @@ export class SmsHandlersService {
       throw sendErr;
     }
 
+    // Pass the provider's status through verbatim — Twilio's create-time
+    // response is often still QUEUED/accepted, and the carrier-side terminal
+    // state (DELIVERED / FAILED) only arrives later via a status callback.
+    // Forcing SENT here would lie about delivery progress.
+    const messageStatus: MessageStatus =
+      result.status === "FAILED"
+        ? MessageStatus.FAILED
+        : result.status === "DELIVERED"
+          ? MessageStatus.DELIVERED
+          : result.status === "SENT"
+            ? MessageStatus.SENT
+            : MessageStatus.QUEUED;
+
     await this.prisma.$transaction(async (tx) => {
       await tx.message.update({
         where: { id: messageRowId },
         data: {
-          status:
-            result.status === "FAILED"
-              ? MessageStatus.FAILED
-              : MessageStatus.SENT,
+          status: messageStatus,
           providerMessageId: result.providerMessageId,
           sentAt: new Date(),
         },
@@ -225,13 +235,22 @@ export class SmsHandlersService {
   }
 }
 
-function isUniqueConstraintError(err: unknown, target: string): boolean {
-  if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-    const meta = err.meta as { target?: string | string[] } | undefined;
-    if (!meta?.target) return false;
-    return Array.isArray(meta.target)
-      ? meta.target.includes(target)
-      : meta.target === target;
+// Prisma reports P2002's target inconsistently across drivers/versions: it
+// can be the literal index name ("messages_outboxEventId_key") or the field
+// list (["outboxEventId"]) or a single field name ("outboxEventId").
+// Match all three so a real conflict can't slip through and rethrow into
+// dead-letter.
+function isOutboxEventDedupConflict(err: unknown): boolean {
+  if (
+    !(err instanceof Prisma.PrismaClientKnownRequestError) ||
+    err.code !== "P2002"
+  ) {
+    return false;
   }
-  return false;
+  const target = (err.meta as { target?: string | string[] } | undefined)
+    ?.target;
+  if (!target) return false;
+  const matches = (s: string) =>
+    s === "messages_outboxEventId_key" || s === "outboxEventId";
+  return Array.isArray(target) ? target.some(matches) : matches(target);
 }

--- a/apps/api/src/messaging/sms-handlers.service.ts
+++ b/apps/api/src/messaging/sms-handlers.service.ts
@@ -1,0 +1,237 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import {
+  ActorType,
+  AppointmentStatus,
+  MessageDirection,
+  MessageStatus,
+  Prisma,
+} from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import { env } from "../env";
+import { PrismaService } from "../prisma/prisma.service";
+import {
+  MESSAGING_PROVIDER,
+  type MessagingProvider,
+} from "./messaging-provider.interface";
+import { firstName, formatConfirmationSms } from "./sms-formatter";
+
+interface OutboxRow {
+  id: string;
+  eventType: string;
+  payload: Prisma.JsonValue;
+}
+
+const APPOINTMENT_INCLUDE = {
+  client: { select: { id: true, displayName: true, phone: true } },
+  staffMember: { select: { id: true, displayName: true } },
+  services: {
+    orderBy: [{ sortOrder: "asc" as const }],
+    select: {
+      serviceNameSnapshot: true,
+      durationSnapshotMinutes: true,
+    },
+  },
+} satisfies Prisma.AppointmentInclude;
+
+/**
+ * Outbox event handlers for the messaging side. Wired into the worker's
+ * dispatch table — the worker handles retry / dead-letter mechanics; this
+ * just decides what to do per event type.
+ *
+ * Idempotency contract: every send writes a Message row keyed by
+ * `outboxEventId`. A retry on the same event hits the unique constraint and
+ * we re-fetch the existing row to decide whether the send actually went
+ * through (`providerMessageId` present) or crashed mid-flight (it's not).
+ */
+@Injectable()
+export class SmsHandlersService {
+  private readonly logger = new Logger(SmsHandlersService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(MESSAGING_PROVIDER)
+    private readonly messaging: MessagingProvider,
+  ) {}
+
+  async handleAppointmentCreated(event: OutboxRow): Promise<void> {
+    // Pull the appointmentId out of the snapshot payload the writer stored
+    // alongside the event (see appointments.service.ts → create()).
+    const payload = (event.payload ?? {}) as { id?: string; salonId?: string };
+    const appointmentId = payload.id;
+    const salonId = payload.salonId;
+    if (!appointmentId || !salonId) {
+      this.logger.warn(
+        `appointment.created event ${event.id} missing id/salonId in payload — skipping`,
+      );
+      return;
+    }
+
+    const appointment = await this.prisma.appointment.findFirst({
+      where: { id: appointmentId, salonId },
+      include: APPOINTMENT_INCLUDE,
+    });
+    if (!appointment) {
+      // The appointment was hard-deleted before we got here. Nothing to do —
+      // but this shouldn't happen because we don't delete appointments. Log
+      // so it's visible if it ever does.
+      this.logger.warn(
+        `appointment.created event ${event.id} target appointment ${appointmentId} not found`,
+      );
+      return;
+    }
+    // Re-formatting on every attempt means a reschedule between create and
+    // send produces a confirmation for the *new* time, not the original one.
+    if (
+      appointment.status === AppointmentStatus.CANCELLED ||
+      appointment.status === AppointmentStatus.NO_SHOW
+    ) {
+      this.logger.log(
+        `appointment.created skipped: appointment ${appointmentId} is ${appointment.status}`,
+      );
+      return;
+    }
+
+    const toAddress = appointment.client?.phone ?? null;
+    if (!toAddress) {
+      // No phone on file → nothing we can send. Don't fail the outbox row;
+      // there's no retry that fixes a missing phone.
+      this.logger.log(
+        `appointment.created skipped: client ${appointment.clientId} has no phone`,
+      );
+      return;
+    }
+
+    const salon = await this.prisma.salon.findUnique({
+      where: { id: salonId },
+      select: { name: true, timezone: true },
+    });
+    if (!salon) {
+      // Salon disappeared (which shouldn't happen — salons are not deleted).
+      // Bail without retrying.
+      this.logger.warn(
+        `appointment.created skipped: salon ${salonId} not found`,
+      );
+      return;
+    }
+
+    const totalDuration = appointment.services.reduce(
+      (acc, s) => acc + s.durationSnapshotMinutes,
+      0,
+    );
+    const body = formatConfirmationSms({
+      startAt: appointment.startAt,
+      staffFirstName: firstName(appointment.staffMember.displayName),
+      clientFirstName: firstName(appointment.client?.displayName ?? "there"),
+      serviceNames: appointment.services.map((s) => s.serviceNameSnapshot),
+      durationMinutes: totalDuration,
+      salonName: salon.name,
+      salonTimezone: salon.timezone,
+    });
+
+    const fromAddress = env.TWILIO_FROM_NUMBER ?? "+15555550100";
+
+    // Idempotency front door: try to insert the Message row keyed by
+    // outboxEventId. If a previous attempt crashed mid-send and left the
+    // row in QUEUED with no providerMessageId, we'll re-call the provider
+    // and update the same row instead of writing a new one.
+    let messageRowId: string;
+    try {
+      const created = await this.prisma.message.create({
+        data: {
+          salonId,
+          clientId: appointment.clientId,
+          channel: "SMS",
+          direction: MessageDirection.OUTBOUND,
+          status: MessageStatus.QUEUED,
+          toAddress,
+          fromAddress,
+          body,
+          outboxEventId: event.id,
+        },
+      });
+      messageRowId = created.id;
+    } catch (err) {
+      if (isUniqueConstraintError(err, "messages_outboxEventId_key")) {
+        const existing = await this.prisma.message.findUnique({
+          where: { outboxEventId: event.id },
+        });
+        if (!existing) throw err;
+        if (existing.providerMessageId) {
+          // Already sent on a previous attempt that crashed before marking
+          // the outbox row completed. The worker's idempotent finalize will
+          // fix that — nothing else to do here.
+          this.logger.log(
+            `appointment.created already sent on prior attempt (sid=${existing.providerMessageId})`,
+          );
+          return;
+        }
+        messageRowId = existing.id;
+      } else {
+        throw err;
+      }
+    }
+
+    let result;
+    try {
+      result = await this.messaging.sendSms({
+        to: toAddress,
+        from: fromAddress,
+        body,
+      });
+    } catch (sendErr) {
+      const message =
+        sendErr instanceof Error ? sendErr.message : String(sendErr);
+      await this.prisma.message.update({
+        where: { id: messageRowId },
+        data: {
+          status: MessageStatus.FAILED,
+          errorMessage: message.slice(0, 500),
+        },
+      });
+      // Re-throw so the worker bumps `attempts` and retries — a transient
+      // Twilio outage shouldn't terminally drop the SMS. The next attempt
+      // will pick up the same Message row via outboxEventId.
+      throw sendErr;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.message.update({
+        where: { id: messageRowId },
+        data: {
+          status:
+            result.status === "FAILED"
+              ? MessageStatus.FAILED
+              : MessageStatus.SENT,
+          providerMessageId: result.providerMessageId,
+          sentAt: new Date(),
+        },
+      });
+      await tx.domainEvent.create({
+        data: {
+          salonId,
+          aggregateType: "MESSAGE",
+          aggregateId: messageRowId,
+          eventType: EventType.MESSAGE_SMS_SENT,
+          payload: {
+            appointmentId,
+            providerMessageId: result.providerMessageId,
+            to: toAddress,
+            kind: "appointment_confirmation",
+          } satisfies Prisma.InputJsonValue,
+          actorType: ActorType.SYSTEM,
+        },
+      });
+    });
+  }
+}
+
+function isUniqueConstraintError(err: unknown, target: string): boolean {
+  if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+    const meta = err.meta as { target?: string | string[] } | undefined;
+    if (!meta?.target) return false;
+    return Array.isArray(meta.target)
+      ? meta.target.includes(target)
+      : meta.target === target;
+  }
+  return false;
+}

--- a/apps/api/src/messaging/twilio-messaging.provider.ts
+++ b/apps/api/src/messaging/twilio-messaging.provider.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger } from "@nestjs/common";
+import twilio, { validateRequest, type Twilio } from "twilio";
+import { env } from "../env";
+import type {
+  MessagingProvider,
+  SendSmsArgs,
+  SendSmsResult,
+  ValidateInboundArgs,
+} from "./messaging-provider.interface";
+
+/**
+ * Twilio-backed SMS provider. Outbound goes through the official Node SDK;
+ * inbound signature verification is HMAC-SHA1 over the request URL + sorted
+ * form params (Twilio's `validateRequest`).
+ *
+ * The constructor reads creds from env at boot. If the auth token rotates,
+ * the API needs a restart — that's fine for now.
+ */
+@Injectable()
+export class TwilioMessagingProvider implements MessagingProvider {
+  private readonly logger = new Logger(TwilioMessagingProvider.name);
+  private readonly client: Twilio;
+  private readonly authToken: string;
+
+  constructor() {
+    if (
+      !env.TWILIO_ACCOUNT_SID ||
+      !env.TWILIO_AUTH_TOKEN ||
+      !env.TWILIO_FROM_NUMBER
+    ) {
+      // The env validator already enforces this when MESSAGING_PROVIDER=twilio,
+      // but we double-check so a misconfigured factory call surfaces clearly.
+      throw new Error(
+        "TwilioMessagingProvider requires TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER",
+      );
+    }
+    this.client = twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN);
+    this.authToken = env.TWILIO_AUTH_TOKEN;
+  }
+
+  async sendSms(args: SendSmsArgs): Promise<SendSmsResult> {
+    const message = await this.client.messages.create({
+      to: args.to,
+      from: args.from,
+      body: args.body,
+    });
+    this.logger.log(
+      `Sent SMS sid=${message.sid} to=${args.to} status=${message.status}`,
+    );
+    return {
+      providerMessageId: message.sid,
+      status: mapStatus(message.status),
+    };
+  }
+
+  validateInboundSignature(args: ValidateInboundArgs): boolean {
+    return validateRequest(this.authToken, args.signature, args.url, args.params);
+  }
+}
+
+function mapStatus(s: string | null): SendSmsResult["status"] {
+  // Twilio's create-time status set: queued, accepted, sending, sent.
+  // Final states (delivered, undelivered, failed) only arrive on the status
+  // callback. Treat queued/accepted/sending as QUEUED so the Message row
+  // doesn't claim "SENT" before the carrier has actually accepted it.
+  switch (s) {
+    case "sent":
+      return "SENT";
+    case "delivered":
+      return "DELIVERED";
+    case "failed":
+    case "undelivered":
+      return "FAILED";
+    default:
+      return "QUEUED";
+  }
+}

--- a/apps/api/src/outbox/outbox.worker.ts
+++ b/apps/api/src/outbox/outbox.worker.ts
@@ -8,17 +8,16 @@ import { OutboxStatus, type OutboxEvent } from "@prisma/client";
 import { EventType } from "@shearsimp/shared";
 import { env } from "../env";
 import { PrismaService } from "../prisma/prisma.service";
+import { SmsHandlersService } from "../messaging/sms-handlers.service";
 
 const POLL_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 25;
 const MAX_ATTEMPTS = 5;
 
-// Outbox stub for Phase 3a. Phase 4 replaces this with a BullMQ-backed
-// processor that actually sends SMS confirmations on `appointment.created`.
-//
-// The worker exists today so the contract is visible end-to-end: writers
-// append OutboxEvent rows in the same transaction as the business write, the
-// worker eventually picks them up, the handler decides what to do.
+// Polls the outbox table for due events and dispatches each to a handler.
+// Phase 4a wires real SMS-sending behaviour for `appointment.created`. The
+// worker still uses simple poll-and-update — Phase 4b will switch to BullMQ
+// for proper leasing / per-event scheduling once reminder jobs land.
 @Injectable()
 export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(OutboxWorker.name);
@@ -26,7 +25,10 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
   private running = false;
   private stopped = false;
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly smsHandlers: SmsHandlersService,
+  ) {}
 
   onModuleInit() {
     if (env.OUTBOX_WORKER_DISABLED) {
@@ -88,7 +90,7 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
 
   // Fetches a small batch of due events and processes them sequentially. We
   // don't claim rows with a status flip + SELECT FOR UPDATE here because there
-  // is only one worker process at this stage; Phase 4 introduces BullMQ which
+  // is only one worker process at this stage; Phase 4b introduces BullMQ which
   // handles dispatch and concurrency properly.
   async processBatch() {
     const due = await this.prisma.outboxEvent.findMany({
@@ -106,9 +108,9 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
 
   private async processOne(event: OutboxEvent) {
     try {
-      await dispatch(event);
+      await this.dispatch(event);
       // Single terminal write per attempt: a crash mid-dispatch leaves the
-      // row in PENDING and the next tick retries it. Phase 4 introduces
+      // row in PENDING and the next tick retries it. Phase 4b introduces
       // proper leasing (claim with FOR UPDATE SKIP LOCKED + worker heartbeat
       // via BullMQ); the stub deliberately avoids non-leased PROCESSING.
       await this.prisma.outboxEvent.update({
@@ -130,9 +132,10 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
         where: { id: event.id },
         data: {
           status: dead ? OutboxStatus.DEAD_LETTER : OutboxStatus.PENDING,
+          attempts: { increment: 1 },
           lastError: message.slice(0, 1000),
-          // Linear backoff is fine for a stub; replace with exponential when
-          // real handlers go in.
+          // Linear backoff is fine for the polling-based worker; switch to
+          // exponential when BullMQ takes over scheduling in 4b.
           nextAttemptAt: new Date(
             Date.now() + (event.attempts + 1) * 30_000,
           ),
@@ -140,17 +143,21 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       });
     }
   }
-}
 
-// Handler dispatch table. Phase 4 will replace the appointment.created branch
-// with a real SMS send. Until then, every event no-ops successfully so the
-// worker exercises the read/update/finalize path end-to-end.
-async function dispatch(event: OutboxEvent): Promise<void> {
-  switch (event.eventType) {
-    case EventType.APPOINTMENT_CREATED:
-      // Intentional no-op for Phase 3a.
-      return;
-    default:
-      return;
+  // Handler dispatch table. Add new event types here as their handlers land
+  // — keeps the worker's flow control isolated from per-event business logic.
+  private async dispatch(event: OutboxEvent): Promise<void> {
+    switch (event.eventType) {
+      case EventType.APPOINTMENT_CREATED:
+        await this.smsHandlers.handleAppointmentCreated(event);
+        return;
+      default:
+        // Unknown event types are silently completed so a bad row can't wedge
+        // the worker. Log so we notice the typo / missing handler.
+        this.logger.warn(
+          `Outbox event ${event.id} has unhandled type "${event.eventType}" — marking complete`,
+        );
+        return;
+    }
   }
 }

--- a/apps/api/src/webhooks/twilio-webhook.controller.ts
+++ b/apps/api/src/webhooks/twilio-webhook.controller.ts
@@ -1,0 +1,212 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Header,
+  HttpCode,
+  Inject,
+  Logger,
+  Post,
+  Req,
+} from "@nestjs/common";
+import {
+  ActorType,
+  MessageDirection,
+  MessageStatus,
+  Prisma,
+} from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type { Request } from "express";
+import { Public } from "../auth/public.decorator";
+import { SkipTenant } from "../tenant/skip-tenant.decorator";
+import { env } from "../env";
+import { PrismaService } from "../prisma/prisma.service";
+import {
+  MESSAGING_PROVIDER,
+  type MessagingProvider,
+} from "../messaging/messaging-provider.interface";
+
+const SOURCE = "twilio";
+
+// Subset of Twilio's inbound SMS form params we read. They arrive
+// application/x-www-form-urlencoded — Nest decodes via the default body
+// parser. Fields not listed here (FromCity, FromCountry, …) are present in
+// the body and used for signature validation but we don't store them.
+interface TwilioSmsBody {
+  MessageSid?: string;
+  AccountSid?: string;
+  From?: string;
+  To?: string;
+  Body?: string;
+  NumMedia?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Twilio → ShearSimplicity inbound SMS. Configured in the Twilio console
+ * (Messaging → Services → Inbound webhook → POST <api>/webhooks/twilio/sms).
+ *
+ * Salon routing in 4a: the single shared TWILIO_FROM_NUMBER means we can't
+ * use the To header to route. We look up the sender by phone across all
+ * salons; if a unique Client matches we store under their salon, otherwise
+ * we log + drop (and still 200 so Twilio doesn't retry forever). Per-salon
+ * numbers in 4b will let us route by To directly.
+ */
+@Controller("webhooks/twilio/sms")
+export class TwilioWebhookController {
+  private readonly logger = new Logger(TwilioWebhookController.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(MESSAGING_PROVIDER)
+    private readonly messaging: MessagingProvider,
+  ) {}
+
+  @Public()
+  @SkipTenant()
+  @Post()
+  @HttpCode(200)
+  // Twilio expects a TwiML body in the response — empty <Response/> means
+  // "no auto-reply". The header has to be set explicitly because the body
+  // is a string, not JSON.
+  @Header("content-type", "text/xml")
+  async handle(
+    @Req() req: Request,
+    @Body() body: TwilioSmsBody,
+  ): Promise<string> {
+    const signature = req.header("x-twilio-signature");
+    if (!signature) {
+      throw new BadRequestException("Missing X-Twilio-Signature header");
+    }
+
+    // Reconstruct the URL Twilio used to compute the signature. Behind a
+    // reverse proxy that rewrites Host, set TWILIO_WEBHOOK_PUBLIC_URL so
+    // the validator sees the same URL the carrier did.
+    const url =
+      env.TWILIO_WEBHOOK_PUBLIC_URL ?? buildRequestUrl(req);
+
+    const params = stringifyParams(body);
+    const valid = this.messaging.validateInboundSignature({
+      signature,
+      url,
+      params,
+    });
+    if (!valid) {
+      throw new BadRequestException("Invalid Twilio signature");
+    }
+
+    const sid = body.MessageSid;
+    const from = body.From;
+    const to = body.To;
+    const messageBody = body.Body ?? "";
+    if (!sid || !from || !to) {
+      throw new BadRequestException(
+        "Missing MessageSid / From / To in webhook body",
+      );
+    }
+
+    // Salon routing: find a client by phone. In 4a we expect each phone to
+    // belong to one salon — if we get multiple matches we log and skip
+    // rather than risk routing to the wrong one.
+    const matches = await this.prisma.client.findMany({
+      where: { phone: from },
+      select: { id: true, salonId: true, displayName: true },
+      take: 2,
+    });
+    if (matches.length === 0) {
+      this.logger.log(
+        `Inbound SMS from ${from} sid=${sid} matched no client — dropping`,
+      );
+      return TWIML_EMPTY;
+    }
+    if (matches.length > 1) {
+      this.logger.warn(
+        `Inbound SMS from ${from} sid=${sid} matched ${matches.length} clients — ambiguous, dropping`,
+      );
+      return TWIML_EMPTY;
+    }
+    const match = matches[0]!;
+
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.processedWebhookEvent.create({
+          data: { source: SOURCE, externalEventId: sid, eventType: "sms.inbound" },
+        });
+        const message = await tx.message.create({
+          data: {
+            salonId: match.salonId,
+            clientId: match.id,
+            channel: "SMS",
+            direction: MessageDirection.INBOUND,
+            status: MessageStatus.RECEIVED,
+            toAddress: to,
+            fromAddress: from,
+            body: messageBody,
+            providerMessageId: sid,
+          },
+        });
+        await tx.domainEvent.create({
+          data: {
+            salonId: match.salonId,
+            aggregateType: "MESSAGE",
+            aggregateId: message.id,
+            eventType: EventType.MESSAGE_SMS_RECEIVED,
+            payload: {
+              providerMessageId: sid,
+              from,
+              to,
+              clientId: match.id,
+            } satisfies Prisma.InputJsonValue,
+            actorType: ActorType.CLIENT,
+          },
+        });
+      });
+    } catch (err) {
+      if (isProcessedWebhookEventDuplicate(err)) {
+        this.logger.log(`Twilio sid ${sid} already processed; skipping`);
+        return TWIML_EMPTY;
+      }
+      throw err;
+    }
+    return TWIML_EMPTY;
+  }
+}
+
+const TWIML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+
+function buildRequestUrl(req: Request): string {
+  // protocol + host + originalUrl reconstructs what the client (Twilio) hit,
+  // including any query string. originalUrl preserves the path Nest didn't
+  // strip — important for /webhooks/twilio/sms.
+  const proto =
+    (req.headers["x-forwarded-proto"] as string | undefined) ?? req.protocol;
+  const host = req.header("host") ?? "";
+  return `${proto}://${host}${req.originalUrl}`;
+}
+
+function stringifyParams(body: TwilioSmsBody): Record<string, string> {
+  // Twilio's validator wants each param as a string. The body parser may
+  // hand us numbers / nested objects in edge cases; coerce to string and
+  // drop anything that doesn't have a representation.
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (typeof v === "string") out[k] = v;
+    else if (v != null) out[k] = String(v);
+  }
+  return out;
+}
+
+function isProcessedWebhookEventDuplicate(err: unknown): boolean {
+  if (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === "P2002"
+  ) {
+    const meta = err.meta as { target?: string | string[] } | undefined;
+    if (!meta?.target) return false;
+    const t = meta.target;
+    return Array.isArray(t)
+      ? t.some((c) => c.includes("source") || c.includes("externalEventId"))
+      : t.includes("source") || t.includes("externalEventId");
+  }
+  return false;
+}

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
 import { ClerkWebhookController } from "./clerk-webhook.controller";
 import { ClerkWebhookService } from "./clerk-webhook.service";
+import { TwilioWebhookController } from "./twilio-webhook.controller";
 
 @Module({
-  controllers: [ClerkWebhookController],
+  controllers: [ClerkWebhookController, TwilioWebhookController],
   providers: [ClerkWebhookService],
 })
 export class WebhooksModule {}

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -9,3 +9,5 @@ process.env.DEV_USER_ID ??= "00000000-0000-0000-0000-000000000001";
 process.env.DEV_USER_EMAIL ??= "dev@shearsimp.test";
 process.env.DEV_SALON_ID ??= "00000000-0000-0000-0000-0000000000a1";
 process.env.DEV_SALON_SLUG ??= "test-salon";
+process.env.MESSAGING_PROVIDER ??= "dev";
+process.env.TWILIO_FROM_NUMBER ??= "+15555550100";

--- a/apps/api/test/sms-formatter.test.ts
+++ b/apps/api/test/sms-formatter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  firstName,
+  formatConfirmationSms,
+} from "../src/messaging/sms-formatter";
+
+describe("sms-formatter", () => {
+  describe("firstName", () => {
+    it("returns the first whitespace-delimited token", () => {
+      expect(firstName("Mira Castellanos")).toBe("Mira");
+      expect(firstName("Mira P. Castellanos")).toBe("Mira");
+      expect(firstName("Mira")).toBe("Mira");
+    });
+
+    it("returns a fallback for blank names", () => {
+      expect(firstName("")).toBe("there");
+      expect(firstName("   ")).toBe("there");
+    });
+  });
+
+  describe("formatConfirmationSms", () => {
+    const baseInput = {
+      // Wed Apr 30 2026 1:00 PM in America/New_York → 17:00 UTC.
+      startAt: new Date("2026-04-30T17:00:00Z"),
+      staffFirstName: "Trina",
+      serviceNames: ["Single-process color"],
+      durationMinutes: 90,
+      clientFirstName: "Mira",
+      salonName: "Bella's Salon",
+      salonTimezone: "America/New_York",
+    };
+
+    it("renders the salon-local date and time", () => {
+      const body = formatConfirmationSms(baseInput);
+      expect(body).toContain("Bella's Salon");
+      expect(body).toContain("Mira");
+      expect(body).toContain("Trina");
+      expect(body).toContain("Single-process color");
+      expect(body).toContain("90 min");
+      expect(body).toContain("STOP");
+      // Date/time rendered in America/New_York
+      expect(body).toMatch(/Thu, Apr 30/);
+      expect(body).toMatch(/1:00\s?PM/i);
+    });
+
+    it("renders the same instant in a different timezone differently", () => {
+      const ny = formatConfirmationSms(baseInput);
+      const la = formatConfirmationSms({
+        ...baseInput,
+        salonTimezone: "America/Los_Angeles",
+      });
+      // 17:00 UTC = 1:00 PM EDT = 10:00 AM PDT
+      expect(ny).toMatch(/1:00\s?PM/i);
+      expect(la).toMatch(/10:00\s?AM/i);
+    });
+
+    it("comma-joins multiple services", () => {
+      const body = formatConfirmationSms({
+        ...baseInput,
+        serviceNames: ["Color refresh", "Blowout"],
+      });
+      expect(body).toContain("Color refresh, Blowout");
+    });
+  });
+});

--- a/apps/api/test/sms-handlers.test.ts
+++ b/apps/api/test/sms-handlers.test.ts
@@ -136,7 +136,7 @@ describe("SmsHandlersService.handleAppointmentCreated", () => {
     );
   });
 
-  it("does not double-send when retried after a successful send (outboxEventId dedup)", async () => {
+  it("does not double-send when retried after a successful send (outboxEventId dedup, constraint-name target)", async () => {
     const dupErr = new Prisma.PrismaClientKnownRequestError(
       "duplicate",
       { code: "P2002", clientVersion: "x", meta: { target: "messages_outboxEventId_key" } },
@@ -157,6 +157,47 @@ describe("SmsHandlersService.handleAppointmentCreated", () => {
     expect(messageFindUnique).toHaveBeenCalledTimes(1);
     expect(sendSms).not.toHaveBeenCalled();
     expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("dedupes when Prisma reports the target as a field-name array", async () => {
+    // Some Prisma versions / drivers report P2002.meta.target as the field
+    // list (`["outboxEventId"]`) instead of the constraint name. Both have
+    // to short-circuit or we'll dead-letter a perfectly idempotent retry.
+    const dupErr = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      { code: "P2002", clientVersion: "x", meta: { target: ["outboxEventId"] } },
+    );
+    const { handler, sendSms, messageFindUnique } = buildHandler({
+      appointment: fakeAppointment(),
+      insertThrows: dupErr,
+      existingMessage: {
+        id: "existing-id",
+        providerMessageId: "SM_already_sent",
+      },
+    });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageFindUnique).toHaveBeenCalledTimes(1);
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+
+  it("preserves the provider's QUEUED status instead of forcing SENT", async () => {
+    const { handler, sendSms, messageUpdate } = buildHandler({
+      appointment: fakeAppointment(),
+    });
+    sendSms.mockResolvedValueOnce({
+      providerMessageId: "SM_queued",
+      status: "QUEUED" as const,
+    });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageUpdate).toHaveBeenCalledTimes(1);
+    expect(messageUpdate.mock.calls[0]![0].data).toMatchObject({
+      providerMessageId: "SM_queued",
+      status: MessageStatus.QUEUED,
+    });
   });
 
   it("re-sends when a previous attempt crashed mid-flight (no providerMessageId yet)", async () => {

--- a/apps/api/test/sms-handlers.test.ts
+++ b/apps/api/test/sms-handlers.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppointmentStatus, MessageStatus, Prisma } from "@prisma/client";
+import { SmsHandlersService } from "../src/messaging/sms-handlers.service";
+import type { MessagingProvider } from "../src/messaging/messaging-provider.interface";
+
+// Mock prisma + messaging provider so the handler can run end-to-end without
+// a database. The goal is to assert the flow control around send + dedup,
+// not Prisma's behavior.
+
+const SALON_ID = "00000000-0000-0000-0000-000000000a01";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000b01";
+const CLIENT_ID = "00000000-0000-0000-0000-000000000c01";
+const STAFF_ID = "00000000-0000-0000-0000-000000000d01";
+
+function fakeAppointment(overrides: Partial<{ status: AppointmentStatus; phone: string | null }> = {}) {
+  return {
+    id: APPOINTMENT_ID,
+    salonId: SALON_ID,
+    clientId: CLIENT_ID,
+    staffMemberId: STAFF_ID,
+    startAt: new Date("2026-04-30T17:00:00Z"),
+    endAt: new Date("2026-04-30T18:30:00Z"),
+    status: overrides.status ?? AppointmentStatus.SCHEDULED,
+    client: {
+      id: CLIENT_ID,
+      displayName: "Mira Castellanos",
+      phone: overrides.phone === undefined ? "+15555550192" : overrides.phone,
+    },
+    staffMember: { id: STAFF_ID, displayName: "Trina Bellweather" },
+    services: [
+      { serviceNameSnapshot: "Single-process color", durationSnapshotMinutes: 90 },
+    ],
+  };
+}
+
+function buildHandler({
+  appointment,
+  messageRowId = "00000000-0000-0000-0000-000000000e01",
+  existingMessage = null,
+  insertThrows = null,
+}: {
+  appointment?: ReturnType<typeof fakeAppointment> | null;
+  messageRowId?: string;
+  existingMessage?: { id: string; providerMessageId: string | null } | null;
+  insertThrows?: Error | null;
+}) {
+  const sendSms = vi.fn().mockResolvedValue({
+    providerMessageId: "SM_test_sid",
+    status: "SENT" as const,
+  });
+  const messaging: MessagingProvider = {
+    sendSms,
+    validateInboundSignature: () => true,
+  };
+
+  const messageCreate = vi.fn().mockImplementation(async () => {
+    if (insertThrows) throw insertThrows;
+    return { id: messageRowId };
+  });
+  const messageFindUnique = vi.fn().mockResolvedValue(existingMessage);
+  const messageUpdate = vi.fn().mockResolvedValue({});
+  const domainEventCreate = vi.fn().mockResolvedValue({});
+
+  const prisma = {
+    appointment: {
+      findFirst: vi.fn().mockResolvedValue(appointment ?? null),
+    },
+    salon: {
+      findUnique: vi.fn().mockResolvedValue({
+        name: "Bella's Salon",
+        timezone: "America/New_York",
+      }),
+    },
+    message: {
+      create: messageCreate,
+      findUnique: messageFindUnique,
+      update: messageUpdate,
+    },
+    domainEvent: {
+      create: domainEventCreate,
+    },
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      // Pass the mock prisma itself as the tx so calls inside the
+      // transaction route to the same spies.
+      return fn(prismaInstance);
+    }),
+  };
+  // Self-reference so $transaction can pass `prisma` as `tx`.
+  const prismaInstance = prisma;
+
+  const handler = new SmsHandlersService(prisma as never, messaging);
+  return { handler, prisma, sendSms, messageCreate, messageFindUnique, messageUpdate, domainEventCreate };
+}
+
+beforeEach(() => {
+  process.env.TWILIO_FROM_NUMBER = "+15555550100";
+  process.env.MESSAGING_PROVIDER = "dev";
+});
+
+describe("SmsHandlersService.handleAppointmentCreated", () => {
+  const event = {
+    id: "00000000-0000-0000-0000-000000000f01",
+    eventType: "appointment.created",
+    payload: { id: APPOINTMENT_ID, salonId: SALON_ID } as Prisma.JsonValue,
+  };
+
+  it("sends a confirmation SMS for a fresh event", async () => {
+    const { handler, sendSms, messageCreate, messageUpdate, domainEventCreate } =
+      buildHandler({ appointment: fakeAppointment() });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageCreate).toHaveBeenCalledTimes(1);
+    expect(messageCreate.mock.calls[0]![0].data).toMatchObject({
+      salonId: SALON_ID,
+      clientId: CLIENT_ID,
+      direction: "OUTBOUND",
+      status: MessageStatus.QUEUED,
+      toAddress: "+15555550192",
+      fromAddress: "+15555550100",
+      outboxEventId: event.id,
+    });
+    expect(sendSms).toHaveBeenCalledTimes(1);
+    expect(sendSms.mock.calls[0]![0]).toMatchObject({
+      to: "+15555550192",
+      from: "+15555550100",
+    });
+    expect(messageUpdate).toHaveBeenCalledTimes(1);
+    expect(messageUpdate.mock.calls[0]![0].data).toMatchObject({
+      providerMessageId: "SM_test_sid",
+      status: MessageStatus.SENT,
+    });
+    expect(domainEventCreate).toHaveBeenCalledTimes(1);
+    expect(domainEventCreate.mock.calls[0]![0].data.eventType).toBe(
+      "message.sms_sent",
+    );
+  });
+
+  it("does not double-send when retried after a successful send (outboxEventId dedup)", async () => {
+    const dupErr = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      { code: "P2002", clientVersion: "x", meta: { target: "messages_outboxEventId_key" } },
+    );
+    const { handler, sendSms, messageCreate, messageFindUnique, domainEventCreate } =
+      buildHandler({
+        appointment: fakeAppointment(),
+        insertThrows: dupErr,
+        existingMessage: {
+          id: "existing-id",
+          providerMessageId: "SM_already_sent",
+        },
+      });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageCreate).toHaveBeenCalledTimes(1);
+    expect(messageFindUnique).toHaveBeenCalledTimes(1);
+    expect(sendSms).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("re-sends when a previous attempt crashed mid-flight (no providerMessageId yet)", async () => {
+    const dupErr = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      { code: "P2002", clientVersion: "x", meta: { target: "messages_outboxEventId_key" } },
+    );
+    const { handler, sendSms, messageCreate, messageFindUnique, messageUpdate } =
+      buildHandler({
+        appointment: fakeAppointment(),
+        insertThrows: dupErr,
+        existingMessage: {
+          id: "existing-id",
+          providerMessageId: null,
+        },
+      });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageCreate).toHaveBeenCalledTimes(1);
+    expect(messageFindUnique).toHaveBeenCalledTimes(1);
+    expect(sendSms).toHaveBeenCalledTimes(1);
+    expect(messageUpdate).toHaveBeenCalledTimes(1);
+    expect(messageUpdate.mock.calls[0]![0].where.id).toBe("existing-id");
+  });
+
+  it("skips cancelled appointments without sending", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: fakeAppointment({ status: AppointmentStatus.CANCELLED }),
+    });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageCreate).not.toHaveBeenCalled();
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+
+  it("skips when the client has no phone on file", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: fakeAppointment({ phone: null }),
+    });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(messageCreate).not.toHaveBeenCalled();
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+
+  it("marks the Message FAILED and re-throws when the provider errors", async () => {
+    const { handler, sendSms, messageUpdate, domainEventCreate } = buildHandler({
+      appointment: fakeAppointment(),
+    });
+    sendSms.mockRejectedValueOnce(new Error("Twilio 503"));
+
+    await expect(handler.handleAppointmentCreated(event)).rejects.toThrow(
+      "Twilio 503",
+    );
+
+    expect(messageUpdate).toHaveBeenCalledTimes(1);
+    expect(messageUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: MessageStatus.FAILED,
+      errorMessage: expect.stringContaining("Twilio 503"),
+    });
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/prisma/migrations/20260429180000_message_outbox_event_id/migration.sql
+++ b/packages/db/prisma/migrations/20260429180000_message_outbox_event_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "messages" ADD COLUMN     "outboxEventId" UUID;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "messages_outboxEventId_key" ON "messages"("outboxEventId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -439,6 +439,11 @@ model Message {
   body               String
   // Idempotency against provider re-delivery.
   providerMessageId  String?
+  // Outbound dedup: the OutboxEvent that produced this Message. Worker INSERTs
+  // a Message row before calling the provider, so a retry hits the unique
+  // constraint and short-circuits — preventing duplicate sends even when the
+  // provider call succeeds and the post-send DB write crashes.
+  outboxEventId      String?          @db.Uuid
   errorCode          String?
   errorMessage       String?
   createdAt          DateTime         @default(now())
@@ -452,6 +457,7 @@ model Message {
   client Client? @relation(fields: [clientId, salonId], references: [id, salonId], onDelete: Restrict)
 
   @@unique([channel, providerMessageId])
+  @@unique([outboxEventId])
   @@index([salonId, clientId, createdAt])
   @@index([salonId, direction, createdAt])
   @@map("messages")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       svix:
         specifier: '1'
         version: 1.92.2
+      twilio:
+        specifier: ^5.4.0
+        version: 5.13.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1528,6 +1531,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1645,6 +1652,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1652,6 +1662,9 @@ packages:
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
+
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1701,6 +1714,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1818,6 +1834,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -1924,6 +1944,9 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1978,6 +2001,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2026,6 +2053,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2348,6 +2378,15 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2362,6 +2401,10 @@ packages:
     peerDependencies:
       typescript: '>3.6.0'
       webpack: ^5.11.0
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2481,6 +2524,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -2715,9 +2762,19 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2814,8 +2871,29 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -3190,6 +3268,10 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3328,6 +3410,10 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  scmp@2.1.0:
+    resolution: {integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==}
+    deprecated: Just use Node.js's crypto.timingSafeEqual()
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3658,6 +3744,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  twilio@5.13.1:
+    resolution: {integrity: sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==}
+    engines: {node: '>=14.0'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3890,6 +3980,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  xmlbuilder@13.0.2:
+    resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
+    engines: {node: '>=6.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -5114,6 +5208,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
@@ -5258,11 +5358,21 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.3: {}
+
+  axios@1.15.2:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -5323,6 +5433,8 @@ snapshots:
       electron-to-chromium: 1.5.344
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -5444,6 +5556,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -5544,6 +5660,8 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  dayjs@1.11.20: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -5581,6 +5699,8 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.7: {}
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -5621,6 +5741,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -6154,6 +6278,8 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -6179,6 +6305,14 @@ snapshots:
       tapable: 2.3.3
       typescript: 5.7.2
       webpack: 5.97.1
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -6308,6 +6442,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.4.24:
     dependencies:
@@ -6559,12 +6700,36 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -6638,7 +6803,21 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.18.1: {}
 
@@ -6988,6 +7167,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-from-env@2.1.0: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -7163,6 +7344,8 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  scmp@2.1.0: {}
 
   semver@6.3.1: {}
 
@@ -7553,6 +7736,19 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  twilio@5.13.1:
+    dependencies:
+      axios: 1.15.2
+      dayjs: 1.11.20
+      https-proxy-agent: 5.0.1
+      jsonwebtoken: 9.0.3
+      qs: 6.14.2
+      scmp: 2.1.0
+      xmlbuilder: 13.0.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -7853,6 +8049,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  xmlbuilder@13.0.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

Wires the `appointment.created` event in the outbox to a real SMS send, behind a swappable `MessagingProvider` so tests and dev can run without hitting Twilio. This is the load-bearing infra for Phase 4 — reminders, reschedule notifications, per-salon numbers, and the message-history UI all depend on it but stay scoped to 4b.

## Schema

- New `Message.outboxEventId` (nullable, unique). The handler INSERTs a `Message` keyed by this **before** calling the provider — so a retry hits the unique constraint and short-circuits, preventing duplicate sends even when the network call succeeds and the post-send DB write crashes. Migration: \`20260429180000_message_outbox_event_id\`.

## Messaging

- `MessagingProvider` interface + `Dev` / `Twilio` implementations, switched on `MESSAGING_PROVIDER` env (mirror of the auth-provider pattern).
  - `DevMessagingProvider` — logs and returns a fake \`dev_*\` sid; refuses to run in `NODE_ENV=production`.
  - `TwilioMessagingProvider` — uses the official `@twilio` SDK for outbound + `validateRequest` for inbound HMAC verification.
- `SmsHandlersService` formats a confirmation SMS in the salon's timezone (via `Intl.DateTimeFormat` — no extra deps), persists a `Message`, appends `message.sms_sent` inside the same transaction.

## Outbox worker

- Replaced the no-op dispatcher with a real handler table. Unhandled event types log + complete (no wedging the worker on a bad row).
- **Bugfix:** the prior failure path forgot to `attempts: { increment: 1 }` — would have looped forever on a bad event. Fixed.

## Inbound webhook

- `POST /webhooks/twilio/sms` validates the `X-Twilio-Signature` header against the (reconstructed) request URL + sorted form params, dedupes on `processed_webhook_events.(source, externalEventId)`, looks up the salon via sender phone, and appends `message.sms_received`.

## Tests (25 total, all passing)

- Pure tests for the formatter (timezone rendering, multi-service body).
- Mocked-prisma tests for the handler: fresh send, retry after success (no double-send), retry after mid-flight crash (re-uses the existing Message row), cancelled appointment, no phone, provider error path.

## Out of scope (4b)

- Reminder scheduling (BullMQ-backed)
- Reschedule / cancel SMS
- Per-salon Twilio numbers (single shared number for now — inbound routes by sender phone, with ambiguous-match guard)
- Deep-link tokens for cancel/reschedule
- Message history UI

## A2P 10DLC

Terms / privacy live at `docs/sms-terms.md` and `docs/privacy-policy.md`. Brand registration is operational, not code.

## Test plan

- [x] `pnpm --filter @shearsimp/api typecheck` passes
- [x] `pnpm --filter @shearsimp/api test` — 25 / 25 pass
- [x] `pnpm --filter @shearsimp/db prisma:validate` passes
- [x] `pnpm --filter @shearsimp/db test` (enum parity) passes
- [x] `pnpm --filter @shearsimp/web typecheck` passes
- [ ] Local smoke: book an appointment, check API logs for `[dev-sms] from=... to=... sid=dev_...` — confirms the outbox actually fires the handler end-to-end
- [ ] Confirm `messages` row was inserted with `outboxEventId` set, `status=SENT`, `providerMessageId` populated
- [ ] Confirm a `domain_events` row with `eventType=message.sms_sent` exists