### PR TITLE
Phase 4b-1: SMS notifications for reschedule + cancel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,14 +161,38 @@ Outbound first, inbound second. Reminder jobs separate from confirmations.
 
 **Out of scope (intentional):** reminder scheduling, reschedule/cancel SMS, message-history UI, per-salon Twilio numbers, deep-link tokens. Those land in 4b.
 
-### Phase 4b — Reminders + per-salon numbers + history UI ⬜
+### Phase 4b-1 — Reschedule + cancel notifications 🚧
 
-- BullMQ-backed reminder jobs scheduled at appointment creation, cancelled on reschedule/cancel
-- Per-salon Twilio numbers stored on `Salon` so inbound routes by `To` instead of by sender phone
-- Reschedule / cancel notifications (new outbox event types and handlers)
+- New outbox emissions in `appointments.service.ts` for reschedule + cancel
+  (alongside the existing domain events)
+- New handler methods on `SmsHandlersService` mirror `handleAppointmentCreated`,
+  share the INSERT-then-send dedup helper, render bodies with old → new for
+  reschedule and the cancelled time for cancel
+- Outbox worker dispatch routes the two new event types
+- Vitest coverage for fresh send, retry dedup, missing-payload skip,
+  status-already-cancelled-on-reschedule skip, no-phone skip
+
+### Phase 4b-2 — Reminder scheduling ⬜
+
+- Reuse `OutboxEvent.nextAttemptAt` for deferred sends (cheaper than pulling
+  in BullMQ for one feature; the outbox already has scheduling primitives)
+- New event type `appointment.reminder_due` emitted on create with
+  `nextAttemptAt = startAt - 24h`; reschedule updates the time, cancel marks
+  the row `COMPLETED`
+- Worker tick already polls by `nextAttemptAt`, so no leasing changes needed
+
+### Phase 4b-3 — Per-salon Twilio numbers ⬜
+
+- New `Salon.smsFromNumber` field + settings UI
+- Inbound webhook routes by `To` header instead of by sender phone
+- Removes the single-shared-number caveat from 4a
+
+### Backlog (was 4b, deferred to 4c or beyond)
+
 - Cancellation / reschedule deep links signed with short-lived tokens
 - Message history per client (UI)
-- Switch outbox worker from poll-and-update to BullMQ leasing with proper heartbeat
+- BullMQ migration (only if we hit operational pain — outbox `nextAttemptAt`
+  is good enough for 4b-2)
 
 ### A2P 10DLC compliance — separate workstream
 

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -289,6 +289,22 @@ export class AppointmentsService {
         },
         actorUserId,
       });
+      // Outbox row drives the reschedule SMS in 4b-1. Minimal payload: id +
+      // salonId + previousStartAt. The handler looks up the appointment for
+      // current state (new startAt, services, staff) and uses
+      // previousStartAt only for the "moved from X to Y" wording.
+      await tx.outboxEvent.create({
+        data: {
+          salonId,
+          eventType: EventType.APPOINTMENT_RESCHEDULED,
+          payload: {
+            id,
+            salonId,
+            previousStartAt: existing.startAt.toISOString(),
+          } as Prisma.InputJsonValue,
+          status: OutboxStatus.PENDING,
+        },
+      });
       return updated;
     });
   }
@@ -326,6 +342,18 @@ export class AppointmentsService {
           reason: input.reason ?? null,
         },
         actorUserId,
+      });
+      // Outbox row drives the cancel SMS in 4b-1. Cancel doesn't move the
+      // appointment, so no previousStartAt is needed — the handler reads
+      // the current row's startAt for the "appointment on X has been
+      // cancelled" wording.
+      await tx.outboxEvent.create({
+        data: {
+          salonId,
+          eventType: EventType.APPOINTMENT_CANCELLED,
+          payload: { id, salonId } as Prisma.InputJsonValue,
+          status: OutboxStatus.PENDING,
+        },
       });
       return updated;
     });

--- a/apps/api/src/messaging/sms-formatter.ts
+++ b/apps/api/src/messaging/sms-formatter.ts
@@ -26,6 +26,51 @@ export function formatConfirmationSms(input: AppointmentForSms): string {
   );
 }
 
+interface RescheduleForSms {
+  previousStartAt: Date;
+  newStartAt: Date;
+  staffFirstName: string;
+  clientFirstName: string;
+  salonName: string;
+  salonTimezone: string;
+}
+
+export function formatRescheduleSms(input: RescheduleForSms): string {
+  const fromLabel = formatDateTimeLabel(input.previousStartAt, input.salonTimezone);
+  const toLabel = formatDateTimeLabel(input.newStartAt, input.salonTimezone);
+  return (
+    `${input.salonName}: Hi ${input.clientFirstName}, your appointment ` +
+    `with ${input.staffFirstName} on ${fromLabel} has been moved to ${toLabel}. ` +
+    `Reply STOP to opt out.`
+  );
+}
+
+interface CancelForSms {
+  startAt: Date;
+  staffFirstName: string;
+  clientFirstName: string;
+  salonName: string;
+  salonTimezone: string;
+}
+
+export function formatCancelSms(input: CancelForSms): string {
+  const when = formatDateTimeLabel(input.startAt, input.salonTimezone);
+  return (
+    `${input.salonName}: Hi ${input.clientFirstName}, your appointment ` +
+    `with ${input.staffFirstName} on ${when} has been cancelled. ` +
+    `Reply STOP to opt out.`
+  );
+}
+
+function formatDateTimeLabel(instant: Date, timeZone: string): string {
+  // "Thu Apr 30 at 1:00 PM" — combined so reschedule/cancel bodies stay
+  // inside one segment with both before/after.
+  return `${formatDateLabel(instant, timeZone)} at ${formatTimeLabel(
+    instant,
+    timeZone,
+  )}`;
+}
+
 export function firstName(displayName: string): string {
   // The displayName is "First Last" / "First" / "First M. Last" — anything
   // before the first whitespace is the bit we'd address the client by.

--- a/apps/api/src/messaging/sms-handlers.service.ts
+++ b/apps/api/src/messaging/sms-handlers.service.ts
@@ -13,7 +13,12 @@ import {
   MESSAGING_PROVIDER,
   type MessagingProvider,
 } from "./messaging-provider.interface";
-import { firstName, formatConfirmationSms } from "./sms-formatter";
+import {
+  firstName,
+  formatCancelSms,
+  formatConfirmationSms,
+  formatRescheduleSms,
+} from "./sms-formatter";
 
 interface OutboxRow {
   id: string;
@@ -32,6 +37,16 @@ const APPOINTMENT_INCLUDE = {
     },
   },
 } satisfies Prisma.AppointmentInclude;
+
+type LoadedAppointment = NonNullable<
+  Awaited<ReturnType<PrismaService["appointment"]["findFirst"]>>
+> &
+  Prisma.AppointmentGetPayload<{ include: typeof APPOINTMENT_INCLUDE }>;
+
+type SmsKind =
+  | "appointment_confirmation"
+  | "appointment_reschedule"
+  | "appointment_cancellation";
 
 /**
  * Outbox event handlers for the messaging side. Wired into the worker's
@@ -54,51 +69,153 @@ export class SmsHandlersService {
   ) {}
 
   async handleAppointmentCreated(event: OutboxRow): Promise<void> {
-    // Pull the appointmentId out of the snapshot payload the writer stored
-    // alongside the event (see appointments.service.ts → create()).
+    const ctx = await this.loadAppointmentContext(event);
+    if (!ctx) return;
+
+    // A reschedule between create and send means the customer should hear
+    // about the *current* time — so reformat from current state every attempt.
+    if (
+      ctx.appointment.status === AppointmentStatus.CANCELLED ||
+      ctx.appointment.status === AppointmentStatus.NO_SHOW
+    ) {
+      this.logger.log(
+        `appointment.created skipped: appointment ${ctx.appointment.id} is ${ctx.appointment.status}`,
+      );
+      return;
+    }
+
+    const totalDuration = ctx.appointment.services.reduce(
+      (acc, s) => acc + s.durationSnapshotMinutes,
+      0,
+    );
+    const body = formatConfirmationSms({
+      startAt: ctx.appointment.startAt,
+      staffFirstName: firstName(ctx.appointment.staffMember.displayName),
+      clientFirstName: firstName(ctx.appointment.client?.displayName ?? "there"),
+      serviceNames: ctx.appointment.services.map((s) => s.serviceNameSnapshot),
+      durationMinutes: totalDuration,
+      salonName: ctx.salonName,
+      salonTimezone: ctx.salonTimezone,
+    });
+
+    await this.sendOutboundSms({
+      event,
+      ctx,
+      body,
+      kind: "appointment_confirmation",
+    });
+  }
+
+  async handleAppointmentRescheduled(event: OutboxRow): Promise<void> {
+    const payload = (event.payload ?? {}) as { previousStartAt?: string };
+    if (!payload.previousStartAt) {
+      this.logger.warn(
+        `appointment.rescheduled event ${event.id} missing previousStartAt — skipping`,
+      );
+      return;
+    }
+    const previousStartAt = new Date(payload.previousStartAt);
+    if (Number.isNaN(previousStartAt.getTime())) {
+      this.logger.warn(
+        `appointment.rescheduled event ${event.id} has invalid previousStartAt — skipping`,
+      );
+      return;
+    }
+
+    const ctx = await this.loadAppointmentContext(event);
+    if (!ctx) return;
+
+    // Cancellations after a reschedule supersede the reschedule notice. Don't
+    // tell the client about a move that no longer matters.
+    if (
+      ctx.appointment.status === AppointmentStatus.CANCELLED ||
+      ctx.appointment.status === AppointmentStatus.NO_SHOW
+    ) {
+      this.logger.log(
+        `appointment.rescheduled skipped: appointment ${ctx.appointment.id} is ${ctx.appointment.status}`,
+      );
+      return;
+    }
+
+    const body = formatRescheduleSms({
+      previousStartAt,
+      newStartAt: ctx.appointment.startAt,
+      staffFirstName: firstName(ctx.appointment.staffMember.displayName),
+      clientFirstName: firstName(ctx.appointment.client?.displayName ?? "there"),
+      salonName: ctx.salonName,
+      salonTimezone: ctx.salonTimezone,
+    });
+
+    await this.sendOutboundSms({
+      event,
+      ctx,
+      body,
+      kind: "appointment_reschedule",
+    });
+  }
+
+  async handleAppointmentCancelled(event: OutboxRow): Promise<void> {
+    const ctx = await this.loadAppointmentContext(event);
+    if (!ctx) return;
+
+    // Don't filter on status here — a cancellation SMS for a CANCELLED
+    // appointment is the whole point.
+    const body = formatCancelSms({
+      startAt: ctx.appointment.startAt,
+      staffFirstName: firstName(ctx.appointment.staffMember.displayName),
+      clientFirstName: firstName(ctx.appointment.client?.displayName ?? "there"),
+      salonName: ctx.salonName,
+      salonTimezone: ctx.salonTimezone,
+    });
+
+    await this.sendOutboundSms({
+      event,
+      ctx,
+      body,
+      kind: "appointment_cancellation",
+    });
+  }
+
+  // ---------- shared helpers ----------
+
+  private async loadAppointmentContext(event: OutboxRow): Promise<{
+    appointment: LoadedAppointment;
+    salonId: string;
+    salonName: string;
+    salonTimezone: string;
+    toAddress: string;
+  } | null> {
     const payload = (event.payload ?? {}) as { id?: string; salonId?: string };
     const appointmentId = payload.id;
     const salonId = payload.salonId;
     if (!appointmentId || !salonId) {
       this.logger.warn(
-        `appointment.created event ${event.id} missing id/salonId in payload — skipping`,
+        `${event.eventType} event ${event.id} missing id/salonId in payload — skipping`,
       );
-      return;
+      return null;
     }
 
-    const appointment = await this.prisma.appointment.findFirst({
+    const appointment = (await this.prisma.appointment.findFirst({
       where: { id: appointmentId, salonId },
       include: APPOINTMENT_INCLUDE,
-    });
+    })) as LoadedAppointment | null;
     if (!appointment) {
-      // The appointment was hard-deleted before we got here. Nothing to do —
-      // but this shouldn't happen because we don't delete appointments. Log
-      // so it's visible if it ever does.
+      // The appointment was hard-deleted before we got here. We don't delete
+      // appointments today — log loudly if this ever fires.
       this.logger.warn(
-        `appointment.created event ${event.id} target appointment ${appointmentId} not found`,
+        `${event.eventType} event ${event.id} target appointment ${appointmentId} not found`,
       );
-      return;
-    }
-    // Re-formatting on every attempt means a reschedule between create and
-    // send produces a confirmation for the *new* time, not the original one.
-    if (
-      appointment.status === AppointmentStatus.CANCELLED ||
-      appointment.status === AppointmentStatus.NO_SHOW
-    ) {
-      this.logger.log(
-        `appointment.created skipped: appointment ${appointmentId} is ${appointment.status}`,
-      );
-      return;
+      return null;
     }
 
     const toAddress = appointment.client?.phone ?? null;
     if (!toAddress) {
-      // No phone on file → nothing we can send. Don't fail the outbox row;
-      // there's no retry that fixes a missing phone.
+      // No phone on file → no retry fixes that. Drop without throwing so the
+      // outbox row completes.
       this.logger.log(
-        `appointment.created skipped: client ${appointment.clientId} has no phone`,
+        `${event.eventType} skipped: client ${appointment.clientId} has no phone`,
       );
-      return;
+      return null;
     }
 
     const salon = await this.prisma.salon.findUnique({
@@ -106,44 +223,50 @@ export class SmsHandlersService {
       select: { name: true, timezone: true },
     });
     if (!salon) {
-      // Salon disappeared (which shouldn't happen — salons are not deleted).
-      // Bail without retrying.
       this.logger.warn(
-        `appointment.created skipped: salon ${salonId} not found`,
+        `${event.eventType} skipped: salon ${salonId} not found`,
       );
-      return;
+      return null;
     }
 
-    const totalDuration = appointment.services.reduce(
-      (acc, s) => acc + s.durationSnapshotMinutes,
-      0,
-    );
-    const body = formatConfirmationSms({
-      startAt: appointment.startAt,
-      staffFirstName: firstName(appointment.staffMember.displayName),
-      clientFirstName: firstName(appointment.client?.displayName ?? "there"),
-      serviceNames: appointment.services.map((s) => s.serviceNameSnapshot),
-      durationMinutes: totalDuration,
+    return {
+      appointment,
+      salonId,
       salonName: salon.name,
       salonTimezone: salon.timezone,
-    });
+      toAddress,
+    };
+  }
 
+  // INSERT-then-send-with-dedup, then transactional finalize. The bulk of
+  // each handler reduces to "render a body and call this".
+  private async sendOutboundSms({
+    event,
+    ctx,
+    body,
+    kind,
+  }: {
+    event: OutboxRow;
+    ctx: {
+      appointment: LoadedAppointment;
+      salonId: string;
+      toAddress: string;
+    };
+    body: string;
+    kind: SmsKind;
+  }): Promise<void> {
     const fromAddress = env.TWILIO_FROM_NUMBER ?? "+15555550100";
 
-    // Idempotency front door: try to insert the Message row keyed by
-    // outboxEventId. If a previous attempt crashed mid-send and left the
-    // row in QUEUED with no providerMessageId, we'll re-call the provider
-    // and update the same row instead of writing a new one.
     let messageRowId: string;
     try {
       const created = await this.prisma.message.create({
         data: {
-          salonId,
-          clientId: appointment.clientId,
+          salonId: ctx.salonId,
+          clientId: ctx.appointment.clientId,
           channel: "SMS",
           direction: MessageDirection.OUTBOUND,
           status: MessageStatus.QUEUED,
-          toAddress,
+          toAddress: ctx.toAddress,
           fromAddress,
           body,
           outboxEventId: event.id,
@@ -157,11 +280,8 @@ export class SmsHandlersService {
         });
         if (!existing) throw err;
         if (existing.providerMessageId) {
-          // Already sent on a previous attempt that crashed before marking
-          // the outbox row completed. The worker's idempotent finalize will
-          // fix that — nothing else to do here.
           this.logger.log(
-            `appointment.created already sent on prior attempt (sid=${existing.providerMessageId})`,
+            `${event.eventType} already sent on prior attempt (sid=${existing.providerMessageId})`,
           );
           return;
         }
@@ -174,7 +294,7 @@ export class SmsHandlersService {
     let result;
     try {
       result = await this.messaging.sendSms({
-        to: toAddress,
+        to: ctx.toAddress,
         from: fromAddress,
         body,
       });
@@ -188,16 +308,13 @@ export class SmsHandlersService {
           errorMessage: message.slice(0, 500),
         },
       });
-      // Re-throw so the worker bumps `attempts` and retries — a transient
-      // Twilio outage shouldn't terminally drop the SMS. The next attempt
-      // will pick up the same Message row via outboxEventId.
       throw sendErr;
     }
 
     // Pass the provider's status through verbatim — Twilio's create-time
-    // response is often still QUEUED/accepted, and the carrier-side terminal
-    // state (DELIVERED / FAILED) only arrives later via a status callback.
-    // Forcing SENT here would lie about delivery progress.
+    // response is often still QUEUED, and DELIVERED/FAILED only arrives
+    // later via the status callback. Forcing SENT here would misrepresent
+    // delivery progress.
     const messageStatus: MessageStatus =
       result.status === "FAILED"
         ? MessageStatus.FAILED
@@ -218,15 +335,15 @@ export class SmsHandlersService {
       });
       await tx.domainEvent.create({
         data: {
-          salonId,
+          salonId: ctx.salonId,
           aggregateType: "MESSAGE",
           aggregateId: messageRowId,
           eventType: EventType.MESSAGE_SMS_SENT,
           payload: {
-            appointmentId,
+            appointmentId: ctx.appointment.id,
             providerMessageId: result.providerMessageId,
-            to: toAddress,
-            kind: "appointment_confirmation",
+            to: ctx.toAddress,
+            kind,
           } satisfies Prisma.InputJsonValue,
           actorType: ActorType.SYSTEM,
         },

--- a/apps/api/src/outbox/outbox.worker.ts
+++ b/apps/api/src/outbox/outbox.worker.ts
@@ -151,6 +151,12 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       case EventType.APPOINTMENT_CREATED:
         await this.smsHandlers.handleAppointmentCreated(event);
         return;
+      case EventType.APPOINTMENT_RESCHEDULED:
+        await this.smsHandlers.handleAppointmentRescheduled(event);
+        return;
+      case EventType.APPOINTMENT_CANCELLED:
+        await this.smsHandlers.handleAppointmentCancelled(event);
+        return;
       default:
         // Unknown event types are silently completed so a bad row can't wedge
         // the worker. Log so we notice the typo / missing handler.

--- a/apps/api/test/sms-formatter.test.ts
+++ b/apps/api/test/sms-formatter.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   firstName,
+  formatCancelSms,
   formatConfirmationSms,
+  formatRescheduleSms,
 } from "../src/messaging/sms-formatter";
 
 describe("sms-formatter", () => {
@@ -60,6 +62,43 @@ describe("sms-formatter", () => {
         serviceNames: ["Color refresh", "Blowout"],
       });
       expect(body).toContain("Color refresh, Blowout");
+    });
+  });
+
+  describe("formatRescheduleSms", () => {
+    it("renders both old and new times in the salon timezone", () => {
+      const body = formatRescheduleSms({
+        previousStartAt: new Date("2026-04-30T17:00:00Z"),
+        newStartAt: new Date("2026-05-02T20:00:00Z"),
+        staffFirstName: "Trina",
+        clientFirstName: "Mira",
+        salonName: "Bella's Salon",
+        salonTimezone: "America/New_York",
+      });
+      expect(body).toContain("Bella's Salon");
+      expect(body).toContain("Mira");
+      expect(body).toContain("Trina");
+      expect(body).toContain("STOP");
+      // Old: Apr 30 1:00 PM EDT, New: May 2 4:00 PM EDT
+      expect(body).toMatch(/Thu, Apr 30 at 1:00\s?PM/);
+      expect(body).toMatch(/Sat, May 2 at 4:00\s?PM/);
+    });
+  });
+
+  describe("formatCancelSms", () => {
+    it("renders the cancelled appointment time in the salon timezone", () => {
+      const body = formatCancelSms({
+        startAt: new Date("2026-04-30T17:00:00Z"),
+        staffFirstName: "Trina",
+        clientFirstName: "Mira",
+        salonName: "Bella's Salon",
+        salonTimezone: "America/New_York",
+      });
+      expect(body).toContain("Bella's Salon");
+      expect(body).toContain("cancelled");
+      expect(body).toContain("Trina");
+      expect(body).toMatch(/Thu, Apr 30 at 1:00\s?PM/);
+      expect(body).toContain("STOP");
     });
   });
 });

--- a/apps/api/test/sms-handlers.test.ts
+++ b/apps/api/test/sms-handlers.test.ts
@@ -264,3 +264,124 @@ describe("SmsHandlersService.handleAppointmentCreated", () => {
     expect(domainEventCreate).not.toHaveBeenCalled();
   });
 });
+
+describe("SmsHandlersService.handleAppointmentRescheduled", () => {
+  const event = {
+    id: "00000000-0000-0000-0000-000000000f02",
+    eventType: "appointment.rescheduled",
+    payload: {
+      id: APPOINTMENT_ID,
+      salonId: SALON_ID,
+      previousStartAt: "2026-04-30T17:00:00Z",
+    } as Prisma.JsonValue,
+  };
+
+  it("sends a reschedule SMS containing both old and new times", async () => {
+    const { handler, sendSms, messageCreate, messageUpdate, domainEventCreate } =
+      buildHandler({
+        appointment: {
+          ...fakeAppointment(),
+          // Stand-in for the new time (May 2 4:00 PM EDT).
+          startAt: new Date("2026-05-02T20:00:00Z"),
+        },
+      });
+
+    await handler.handleAppointmentRescheduled(event);
+
+    expect(messageCreate).toHaveBeenCalledTimes(1);
+    expect(messageCreate.mock.calls[0]![0].data.body).toMatch(/Apr 30/);
+    expect(messageCreate.mock.calls[0]![0].data.body).toMatch(/May 2/);
+    expect(messageCreate.mock.calls[0]![0].data.outboxEventId).toBe(event.id);
+    expect(sendSms).toHaveBeenCalledTimes(1);
+    expect(messageUpdate).toHaveBeenCalledTimes(1);
+    expect(domainEventCreate).toHaveBeenCalledTimes(1);
+    expect(domainEventCreate.mock.calls[0]![0].data.payload.kind).toBe(
+      "appointment_reschedule",
+    );
+  });
+
+  it("skips when previousStartAt is missing from the payload", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: fakeAppointment(),
+    });
+    await handler.handleAppointmentRescheduled({
+      ...event,
+      payload: { id: APPOINTMENT_ID, salonId: SALON_ID } as Prisma.JsonValue,
+    });
+    expect(messageCreate).not.toHaveBeenCalled();
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+
+  it("skips when the appointment was cancelled before the reschedule SMS fired", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: fakeAppointment({ status: AppointmentStatus.CANCELLED }),
+    });
+    await handler.handleAppointmentRescheduled(event);
+    expect(messageCreate).not.toHaveBeenCalled();
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+
+  it("dedupes on retry via the outboxEventId path", async () => {
+    const dupErr = new Prisma.PrismaClientKnownRequestError(
+      "duplicate",
+      {
+        code: "P2002",
+        clientVersion: "x",
+        meta: { target: ["outboxEventId"] },
+      },
+    );
+    const { handler, sendSms, messageFindUnique } = buildHandler({
+      appointment: fakeAppointment(),
+      insertThrows: dupErr,
+      existingMessage: { id: "existing-id", providerMessageId: "SM_already_sent" },
+    });
+    await handler.handleAppointmentRescheduled(event);
+    expect(messageFindUnique).toHaveBeenCalledTimes(1);
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+});
+
+describe("SmsHandlersService.handleAppointmentCancelled", () => {
+  const event = {
+    id: "00000000-0000-0000-0000-000000000f03",
+    eventType: "appointment.cancelled",
+    payload: { id: APPOINTMENT_ID, salonId: SALON_ID } as Prisma.JsonValue,
+  };
+
+  it("sends a cancel SMS even when the appointment status is CANCELLED", async () => {
+    // Cancellation flips status to CANCELLED in the same transaction that
+    // emits the outbox event — by the time we run, status is already CANCELLED.
+    // Don't filter on it (the create handler does) because that's the whole
+    // point of this notice.
+    const { handler, sendSms, messageCreate, domainEventCreate } = buildHandler({
+      appointment: fakeAppointment({ status: AppointmentStatus.CANCELLED }),
+    });
+
+    await handler.handleAppointmentCancelled(event);
+
+    expect(messageCreate).toHaveBeenCalledTimes(1);
+    expect(messageCreate.mock.calls[0]![0].data.body).toMatch(/cancelled/i);
+    expect(sendSms).toHaveBeenCalledTimes(1);
+    expect(domainEventCreate.mock.calls[0]![0].data.payload.kind).toBe(
+      "appointment_cancellation",
+    );
+  });
+
+  it("skips when the client has no phone on file", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: fakeAppointment({ phone: null }),
+    });
+    await handler.handleAppointmentCancelled(event);
+    expect(messageCreate).not.toHaveBeenCalled();
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+
+  it("skips when the appointment is missing", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: null,
+    });
+    await handler.handleAppointmentCancelled(event);
+    expect(messageCreate).not.toHaveBeenCalled();
+    expect(sendSms).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Builds on 4a's handler dispatch — same outbox row → `Message` dedup → provider send → domain event flow, just two more event types wired up.

- `appointments.service.ts` now emits `OutboxEvent` rows for reschedule and cancel alongside the existing domain events. Reschedule payload carries `previousStartAt` so the SMS body can render \"moved from X to Y\" without a second appointment fetch.
- New formatter helpers `formatRescheduleSms` / `formatCancelSms` render both times in the salon timezone and share the existing STOP footer.
- `sms-handlers.service.ts` factored: extracted `loadAppointmentContext` (id/salonId resolution + missing-row / no-phone / no-salon skips) and `sendOutboundSms` (the INSERT-then-send dedup + finalize). The three handlers now read as \"render a body and call the helper,\" which keeps each event's policy decisions visible:
  - Cancel handler intentionally does **not** filter on `status=CANCELLED` — that's the whole point.
  - Reschedule handler **does** filter on `CANCELLED` so a late cancel supersedes a pending reschedule notice.
- Outbox worker dispatch routes the two new event types.

## Tests

36 / 36 passing (was 27, added 9). Covers:

- Fresh send for both new flows
- `outboxEventId` dedup on the field-array P2002 target shape (reschedule path)
- Missing-`previousStartAt` skip
- Late-cancel-after-reschedule skip
- No-phone skip
- Cancel-still-sends-when-status-is-CANCELLED invariant

## Test plan

- [x] `pnpm --filter @shearsimp/api typecheck` passes
- [x] `pnpm --filter @shearsimp/api test` — 36 / 36 pass
- [x] `pnpm --filter @shearsimp/db typecheck` / `web` / `shared` all pass
- [ ] Local smoke: book an appointment, reschedule it → API log shows two `[dev-sms]` entries (confirmation + reschedule); `messages` table has two outbound rows with distinct `outboxEventId`
- [ ] Cancel that appointment → third `[dev-sms]` for cancel; `messages` table has a third row