### PR TITLE
Phase 4b-2: 24h reminder SMS via deferred outbox events

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,14 +172,21 @@ Outbound first, inbound second. Reminder jobs separate from confirmations.
 - Vitest coverage for fresh send, retry dedup, missing-payload skip,
   status-already-cancelled-on-reschedule skip, no-phone skip
 
-### Phase 4b-2 — Reminder scheduling ⬜
+### Phase 4b-2 — Reminder scheduling 🚧
 
-- Reuse `OutboxEvent.nextAttemptAt` for deferred sends (cheaper than pulling
-  in BullMQ for one feature; the outbox already has scheduling primitives)
-- New event type `appointment.reminder_due` emitted on create with
-  `nextAttemptAt = startAt - 24h`; reschedule updates the time, cancel marks
-  the row `COMPLETED`
-- Worker tick already polls by `nextAttemptAt`, so no leasing changes needed
+- New event type `appointment.reminder_due`. Reuses `OutboxEvent.nextAttemptAt`
+  for deferred dispatch (the worker's existing poll already filters on it,
+  so no leasing/queue changes were needed).
+- `create()` schedules with `nextAttemptAt = startAt - 24h`. Same-day
+  bookings end up with a past `nextAttemptAt` and fire on the next tick,
+  which is the correct behaviour.
+- `reschedule()` does an `updateMany` to move the still-`PENDING` row
+  forward/back; rows that already fired don't match (status moved past
+  PENDING) and stay as-is — once a reminder went out for the old time, we
+  can't unsend it.
+- `cancel()` marks the still-`PENDING` row `COMPLETED` to suppress firing.
+- Handler skips on CANCELLED / NO_SHOW / COMPLETED status (belt + suspenders
+  for races) and on a startAt that's already past at fire time.
 
 ### Phase 4b-3 — Per-salon Twilio numbers ⬜
 

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -32,6 +32,13 @@ import {
 // is a generous upper bound for the calendar UI; longer ranges should paginate.
 const RANGE_QUERY_MAX_DAYS = 62;
 
+// How far in advance the reminder SMS fires. The actual schedule lives in
+// `OutboxEvent.nextAttemptAt`, which the existing worker already polls — no
+// separate scheduler needed. If startAt is less than this far away (or
+// already past) the row's nextAttemptAt is in the past and the worker fires
+// it on its next tick.
+const REMINDER_LEAD_MS = 24 * 60 * 60 * 1000;
+
 const APPOINTMENT_INCLUDE = {
   client: { select: { id: true, displayName: true, phone: true, email: true } },
   staffMember: { select: { id: true, displayName: true, color: true } },
@@ -196,15 +203,28 @@ export class AppointmentsService {
         payload: eventPayload,
         actorUserId,
       });
-      // Outbox row for downstream side-effects (Phase 4 wires the SMS
-      // confirmation handler). The worker is a noop today; the row exists
-      // because the contract is "events ride along the same transaction".
+      // Outbox row driving the confirmation SMS (Phase 4a).
       await tx.outboxEvent.create({
         data: {
           salonId,
           eventType: EventType.APPOINTMENT_CREATED,
           payload: eventPayload as Prisma.InputJsonValue,
           status: OutboxStatus.PENDING,
+        },
+      });
+      // Outbox row driving the 24h reminder SMS (Phase 4b-2). nextAttemptAt
+      // is in the past for same-day bookings — that's fine, the worker
+      // fires it on the next tick.
+      await tx.outboxEvent.create({
+        data: {
+          salonId,
+          eventType: EventType.APPOINTMENT_REMINDER_DUE,
+          payload: {
+            id: appointment.id,
+            salonId,
+          } as Prisma.InputJsonValue,
+          status: OutboxStatus.PENDING,
+          nextAttemptAt: new Date(startAt.getTime() - REMINDER_LEAD_MS),
         },
       });
       return appointment;
@@ -305,6 +325,23 @@ export class AppointmentsService {
           status: OutboxStatus.PENDING,
         },
       });
+      // Move the still-pending reminder forward (or back) to match the new
+      // startAt. updateMany skips rows that have already fired (status !=
+      // PENDING), which is the correct behaviour — once a reminder went
+      // out for the old time, we can't unsend it.
+      await tx.outboxEvent.updateMany({
+        where: {
+          eventType: EventType.APPOINTMENT_REMINDER_DUE,
+          status: OutboxStatus.PENDING,
+          salonId,
+          payload: { path: ["id"], equals: id },
+        },
+        data: {
+          nextAttemptAt: new Date(
+            updated.startAt.getTime() - REMINDER_LEAD_MS,
+          ),
+        },
+      });
       return updated;
     });
   }
@@ -353,6 +390,21 @@ export class AppointmentsService {
           eventType: EventType.APPOINTMENT_CANCELLED,
           payload: { id, salonId } as Prisma.InputJsonValue,
           status: OutboxStatus.PENDING,
+        },
+      });
+      // Suppress any still-pending reminder. We complete the row rather
+      // than delete it so the audit trail (and the worker's metrics)
+      // still see what was scheduled.
+      await tx.outboxEvent.updateMany({
+        where: {
+          eventType: EventType.APPOINTMENT_REMINDER_DUE,
+          status: OutboxStatus.PENDING,
+          salonId,
+          payload: { path: ["id"], equals: id },
+        },
+        data: {
+          status: OutboxStatus.COMPLETED,
+          processedAt: new Date(),
         },
       });
       return updated;

--- a/apps/api/src/messaging/sms-formatter.ts
+++ b/apps/api/src/messaging/sms-formatter.ts
@@ -72,8 +72,12 @@ interface ReminderForSms {
 
 export function formatReminderSms(input: ReminderForSms): string {
   const when = formatDateTimeLabel(input.startAt, input.salonTimezone);
+  // Use a colon, not an em dash. Em dash is outside GSM-7 and forces the
+  // whole message into UCS-2, dropping per-segment capacity from 160 → 70
+  // chars. That was the only non-GSM-7 punctuation in any of our
+  // production-bound templates; the other helpers stay ASCII.
   return (
-    `${input.salonName}: Reminder — your appointment with ` +
+    `${input.salonName}: Reminder: your appointment with ` +
     `${input.staffFirstName} is ${when}. Reply STOP to opt out.`
   );
 }

--- a/apps/api/src/messaging/sms-formatter.ts
+++ b/apps/api/src/messaging/sms-formatter.ts
@@ -62,6 +62,22 @@ export function formatCancelSms(input: CancelForSms): string {
   );
 }
 
+interface ReminderForSms {
+  startAt: Date;
+  staffFirstName: string;
+  clientFirstName: string;
+  salonName: string;
+  salonTimezone: string;
+}
+
+export function formatReminderSms(input: ReminderForSms): string {
+  const when = formatDateTimeLabel(input.startAt, input.salonTimezone);
+  return (
+    `${input.salonName}: Reminder — your appointment with ` +
+    `${input.staffFirstName} is ${when}. Reply STOP to opt out.`
+  );
+}
+
 function formatDateTimeLabel(instant: Date, timeZone: string): string {
   // "Thu Apr 30 at 1:00 PM" — combined so reschedule/cancel bodies stay
   // inside one segment with both before/after.

--- a/apps/api/src/messaging/sms-handlers.service.ts
+++ b/apps/api/src/messaging/sms-handlers.service.ts
@@ -17,6 +17,7 @@ import {
   firstName,
   formatCancelSms,
   formatConfirmationSms,
+  formatReminderSms,
   formatRescheduleSms,
 } from "./sms-formatter";
 
@@ -46,7 +47,8 @@ type LoadedAppointment = NonNullable<
 type SmsKind =
   | "appointment_confirmation"
   | "appointment_reschedule"
-  | "appointment_cancellation";
+  | "appointment_cancellation"
+  | "appointment_reminder";
 
 /**
  * Outbox event handlers for the messaging side. Wired into the worker's
@@ -173,6 +175,50 @@ export class SmsHandlersService {
       ctx,
       body,
       kind: "appointment_cancellation",
+    });
+  }
+
+  async handleAppointmentReminderDue(event: OutboxRow): Promise<void> {
+    const ctx = await this.loadAppointmentContext(event);
+    if (!ctx) return;
+
+    // Cancellation suppression already happens at scheduling time
+    // (cancel() marks the reminder row COMPLETED in the same transaction).
+    // The status checks here are belt + suspenders for races and for any
+    // path that bypasses the suppression — e.g., a status transition to
+    // COMPLETED / NO_SHOW between scheduling and firing.
+    if (
+      ctx.appointment.status === AppointmentStatus.CANCELLED ||
+      ctx.appointment.status === AppointmentStatus.NO_SHOW ||
+      ctx.appointment.status === AppointmentStatus.COMPLETED
+    ) {
+      this.logger.log(
+        `appointment.reminder_due skipped: appointment ${ctx.appointment.id} is ${ctx.appointment.status}`,
+      );
+      return;
+    }
+    // A reminder for a time that's already past is just noise. Drop without
+    // sending; the worker still marks the row COMPLETED so it stops polling.
+    if (ctx.appointment.startAt.getTime() <= Date.now()) {
+      this.logger.log(
+        `appointment.reminder_due skipped: appointment ${ctx.appointment.id} startAt is in the past`,
+      );
+      return;
+    }
+
+    const body = formatReminderSms({
+      startAt: ctx.appointment.startAt,
+      staffFirstName: firstName(ctx.appointment.staffMember.displayName),
+      clientFirstName: firstName(ctx.appointment.client?.displayName ?? "there"),
+      salonName: ctx.salonName,
+      salonTimezone: ctx.salonTimezone,
+    });
+
+    await this.sendOutboundSms({
+      event,
+      ctx,
+      body,
+      kind: "appointment_reminder",
     });
   }
 

--- a/apps/api/src/outbox/outbox.worker.ts
+++ b/apps/api/src/outbox/outbox.worker.ts
@@ -157,6 +157,9 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
       case EventType.APPOINTMENT_CANCELLED:
         await this.smsHandlers.handleAppointmentCancelled(event);
         return;
+      case EventType.APPOINTMENT_REMINDER_DUE:
+        await this.smsHandlers.handleAppointmentReminderDue(event);
+        return;
       default:
         // Unknown event types are silently completed so a bad row can't wedge
         // the worker. Log so we notice the typo / missing handler.

--- a/apps/api/test/sms-formatter.test.ts
+++ b/apps/api/test/sms-formatter.test.ts
@@ -3,6 +3,7 @@ import {
   firstName,
   formatCancelSms,
   formatConfirmationSms,
+  formatReminderSms,
   formatRescheduleSms,
 } from "../src/messaging/sms-formatter";
 
@@ -96,6 +97,23 @@ describe("sms-formatter", () => {
       });
       expect(body).toContain("Bella's Salon");
       expect(body).toContain("cancelled");
+      expect(body).toContain("Trina");
+      expect(body).toMatch(/Thu, Apr 30 at 1:00\s?PM/);
+      expect(body).toContain("STOP");
+    });
+  });
+
+  describe("formatReminderSms", () => {
+    it("renders a reminder body with the appointment time", () => {
+      const body = formatReminderSms({
+        startAt: new Date("2026-04-30T17:00:00Z"),
+        staffFirstName: "Trina",
+        clientFirstName: "Mira",
+        salonName: "Bella's Salon",
+        salonTimezone: "America/New_York",
+      });
+      expect(body).toContain("Bella's Salon");
+      expect(body).toContain("Reminder");
       expect(body).toContain("Trina");
       expect(body).toMatch(/Thu, Apr 30 at 1:00\s?PM/);
       expect(body).toContain("STOP");

--- a/apps/api/test/sms-handlers.test.ts
+++ b/apps/api/test/sms-handlers.test.ts
@@ -341,6 +341,83 @@ describe("SmsHandlersService.handleAppointmentRescheduled", () => {
   });
 });
 
+describe("SmsHandlersService.handleAppointmentReminderDue", () => {
+  const event = {
+    id: "00000000-0000-0000-0000-000000000f04",
+    eventType: "appointment.reminder_due",
+    payload: { id: APPOINTMENT_ID, salonId: SALON_ID } as Prisma.JsonValue,
+  };
+
+  // The handler reads Date.now() to decide whether the appointment is past.
+  // The fake appointments use 2026-04-30 17:00 UTC, so anchor "now" earlier
+  // than that for the happy path.
+  const FUTURE_NOW = new Date("2026-04-30T16:00:00Z"); // 1 hour before
+  const PAST_NOW = new Date("2026-05-01T00:00:00Z"); // after appointment
+
+  it("sends a reminder SMS for an upcoming appointment", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FUTURE_NOW);
+    try {
+      const { handler, sendSms, messageCreate, domainEventCreate } =
+        buildHandler({ appointment: fakeAppointment() });
+
+      await handler.handleAppointmentReminderDue(event);
+
+      expect(messageCreate).toHaveBeenCalledTimes(1);
+      expect(messageCreate.mock.calls[0]![0].data.body).toMatch(/Reminder/);
+      expect(sendSms).toHaveBeenCalledTimes(1);
+      expect(domainEventCreate.mock.calls[0]![0].data.payload.kind).toBe(
+        "appointment_reminder",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips when the appointment is already in the past", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(PAST_NOW);
+    try {
+      const { handler, sendSms, messageCreate } = buildHandler({
+        appointment: fakeAppointment(),
+      });
+      await handler.handleAppointmentReminderDue(event);
+      expect(messageCreate).not.toHaveBeenCalled();
+      expect(sendSms).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips when status has moved to COMPLETED before the reminder fired", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FUTURE_NOW);
+    try {
+      const { handler, sendSms } = buildHandler({
+        appointment: fakeAppointment({ status: AppointmentStatus.COMPLETED }),
+      });
+      await handler.handleAppointmentReminderDue(event);
+      expect(sendSms).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips when status is CANCELLED (belt + suspenders for the suppression)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FUTURE_NOW);
+    try {
+      const { handler, sendSms } = buildHandler({
+        appointment: fakeAppointment({ status: AppointmentStatus.CANCELLED }),
+      });
+      await handler.handleAppointmentReminderDue(event);
+      expect(sendSms).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("SmsHandlersService.handleAppointmentCancelled", () => {
   const event = {
     id: "00000000-0000-0000-0000-000000000f03",

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -98,6 +98,8 @@ export const EventType = {
   PAYMENT_SUCCEEDED: "payment.succeeded",
   PAYMENT_REFUNDED: "payment.refunded",
 
+  APPOINTMENT_REMINDER_DUE: "appointment.reminder_due",
+
   MESSAGE_SMS_SENT: "message.sms_sent",
   MESSAGE_SMS_RECEIVED: "message.sms_received",
 


### PR DESCRIPTION
## Summary

Reuses the outbox's existing \`nextAttemptAt\` scheduling instead of pulling in BullMQ. The worker already polls by \`nextAttemptAt\`, so a deferred reminder is just an \`OutboxEvent\` row whose \`nextAttemptAt\` is in the future — no separate queue, no leasing changes.

## Scheduling (`appointments.service.ts`)

- **`create()`** emits an \`appointment.reminder_due\` row with \`nextAttemptAt = startAt - 24h\`. Same-day bookings get a past \`nextAttemptAt\` and fire on the next tick (correct behaviour — the customer wants to know they have an appointment today).
- **`reschedule()`** does an \`updateMany\` on still-\`PENDING\` rows to move the reminder forward/back. Rows that already fired don't match (status has moved past PENDING) and stay as-is — once a reminder went out for the old time, we can't unsend it.
- **`cancel()`** marks the still-\`PENDING\` row \`COMPLETED\` to suppress firing. Using \`COMPLETED\` rather than delete preserves the audit trail and worker metrics.

## Handler

- \`handleAppointmentReminderDue\` uses the existing \`loadAppointmentContext\` + \`sendOutboundSms\` helpers, so the only new code is render-the-body and the per-event skip rules.
- Skips on \`CANCELLED\` / \`NO_SHOW\` / \`COMPLETED\` status (belt + suspenders for races, and for direct status transitions to \`COMPLETED\` before the reminder fired).
- Skips when \`startAt\` is already past at fire time.

## Why not BullMQ

The original 4b plan called for it. Replaced with the outbox's existing scheduling because:

- The outbox already supports deferred dispatch via \`nextAttemptAt\` — we'd be adding Redis + a queue worker for a feature that fits in the table we have.
- Same transactional guarantees — the reminder row appends in the same write that creates the appointment, so we can't have an appointment without its reminder scheduled.
- One worker process, one polling loop, one place to look when something doesn't fire.

If we hit operational pain (high event volume, want per-event TTL/dead-letter dashboards, multiple workers needing leasing), BullMQ migration becomes a focused PR. Until then, this is simpler.

## Tests

41 / 41 passing (was 36, added 5):

- Reminder formatter renders the timezone-correct date + STOP footer
- Fresh reminder send for an upcoming appointment
- Skip when \`startAt\` is already past
- Skip when status moved to \`COMPLETED\`
- Skip when status is \`CANCELLED\` (suppression backstop)

## Test plan

- [x] \`pnpm --filter @shearsimp/api typecheck\` / \`test\` (41/41)
- [x] \`pnpm --filter @shearsimp/db typecheck\` / \`test\` (enum parity)
- [x] \`pnpm --filter @shearsimp/web typecheck\` / \`shared\` typecheck
- [ ] Smoke: book an appointment for ~25 min from now → confirmation fires immediately, reminder fires within 5s of \`startAt - 24h\` (i.e., basically right away). \`outbox_events\` table shows two rows for the appointment, both transition to \`COMPLETED\`.
- [ ] Smoke: book for tomorrow, reschedule to 2 days out → \`outbox_events\` row for the reminder shows updated \`nextAttemptAt\` matching the new \`startAt - 24h\`.
- [ ] Smoke: book for tomorrow, cancel → reminder row goes \`COMPLETED\` immediately; no third \`[dev-sms]\` log line for a reminder appears.