### PR TITLE
Fix nested-button hydration error in services trigger

### DIFF
--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
@@ -565,10 +565,24 @@ function ServicesField({
     <div className="bk-field bk-svc-field">
       <label className="bk-label">Services</label>
       <div className={`bk-svc-combo${open ? " is-open" : ""}`} ref={popRef}>
-        <button
-          type="button"
+        {/* Trigger is a div, not a button. The selected-service tags inside
+            need their own × <button> for removal, and <button> nested inside
+            <button> is invalid HTML — Next strict-mode reports it as a
+            hydration error. role="button" + Enter/Space/Esc keyboard
+            handlers preserve the same a11y affordance. */}
+        <div
+          role="button"
+          tabIndex={0}
           className="bk-svc-trigger"
           onClick={() => setOpen((o) => !o)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setOpen((o) => !o);
+            } else if (e.key === "Escape" && open) {
+              setOpen(false);
+            }
+          }}
           aria-haspopup="listbox"
           aria-expanded={open}
         >
@@ -615,7 +629,7 @@ function ServicesField({
               ▾
             </span>
           </span>
-        </button>
+        </div>
 
         {open && (
           <div className="bk-svc-pop" role="listbox">


### PR DESCRIPTION
## Summary

The \`ServicesField\` combobox trigger was a \`<button>\` wrapping each selected-service tag, and each tag has a × \`<button>\` for removal. \`<button>\` nested inside \`<button>\` is invalid HTML — Next surfaces it as a hydration error in React strict mode.

## Fix

Switch the trigger to \`<div role=\"button\" tabIndex={0}>\` with Enter/Space to toggle and Escape to close. Same a11y affordances, no nested buttons. The chip-remove × buttons stay as real \`<button>\`s.

## Test plan

- [x] \`pnpm --filter @shearsimp/web typecheck\` passes
- [ ] Open booking modal, click services trigger → opens (mouse)
- [ ] Tab to trigger, press Enter → opens; press Esc → closes
- [ ] Pick a service, click × on the tag → removes it without re-opening the popover
- [ ] No hydration / nested-button warnings in the browser console