### PR TITLE
Phase 4b-3: per-salon Twilio numbers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -188,11 +188,14 @@ Outbound first, inbound second. Reminder jobs separate from confirmations.
 - Handler skips on CANCELLED / NO_SHOW / COMPLETED status (belt + suspenders
   for races) and on a startAt that's already past at fire time.
 
-### Phase 4b-3 — Per-salon Twilio numbers ⬜
+### Phase 4b-3 — Per-salon Twilio numbers 🚧
 
-- New `Salon.smsFromNumber` field + settings UI
-- Inbound webhook routes by `To` header instead of by sender phone
-- Removes the single-shared-number caveat from 4a
+- New nullable, unique `Salon.smsFromNumber` (E.164) + settings UI field
+- Outbound: handler reads `Salon.smsFromNumber` first, falls back to the
+  env-level `TWILIO_FROM_NUMBER`, drops with a logged warning if neither
+- Inbound: webhook routes by `To` header (`Salon.findUnique` on `smsFromNumber`)
+  with a sender-phone fallback that keeps single-tenant dev working
+- Shared zod validates E.164 format on PATCH; null clears the number
 
 ### Backlog (was 4b, deferred to 4c or beyond)
 

--- a/apps/api/src/messaging/sms-handlers.service.ts
+++ b/apps/api/src/messaging/sms-handlers.service.ts
@@ -229,6 +229,7 @@ export class SmsHandlersService {
     salonId: string;
     salonName: string;
     salonTimezone: string;
+    salonSmsFromNumber: string | null;
     toAddress: string;
   } | null> {
     const payload = (event.payload ?? {}) as { id?: string; salonId?: string };
@@ -266,7 +267,7 @@ export class SmsHandlersService {
 
     const salon = await this.prisma.salon.findUnique({
       where: { id: salonId },
-      select: { name: true, timezone: true },
+      select: { name: true, timezone: true, smsFromNumber: true },
     });
     if (!salon) {
       this.logger.warn(
@@ -280,6 +281,7 @@ export class SmsHandlersService {
       salonId,
       salonName: salon.name,
       salonTimezone: salon.timezone,
+      salonSmsFromNumber: salon.smsFromNumber,
       toAddress,
     };
   }
@@ -296,12 +298,24 @@ export class SmsHandlersService {
     ctx: {
       appointment: LoadedAppointment;
       salonId: string;
+      salonSmsFromNumber: string | null;
       toAddress: string;
     };
     body: string;
     kind: SmsKind;
   }): Promise<void> {
-    const fromAddress = env.TWILIO_FROM_NUMBER ?? "+15555550100";
+    // Per-salon number wins over the platform default. The platform default
+    // is the dev / shared-number fallback while salons are still onboarding.
+    // If neither is set we drop the send entirely — there's no retry that
+    // fixes a missing number, so we mark the row complete rather than
+    // dead-letter it.
+    const fromAddress = ctx.salonSmsFromNumber ?? env.TWILIO_FROM_NUMBER ?? null;
+    if (!fromAddress) {
+      this.logger.warn(
+        `${event.eventType} skipped: no smsFromNumber on salon ${ctx.salonId} and no TWILIO_FROM_NUMBER fallback`,
+      );
+      return;
+    }
 
     let messageRowId: string;
     try {

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { EventType } from "@shearsimp/shared";
 import type { SalonSettingsUpdateInput } from "@shearsimp/shared";
@@ -39,37 +43,70 @@ export class SettingsService {
       data.smsFromNumber = input.smsFromNumber;
     }
 
-    return this.prisma.$transaction(async (tx) => {
-      const salon = await tx.salon.update({
-        where: { id: salonId },
-        data,
-        select: {
-          id: true,
-          slug: true,
-          name: true,
-          timezone: true,
-          smsFromNumber: true,
-          isActive: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      });
-      await appendDomainEvent(tx, {
-        salonId,
-        aggregateType: "SALON",
-        aggregateId: salonId,
-        eventType: EventType.SALON_UPDATED,
-        payload: {
-          changes: input,
-          after: {
-            name: salon.name,
-            timezone: salon.timezone,
-            smsFromNumber: salon.smsFromNumber,
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const salon = await tx.salon.update({
+          where: { id: salonId },
+          data,
+          select: {
+            id: true,
+            slug: true,
+            name: true,
+            timezone: true,
+            smsFromNumber: true,
+            isActive: true,
+            createdAt: true,
+            updatedAt: true,
           },
-        },
-        actorUserId,
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "SALON",
+          aggregateId: salonId,
+          eventType: EventType.SALON_UPDATED,
+          payload: {
+            changes: input,
+            after: {
+              name: salon.name,
+              timezone: salon.timezone,
+              smsFromNumber: salon.smsFromNumber,
+            },
+          },
+          actorUserId,
+        });
+        return salon;
       });
-      return salon;
-    });
+    } catch (e) {
+      // smsFromNumber is unique across all salons (Twilio routes inbound by
+      // To, so two salons can't share). Map the constraint violation to a
+      // 409 with a field-scoped error message instead of letting Nest serve
+      // a generic 500.
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === "P2002"
+      ) {
+        const target = (e.meta as { target?: string[] | string } | undefined)
+          ?.target;
+        const hitsSmsFromNumber = Array.isArray(target)
+          ? target.includes("smsFromNumber")
+          : target === "smsFromNumber" ||
+            target === "salons_smsFromNumber_key";
+        if (hitsSmsFromNumber) {
+          // Shape matches the Zod-style payload the web's ApiError.fieldMessages()
+          // already parses, so the form can surface the conflict at the
+          // smsFromNumber field instead of as a generic top-of-form error.
+          throw new ConflictException({
+            message: "Another salon already uses that SMS sender number",
+            issues: [
+              {
+                path: "smsFromNumber",
+                message: "Already claimed by another salon",
+              },
+            ],
+          });
+        }
+      }
+      throw e;
+    }
   }
 }

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -17,6 +17,7 @@ export class SettingsService {
         slug: true,
         name: true,
         timezone: true,
+        smsFromNumber: true,
         isActive: true,
         createdAt: true,
         updatedAt: true,
@@ -34,6 +35,9 @@ export class SettingsService {
     const data: Prisma.SalonUpdateInput = {};
     if (input.name !== undefined) data.name = input.name;
     if (input.timezone !== undefined) data.timezone = input.timezone;
+    if (input.smsFromNumber !== undefined) {
+      data.smsFromNumber = input.smsFromNumber;
+    }
 
     return this.prisma.$transaction(async (tx) => {
       const salon = await tx.salon.update({
@@ -44,6 +48,7 @@ export class SettingsService {
           slug: true,
           name: true,
           timezone: true,
+          smsFromNumber: true,
           isActive: true,
           createdAt: true,
           updatedAt: true,
@@ -56,7 +61,11 @@ export class SettingsService {
         eventType: EventType.SALON_UPDATED,
         payload: {
           changes: input,
-          after: { name: salon.name, timezone: salon.timezone },
+          after: {
+            name: salon.name,
+            timezone: salon.timezone,
+            smsFromNumber: salon.smsFromNumber,
+          },
         },
         actorUserId,
       });

--- a/apps/api/src/webhooks/twilio-webhook.controller.ts
+++ b/apps/api/src/webhooks/twilio-webhook.controller.ts
@@ -105,27 +105,48 @@ export class TwilioWebhookController {
       );
     }
 
-    // Salon routing: find a client by phone. In 4a we expect each phone to
-    // belong to one salon — if we get multiple matches we log and skip
-    // rather than risk routing to the wrong one.
-    const matches = await this.prisma.client.findMany({
-      where: { phone: from },
-      select: { id: true, salonId: true, displayName: true },
-      take: 2,
+    // Salon routing: when a salon claims the destination number via
+    // smsFromNumber we route by `To` directly (Twilio's own routing
+    // primitive). Falling back to sender-phone lookup keeps the dev /
+    // single-shared-number path working until every salon has provisioned
+    // its own number.
+    const salonByNumber = await this.prisma.salon.findUnique({
+      where: { smsFromNumber: to },
+      select: { id: true },
     });
-    if (matches.length === 0) {
-      this.logger.log(
-        `Inbound SMS from ${from} sid=${sid} matched no client — dropping`,
-      );
-      return TWIML_EMPTY;
+    let match: { id: string; salonId: string };
+    if (salonByNumber) {
+      const client = await this.prisma.client.findFirst({
+        where: { salonId: salonByNumber.id, phone: from },
+        select: { id: true, salonId: true },
+      });
+      if (!client) {
+        this.logger.log(
+          `Inbound SMS to ${to} (salon ${salonByNumber.id}) from ${from} sid=${sid} matched no client in that salon — dropping`,
+        );
+        return TWIML_EMPTY;
+      }
+      match = client;
+    } else {
+      const fallback = await this.prisma.client.findMany({
+        where: { phone: from },
+        select: { id: true, salonId: true },
+        take: 2,
+      });
+      if (fallback.length === 0) {
+        this.logger.log(
+          `Inbound SMS from ${from} sid=${sid} matched no client — dropping`,
+        );
+        return TWIML_EMPTY;
+      }
+      if (fallback.length > 1) {
+        this.logger.warn(
+          `Inbound SMS from ${from} sid=${sid} matched ${fallback.length} clients across salons — ambiguous, dropping`,
+        );
+        return TWIML_EMPTY;
+      }
+      match = fallback[0]!;
     }
-    if (matches.length > 1) {
-      this.logger.warn(
-        `Inbound SMS from ${from} sid=${sid} matched ${matches.length} clients — ambiguous, dropping`,
-      );
-      return TWIML_EMPTY;
-    }
-    const match = matches[0]!;
 
     try {
       await this.prisma.$transaction(async (tx) => {

--- a/apps/api/test/sms-handlers.test.ts
+++ b/apps/api/test/sms-handlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppointmentStatus, MessageStatus, Prisma } from "@prisma/client";
 import { SmsHandlersService } from "../src/messaging/sms-handlers.service";
 import type { MessagingProvider } from "../src/messaging/messaging-provider.interface";
+import { env } from "../src/env";
 
 // Mock prisma + messaging provider so the handler can run end-to-end without
 // a database. The goal is to assert the flow control around send + dedup,
@@ -38,11 +39,13 @@ function buildHandler({
   messageRowId = "00000000-0000-0000-0000-000000000e01",
   existingMessage = null,
   insertThrows = null,
+  salonSmsFromNumber = null,
 }: {
   appointment?: ReturnType<typeof fakeAppointment> | null;
   messageRowId?: string;
   existingMessage?: { id: string; providerMessageId: string | null } | null;
   insertThrows?: Error | null;
+  salonSmsFromNumber?: string | null;
 }) {
   const sendSms = vi.fn().mockResolvedValue({
     providerMessageId: "SM_test_sid",
@@ -69,6 +72,7 @@ function buildHandler({
       findUnique: vi.fn().mockResolvedValue({
         name: "Bella's Salon",
         timezone: "America/New_York",
+        smsFromNumber: salonSmsFromNumber,
       }),
     },
     message: {
@@ -134,6 +138,41 @@ describe("SmsHandlersService.handleAppointmentCreated", () => {
     expect(domainEventCreate.mock.calls[0]![0].data.eventType).toBe(
       "message.sms_sent",
     );
+  });
+
+  it("uses the salon's smsFromNumber when set, ignoring the env fallback", async () => {
+    const { handler, sendSms, messageCreate } = buildHandler({
+      appointment: fakeAppointment(),
+      salonSmsFromNumber: "+15551112222",
+    });
+
+    await handler.handleAppointmentCreated(event);
+
+    expect(sendSms.mock.calls[0]![0].from).toBe("+15551112222");
+    expect(messageCreate.mock.calls[0]![0].data.fromAddress).toBe(
+      "+15551112222",
+    );
+  });
+
+  it("skips when neither salon nor env has a from-number", async () => {
+    // env is loaded once at module init from process.env, so we mutate the
+    // cached object directly rather than reach for vi.mock — the handler
+    // reads `env.TWILIO_FROM_NUMBER`, not `process.env`.
+    const prev = env.TWILIO_FROM_NUMBER;
+    (env as { TWILIO_FROM_NUMBER?: string }).TWILIO_FROM_NUMBER = undefined;
+    try {
+      const { handler, sendSms, messageCreate } = buildHandler({
+        appointment: fakeAppointment(),
+        salonSmsFromNumber: null,
+      });
+
+      await handler.handleAppointmentCreated(event);
+
+      expect(messageCreate).not.toHaveBeenCalled();
+      expect(sendSms).not.toHaveBeenCalled();
+    } finally {
+      (env as { TWILIO_FROM_NUMBER?: string }).TWILIO_FROM_NUMBER = prev;
+    }
   });
 
   it("does not double-send when retried after a successful send (outboxEventId dedup, constraint-name target)", async () => {

--- a/apps/web/src/app/(app)/settings/_actions.ts
+++ b/apps/web/src/app/(app)/settings/_actions.ts
@@ -22,9 +22,17 @@ export async function updateSettingsAction(
   _prev: FormState,
   formData: FormData,
 ): Promise<FormState> {
+  const rawSms = optional(formData.get("smsFromNumber"));
   const raw = {
     name: optional(formData.get("name")),
     timezone: optional(formData.get("timezone")),
+    // Distinguish "field absent" from "user cleared the input". The form
+    // always submits the field, so an empty string means "clear it" → null.
+    // A non-submission (no key in formData) means "leave it alone" →
+    // undefined, which the zod schema treats as no-op.
+    smsFromNumber: formData.has("smsFromNumber")
+      ? rawSms ?? null
+      : undefined,
   };
   const parsed = salonSettingsUpdateSchema.safeParse(raw);
   if (!parsed.success) return { errors: toFormErrors(parsed) };

--- a/apps/web/src/app/(app)/settings/_components/settings-form.tsx
+++ b/apps/web/src/app/(app)/settings/_components/settings-form.tsx
@@ -20,7 +20,12 @@ const TIMEZONE_OPTIONS = [
 export function SettingsForm({
   defaults,
 }: {
-  defaults: { name: string; timezone: string; slug: string };
+  defaults: {
+    name: string;
+    timezone: string;
+    slug: string;
+    smsFromNumber: string;
+  };
 }) {
   const [state, formAction, pending] = useActionState<FormState, FormData>(
     updateSettingsAction,
@@ -64,6 +69,21 @@ export function SettingsForm({
             </option>
           ))}
         </Select>
+      </Field>
+      <Field
+        label="SMS sender number"
+        name="smsFromNumber"
+        error={errors.smsFromNumber}
+        hint="E.164 format, e.g. +15555550100. Leave blank to use the platform default."
+      >
+        <Input
+          id="smsFromNumber"
+          name="smsFromNumber"
+          defaultValue={defaults.smsFromNumber}
+          placeholder="+15555550100"
+          inputMode="tel"
+          autoComplete="off"
+        />
       </Field>
       <div className="ss-form-actions">
         <Button type="submit" disabled={pending}>

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ interface SalonSettings {
   slug: string;
   name: string;
   timezone: string;
+  smsFromNumber: string | null;
 }
 
 export default async function SettingsPage() {
@@ -24,6 +25,7 @@ export default async function SettingsPage() {
             name: settings.name,
             timezone: settings.timezone,
             slug: settings.slug,
+            smsFromNumber: settings.smsFromNumber ?? "",
           }}
         />
       </Card>

--- a/packages/db/prisma/migrations/20260429210000_salon_sms_from_number/migration.sql
+++ b/packages/db/prisma/migrations/20260429210000_salon_sms_from_number/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "salons" ADD COLUMN     "smsFromNumber" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "salons_smsFromNumber_key" ON "salons"("smsFromNumber");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -133,6 +133,11 @@ model Salon {
   name        String
   timezone    String   @default("America/New_York")
   clerkOrgId  String?  @unique
+  // E.164 number this salon's SMS goes out from. Unique because Twilio
+  // numbers route inbound messages by `To` — two salons can't share one.
+  // Nullable until an owner provisions a number; sends fall back to the
+  // env-level TWILIO_FROM_NUMBER when unset.
+  smsFromNumber String? @unique
   isActive    Boolean  @default(true)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -329,13 +329,26 @@ export type AppointmentListQueryInput = z.infer<
 // branding land later.)
 // ─────────────────────────────────────────────────────────────────────────────
 
+// E.164 format: leading +, then 1–14 digits. Twilio enforces this on its
+// side too; the shared schema rejects malformed values up front so the
+// UI gets a meaningful error instead of a 4xx from the carrier.
+const e164Schema = z
+  .string()
+  .trim()
+  .regex(/^\+[1-9]\d{1,14}$/, "Must be in E.164 format, e.g. +15555550100");
+
 export const salonSettingsUpdateSchema = z
   .object({
     name: trimmedString(120).optional(),
     timezone: timezoneSchema.optional(),
+    // null = clear the salon's number; undefined = leave it alone.
+    smsFromNumber: z.union([e164Schema, z.null()]).optional(),
   })
   .refine(
-    (s) => s.name !== undefined || s.timezone !== undefined,
+    (s) =>
+      s.name !== undefined ||
+      s.timezone !== undefined ||
+      s.smsFromNumber !== undefined,
     "Provide at least one field to update",
   );
 


### PR DESCRIPTION
## Summary

Removes the single-shared-number caveat from 4a. Each salon can now own its own Twilio number, with a fallback to the platform default while salons are still onboarding.

## Schema

- \`Salon.smsFromNumber\`: nullable unique \`TEXT\` (E.164). Unique because Twilio numbers route inbound by \`To\` — two salons can't share one.
- Migration: \`20260429210000_salon_sms_from_number\`.

## Settings

- Shared zod accepts \`smsFromNumber\` as either an E.164 string or \`null\` (null clears; undefined is no-op so partial PATCHes don't have to send the field). Format check up front so the UI surfaces a meaningful error instead of a 4xx from the carrier.
- \`/settings\` page exposes a single text input with E.164 hint.

## Outbound

- \`loadAppointmentContext\` reads \`Salon.smsFromNumber\` and the shared \`sendOutboundSms\` helper resolves the from-address as \`salon.smsFromNumber ?? env.TWILIO_FROM_NUMBER\`. If neither is set the send is dropped with a logged warning rather than thrown — there's no retry that fixes a missing number, so we shouldn't cycle the row through dead-letter.

## Inbound

- Twilio webhook routes by \`To\` first via a unique lookup on \`Salon.smsFromNumber\`, narrowing the client search to that salon.
- Falls back to the existing cross-salon sender-phone lookup when no salon claims the number — single-tenant dev keeps working unchanged. Multi-tenant production is correct as soon as each salon provisions its own number.

## Tests

43 / 43 passing (was 41, added 2):

- Outbound uses salon's number when set, ignoring env fallback
- Outbound skips entirely when both salon's number and env fallback are missing

Existing tests pass unchanged because the default mocked salon returns \`smsFromNumber=null\`, falling back to the test setup's env value just as before.

## Test plan

- [x] \`pnpm --filter @shearsimp/api typecheck\` / \`test\` (43/43)
- [x] \`pnpm --filter @shearsimp/db typecheck\` / \`test\` / \`prisma:validate\`
- [x] \`pnpm --filter @shearsimp/web typecheck\` / \`shared\` build
- [ ] On \`/settings\`, save \`+15555550100\` → reloads with the value populated. Save \`5555\` → form shows \"Must be in E.164 format\" error. Clear and save → field becomes empty in DB.
- [ ] Book + cancel an appointment with the salon's number set → outbound \`messages\` rows have \`fromAddress\` matching the new number, not the env value.
- [ ] Send a Twilio webhook (curl with the salon's number as \`To\`) → inbound \`messages\` row gets \`salonId\` set to that salon, \`clientId\` resolved within that salon.