### PR TITLE
Fix booking flow: 1-slot click targets in the day-view picker

### DIFF
--- a/apps/web/src/app/(app)/schedule/_components/book-calendar.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-calendar.tsx
@@ -642,8 +642,15 @@ function BookDayView({
                 ),
               )}
 
-              {/* Open slots — only render the start of a fits-the-duration
-                  window so we don't paint a slot you can't actually book. */}
+              {/* Open slots — one button per quarter-hour slot, sized to a
+                  single slot so click targets don't overlap. We still gate
+                  by "fits the duration" so we never offer a slot the
+                  appointment can't actually fit into.
+                  The earlier rendering made each button `requiredSlots`
+                  rows tall, which stacked them up to 6 deep on a 90-min
+                  service — clicks were dispatched to whichever button
+                  happened to be last in DOM order at that y-coord, so
+                  picking "1:00" often booked 1:15 / 1:30 / etc. */}
               {Array.from({ length: TOTAL_SLOTS }).map((_, slot) => {
                 if (occ[slot]) return null;
                 let fits = true;
@@ -655,17 +662,14 @@ function BookDayView({
                 }
                 if (!fits) return null;
                 const minutes = SLOT_START_MIN + slot * SLOT_MIN;
-                const isSelectedHere =
-                  selectedMinutes === minutes &&
-                  (!selectedStaffId || selectedStaffId === s.id);
                 return (
                   <button
                     key={`o${slot}`}
                     type="button"
-                    className={`bk-day-open${isSelectedHere ? " is-picked" : ""}`}
+                    className="bk-day-open"
                     style={{
                       top: slot * SLOT_HEIGHT,
-                      height: requiredSlots * SLOT_HEIGHT,
+                      height: SLOT_HEIGHT,
                     }}
                     aria-label={`Book ${minutesLabel(minutes)} with ${s.displayName}`}
                     onClick={() => {
@@ -677,6 +681,35 @@ function BookDayView({
                   />
                 );
               })}
+
+              {/* Picked-slot preview — non-interactive overlay that shows
+                  the appointment's full duration in this column. We paint
+                  it on top of the open-slot buttons (pointer-events: none
+                  so it doesn't intercept further clicks) once a slot is
+                  picked for this stylist. */}
+              {selectedMinutes !== null &&
+                (!selectedStaffId || selectedStaffId === s.id) &&
+                selectedMinutes >= SLOT_START_MIN &&
+                selectedMinutes < SLOT_END_MIN && (() => {
+                  const startSlot =
+                    (selectedMinutes - SLOT_START_MIN) / SLOT_MIN;
+                  if (occ[startSlot]) return null;
+                  return (
+                    <div
+                      key="picked"
+                      className="bk-day-pick"
+                      style={{
+                        top: startSlot * SLOT_HEIGHT,
+                        height: requiredSlots * SLOT_HEIGHT,
+                      }}
+                      aria-hidden
+                    >
+                      <span className="bk-day-pick-label">
+                        {minutesLabel(selectedMinutes)}
+                      </span>
+                    </div>
+                  );
+                })()}
 
               {/* Existing appointments — read-only, color-coded. */}
               {appointments

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -2097,6 +2097,39 @@
   border-style: solid;
 }
 
+/* Selected-slot preview. Painted on top of the row of bk-day-open buttons
+   with pointer-events: none, so the user can still click a different open
+   slot (or the same one) while the preview is visible. The "block-y"
+   look makes it clear that this is the duration the appointment will
+   occupy — not just the start handle. */
+.bk-day-pick {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  border-radius: 5px;
+  background: linear-gradient(
+    135deg,
+    rgba(30, 195, 217, 0.32),
+    rgba(30, 195, 217, 0.14)
+  );
+  border: 1px solid var(--ss-magenta);
+  box-shadow: 0 0 0 1px rgba(30, 195, 217, 0.24);
+  pointer-events: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 3px 6px;
+  z-index: 1;
+}
+.bk-day-pick-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--ss-magenta-deep, var(--ss-text-heading));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.theme-twilight .bk-day-pick-label { color: var(--ss-magenta); }
+
 .bk-day-block {
   position: absolute;
   left: 4px;


### PR DESCRIPTION
## Summary

The open-slot buttons in the booking modal's day view were rendered \`requiredSlots\` rows tall (e.g., 6 × 14px = 84px for a 90-min service). That made every button overlap the next 5 buttons stacked above it, so clicks were dispatched to whichever button happened to land last in DOM order at that y-coord — picking \"1:00\" often booked 1:15 / 1:30 / etc., and sometimes nothing at all when the resolved slot didn't match what the user thought they were clicking.

## Fix

- Open-slot buttons are now 1 \`SLOT_HEIGHT\` tall (14px) so click targets correspond exactly to the time label next to them. The fits-the-duration gate still applies, so we never render a start slot where the appointment can't actually fit.
- A separate non-interactive overlay (\`.bk-day-pick\`, \`pointer-events: none\`) paints on top after selection showing the full appointment duration as a magenta-bordered block. Lets the user see the time the booking will occupy without the overlay intercepting clicks for re-picking.

## Test plan

- [x] \`pnpm --filter @shearsimp/web typecheck\` passes
- [ ] Open booking modal, pick a 90-min service → click 1:00 PM in the day view → confirms 1:00 PM (not 1:15 or 1:30)
- [ ] After selecting, the magenta block extends from 1:00 to 2:30 (90 min)
- [ ] Clicking another open slot moves the picked block; the booking time matches what's clicked
- [ ] \"Book appointment\" actually creates the appointment at the displayed time (cross-check the schedule view)