### PR TITLE
Phase 5a: payments backend (Stripe Checkout via PaymentProvider)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -205,15 +205,35 @@ PR: [#17](https://github.com/jnoecker/ShearSimplicity/pull/17)
 - [#25](https://github.com/jnoecker/ShearSimplicity/issues/25) — A2P 10DLC brand + campaign registration
 - [#26](https://github.com/jnoecker/ShearSimplicity/issues/26) — Replace SMS terms / privacy placeholder copy
 
-## Phase 5 — Payments / POS (Stripe Checkout) ⬜
+## Phase 5 — Payments / POS (Stripe Checkout) 🚧
 
-PCI exposure stays minimal — Stripe-hosted surfaces only this phase. Will likely slice into 5a / 5b / 5c the way Phase 4 did; sub-shape decided when 5 starts.
+PCI exposure stays minimal — Stripe-hosted surfaces only this phase.
 
-- Stripe adapter behind a `PaymentProvider` interface
-- Create Checkout Session for an appointment; webhook updates `payments.status` (idempotent on Stripe event ID)
-- Tip capture, receipt URL, refund tracking
-- Appointment checkout state separate from appointment status (an appointment can be `COMPLETED` and `payments.status = PENDING`)
-- Webhook signature validation + idempotency on Stripe `event.id`
+### Phase 5a — Backend payment infrastructure 🚧
+
+- `PaymentProvider` interface, switchable on `PAYMENT_PROVIDER` env
+  (`dev` returns a synthetic checkout URL + sid; `stripe` uses the official SDK)
+- `POST /payments/checkout` creates a Stripe Checkout Session for an appointment
+- Pre-generates the Payment row id and uses it as Stripe's idempotency key,
+  so retries hit Stripe's idempotency cache instead of creating duplicate sessions
+- Rejects with 409 when a SUCCEEDED payment already exists for the appointment
+- Stripe webhook `POST /webhooks/stripe` with HMAC signature verification,
+  deduped on `processed_webhook_events.(source, event.id)`
+- Handles `checkout.session.completed` → SUCCEEDED + `payment.succeeded` event,
+  `payment_intent.payment_failed` → FAILED with reason
+- Refunds + disputes intentionally deferred to 5c
+
+### Phase 5b — Pay-for-appointment UI ⬜
+
+- "Pay now" / "Send payment link" on appointment detail
+- Client-facing receipt + status display
+- Payment column on the schedule view
+
+### Phase 5c — Tips + refunds ⬜
+
+- Tip capture flow at checkout
+- Refund initiation + UI
+- `charge.refunded` / `charge.dispute.*` webhook handlers
 
 **Single platform Stripe account for now.** Migration to Stripe Connect (per-salon merchant accounts, platform fee on each charge) tracked as [#18](https://github.com/jnoecker/ShearSimplicity/issues/18) — not on the critical path until a salon needs their own merchant account.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "cookie-parser": "^1.4.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "stripe": "^17.5.0",
     "svix": "1",
     "twilio": "^5.4.0",
     "zod": "^3.23.8"

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { OutboxModule } from "./outbox/outbox.module";
 import { SettingsModule } from "./settings/settings.module";
 import { WebhooksModule } from "./webhooks/webhooks.module";
 import { MessagingModule } from "./messaging/messaging.module";
+import { PaymentsModule } from "./payments/payments.module";
 
 // AuthGuard runs first; TenantGuard depends on the identity it attaches to
 // the request. Order matters: Nest evaluates global guards in registration
@@ -30,6 +31,7 @@ import { MessagingModule } from "./messaging/messaging.module";
     ClientsModule,
     AppointmentsModule,
     MessagingModule,
+    PaymentsModule,
     OutboxModule,
     SettingsModule,
     WebhooksModule,

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -40,6 +40,11 @@ const schema = z
     // for signature verification when behind a proxy that rewrites the host).
     // Optional: when unset we trust the request's own host header.
     TWILIO_WEBHOOK_PUBLIC_URL: z.string().url().optional(),
+
+    // Phase 5a — payments.
+    PAYMENT_PROVIDER: z.enum(["dev", "stripe"]).default("dev"),
+    STRIPE_SECRET_KEY: z.string().optional(),
+    STRIPE_WEBHOOK_SECRET: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     if (env.AUTH_PROVIDER === "clerk") {
@@ -69,6 +74,21 @@ const schema = z
             code: z.ZodIssueCode.custom,
             path: [key],
             message: `${key} is required when MESSAGING_PROVIDER=twilio`,
+          });
+        }
+      }
+    }
+
+    if (env.PAYMENT_PROVIDER === "stripe") {
+      for (const key of [
+        "STRIPE_SECRET_KEY",
+        "STRIPE_WEBHOOK_SECRET",
+      ] as const) {
+        if (!env[key]) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key],
+            message: `${key} is required when PAYMENT_PROVIDER=stripe`,
           });
         }
       }

--- a/apps/api/src/payments/dev-payment.provider.ts
+++ b/apps/api/src/payments/dev-payment.provider.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
+import { env } from "../env";
+import type {
+  CreateCheckoutSessionArgs,
+  CreateCheckoutSessionResult,
+  ParsedWebhookEvent,
+  PaymentProvider,
+} from "./payment-provider.interface";
+
+/**
+ * Local-development payment provider. Logs every checkout attempt and
+ * returns a synthetic session sid prefixed `dev_cs_` so it never collides
+ * with a real Stripe session id (`cs_test_...`).
+ *
+ * The "checkout URL" we hand back is a self-routed URL that the dev web
+ * app can intercept to simulate a successful payment without leaving the
+ * loopback — flows back through the same webhook path we'd use in
+ * production.
+ *
+ * Webhook signature verification is a no-op — local testing simulates
+ * Stripe webhooks via curl, which can't sign with the production secret.
+ * Refuses to run when NODE_ENV=production so this can't accidentally ship.
+ */
+@Injectable()
+export class DevPaymentProvider implements PaymentProvider {
+  private readonly logger = new Logger(DevPaymentProvider.name);
+
+  async createCheckoutSession(
+    args: CreateCheckoutSessionArgs,
+  ): Promise<CreateCheckoutSessionResult> {
+    if (env.NODE_ENV === "production") {
+      throw new Error("DevPaymentProvider must not run in production");
+    }
+    const sid = `dev_cs_${randomUUID()}`;
+    this.logger.log(
+      `[dev-checkout] sid=${sid} amount=${args.amountCents} ${args.currency} product=${JSON.stringify(args.productName)} success=${args.successUrl}`,
+    );
+    // The dev URL points at a stub on the web side that simulates the
+    // user clicking through — Phase 5b wires up the actual route.
+    const url = `${env.WEB_ORIGIN}/dev/checkout?sid=${sid}&amount=${args.amountCents}`;
+    return { providerSessionId: sid, url };
+  }
+
+  verifyAndParseWebhook(rawBody: Buffer, _signature: string): ParsedWebhookEvent {
+    if (env.NODE_ENV === "production") {
+      throw new Error("DevPaymentProvider must not run in production");
+    }
+    // The dev webhook accepts whatever JSON you send and trusts the body.
+    // Useful for curl-driven local testing of the handler logic.
+    const parsed = JSON.parse(rawBody.toString("utf8")) as {
+      id?: string;
+      type?: string;
+      data?: unknown;
+    };
+    if (!parsed.id || !parsed.type) {
+      throw new Error("Dev webhook body must include `id` and `type`");
+    }
+    return { id: parsed.id, type: parsed.type, data: parsed.data ?? {} };
+  }
+}

--- a/apps/api/src/payments/payment-provider.interface.ts
+++ b/apps/api/src/payments/payment-provider.interface.ts
@@ -1,0 +1,50 @@
+export const PAYMENT_PROVIDER = Symbol("PaymentProvider");
+
+export interface CreateCheckoutSessionArgs {
+  /** Our internal Payment.id; passed to the provider as their idempotency key. */
+  idempotencyKey: string;
+  amountCents: number;
+  currency: string;
+  /** Where Stripe redirects on success / cancel. The provider may append
+   *  query params (e.g. session_id) — both URLs end up in the user's browser. */
+  successUrl: string;
+  cancelUrl: string;
+  /** Free-form description shown on the Stripe-hosted checkout page. */
+  productName: string;
+  /** Optional client email — pre-fills the receipt-to address. */
+  customerEmail?: string;
+  /** Stored on the session so the webhook handler can correlate back to our row. */
+  metadata: Record<string, string>;
+}
+
+export interface CreateCheckoutSessionResult {
+  providerSessionId: string;
+  url: string;
+}
+
+export interface ParsedWebhookEvent {
+  /** Provider's stable event id — used for `processed_webhook_events` dedup. */
+  id: string;
+  type: string;
+  /** The raw event payload — handlers narrow by `type`. */
+  data: unknown;
+}
+
+/**
+ * Pluggable payment provider. Implementations:
+ *  - DevPaymentProvider: returns a synthetic URL + sid prefixed `dev_`,
+ *    never reaches the network. Webhook verification is a no-op so a curl
+ *    can simulate Stripe events locally.
+ *  - StripePaymentProvider: official Stripe SDK for create-session and
+ *    `Webhook.constructEvent` for HMAC-SHA256 signature verification on
+ *    inbound events.
+ *
+ * `verifyAndParseWebhook` throws on a bad signature so the controller can
+ * return 400 without leaking which check failed.
+ */
+export interface PaymentProvider {
+  createCheckoutSession(
+    args: CreateCheckoutSessionArgs,
+  ): Promise<CreateCheckoutSessionResult>;
+  verifyAndParseWebhook(rawBody: Buffer, signature: string): ParsedWebhookEvent;
+}

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { checkoutCreateSchema } from "@shearsimp/shared";
+import type { CheckoutCreateInput } from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { PaymentsService } from "./payments.service";
+
+@Controller("payments")
+export class PaymentsController {
+  constructor(private readonly payments: PaymentsService) {}
+
+  // POST /payments/checkout: returns a Stripe Checkout Session URL the
+  // caller redirects the user to. The webhook (5a) finalises status when
+  // Stripe calls us back; the UI just needs to follow the URL.
+  @Post("checkout")
+  async createCheckout(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(checkoutCreateSchema))
+    input: CheckoutCreateInput,
+  ): Promise<{ url: string; paymentId: string }> {
+    return this.payments.createCheckoutForAppointment(
+      salon.salonId,
+      user.userId,
+      input,
+    );
+  }
+}

--- a/apps/api/src/payments/payments.module.ts
+++ b/apps/api/src/payments/payments.module.ts
@@ -1,0 +1,34 @@
+import { Global, Module, type Provider } from "@nestjs/common";
+import { PrismaModule } from "../prisma/prisma.module";
+import { env } from "../env";
+import { PAYMENT_PROVIDER } from "./payment-provider.interface";
+import { DevPaymentProvider } from "./dev-payment.provider";
+import { StripePaymentProvider } from "./stripe-payment.provider";
+import { PaymentsService } from "./payments.service";
+import { PaymentsController } from "./payments.controller";
+
+// Only the selected provider is constructed. Listing both classes in
+// `providers` would have Nest eagerly instantiate them on bootstrap, and
+// StripePaymentProvider's constructor throws when its env vars are absent
+// — which would crash startup in any dev/test env that left the Stripe
+// creds unset. (Same pattern as MessagingModule.)
+const paymentProviderFactory: Provider = {
+  provide: PAYMENT_PROVIDER,
+  useFactory: () => {
+    switch (env.PAYMENT_PROVIDER) {
+      case "dev":
+        return new DevPaymentProvider();
+      case "stripe":
+        return new StripePaymentProvider();
+    }
+  },
+};
+
+@Global()
+@Module({
+  imports: [PrismaModule],
+  controllers: [PaymentsController],
+  providers: [paymentProviderFactory, PaymentsService],
+  exports: [PAYMENT_PROVIDER, PaymentsService],
+})
+export class PaymentsModule {}

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -1,0 +1,174 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import {
+  ActorType,
+  PaymentProvider as PaymentProviderEnum,
+  PaymentStatus,
+  Prisma,
+} from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import { randomUUID } from "node:crypto";
+import { env } from "../env";
+import { PrismaService } from "../prisma/prisma.service";
+import {
+  PAYMENT_PROVIDER,
+  type PaymentProvider as PaymentProviderImpl,
+} from "./payment-provider.interface";
+
+export interface CreateCheckoutInput {
+  appointmentId: string;
+  /** Optional override of the post-payment redirect; falls back to a route on
+   *  WEB_ORIGIN that the frontend handles. Stripe requires both URLs. */
+  successUrl?: string;
+  cancelUrl?: string;
+}
+
+const APPOINTMENT_INCLUDE = {
+  client: { select: { id: true, displayName: true, email: true } },
+  staffMember: { select: { displayName: true } },
+  services: {
+    orderBy: [{ sortOrder: "asc" as const }],
+    select: {
+      serviceNameSnapshot: true,
+      priceSnapshotCents: true,
+      currencySnapshot: true,
+    },
+  },
+  salon: { select: { name: true } },
+} satisfies Prisma.AppointmentInclude;
+
+@Injectable()
+export class PaymentsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(PAYMENT_PROVIDER)
+    private readonly provider: PaymentProviderImpl,
+  ) {}
+
+  async createCheckoutForAppointment(
+    salonId: string,
+    actorUserId: string,
+    input: CreateCheckoutInput,
+  ): Promise<{ url: string; paymentId: string }> {
+    const appointment = await this.prisma.appointment.findFirst({
+      where: { id: input.appointmentId, salonId },
+      include: APPOINTMENT_INCLUDE,
+    });
+    if (!appointment) throw new NotFoundException("Appointment not found");
+    if (appointment.services.length === 0) {
+      throw new BadRequestException(
+        "Appointment has no services to charge for",
+      );
+    }
+
+    // A SUCCEEDED payment already exists → caller is double-charging by
+    // mistake. PENDING and FAILED rows are fine to re-attempt around (a
+    // PENDING row may have come from an abandoned checkout window).
+    const alreadyPaid = await this.prisma.payment.findFirst({
+      where: {
+        salonId,
+        appointmentId: appointment.id,
+        status: PaymentStatus.SUCCEEDED,
+      },
+      select: { id: true },
+    });
+    if (alreadyPaid) {
+      throw new ConflictException({
+        message: "This appointment is already paid",
+        appointmentId: appointment.id,
+        paymentId: alreadyPaid.id,
+      });
+    }
+
+    const amountCents = appointment.services.reduce(
+      (acc, s) => acc + s.priceSnapshotCents,
+      0,
+    );
+    const currency = appointment.services[0]?.currencySnapshot ?? "USD";
+    const productName = formatProductName(
+      appointment.services.map((s) => s.serviceNameSnapshot),
+      appointment.salon.name,
+    );
+
+    // Pre-generate the row id so we can pass it to the provider as the
+    // idempotency key *before* we INSERT. A retry of the create-session
+    // call (e.g. transient Stripe 5xx) hits Stripe's idempotency cache
+    // and returns the original session — no duplicate sessions for one
+    // booking attempt.
+    const paymentId = randomUUID();
+    const successUrl =
+      input.successUrl ??
+      `${env.WEB_ORIGIN}/schedule?paid=${appointment.id}&session_id={CHECKOUT_SESSION_ID}`;
+    const cancelUrl =
+      input.cancelUrl ??
+      `${env.WEB_ORIGIN}/schedule?paymentCancelled=${appointment.id}`;
+
+    const session = await this.provider.createCheckoutSession({
+      idempotencyKey: paymentId,
+      amountCents,
+      currency,
+      successUrl,
+      cancelUrl,
+      productName,
+      customerEmail: appointment.client?.email ?? undefined,
+      metadata: {
+        salonId,
+        appointmentId: appointment.id,
+        paymentId,
+      },
+    });
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.payment.create({
+        data: {
+          id: paymentId,
+          salonId,
+          appointmentId: appointment.id,
+          clientId: appointment.clientId,
+          status: PaymentStatus.PENDING,
+          provider: PaymentProviderEnum.STRIPE,
+          providerPaymentId: session.providerSessionId,
+          amountCents,
+          currency,
+          idempotencyKey: paymentId,
+        },
+      });
+      await tx.domainEvent.create({
+        data: {
+          salonId,
+          aggregateType: "PAYMENT",
+          aggregateId: paymentId,
+          eventType: EventType.PAYMENT_CREATED,
+          payload: {
+            appointmentId: appointment.id,
+            amountCents,
+            currency,
+            providerSessionId: session.providerSessionId,
+          } satisfies Prisma.InputJsonValue,
+          actorType: actorUserId ? ActorType.USER : ActorType.SYSTEM,
+          actorId: actorUserId ?? null,
+        },
+      });
+      return { url: session.url, paymentId };
+    });
+  }
+}
+
+function formatProductName(
+  services: string[],
+  salonName: string,
+): string {
+  // Stripe's product_data.name has a 250-char limit. Truncate the
+  // service list rather than the salon name — the brand stays visible
+  // even on long-package bookings.
+  const joined = services.join(", ");
+  const tail = ` — ${salonName}`;
+  const max = 250 - tail.length;
+  const head = joined.length > max ? joined.slice(0, max - 1) + "…" : joined;
+  return head + tail;
+}

--- a/apps/api/src/payments/stripe-payment.provider.ts
+++ b/apps/api/src/payments/stripe-payment.provider.ts
@@ -54,6 +54,13 @@ export class StripePaymentProvider implements PaymentProvider {
         cancel_url: args.cancelUrl,
         customer_email: args.customerEmail,
         metadata: args.metadata,
+        // Stripe doesn't auto-copy Checkout Session metadata onto the
+        // underlying PaymentIntent. Without this, an early
+        // payment_intent.payment_failed (one that arrives before the
+        // session.completed event) has no metadata for our handler to
+        // correlate back to the Payment row, so it'd silently log + skip
+        // and the row would stay PENDING forever.
+        payment_intent_data: { metadata: args.metadata },
       },
       // Stripe's HTTP-level idempotency: a retry with the same key is a no-op
       // and returns the original session. Pairing this with our DB-level

--- a/apps/api/src/payments/stripe-payment.provider.ts
+++ b/apps/api/src/payments/stripe-payment.provider.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from "@nestjs/common";
+import Stripe from "stripe";
+import { env } from "../env";
+import type {
+  CreateCheckoutSessionArgs,
+  CreateCheckoutSessionResult,
+  ParsedWebhookEvent,
+  PaymentProvider,
+} from "./payment-provider.interface";
+
+/**
+ * Stripe-backed payment provider. Outbound is the official Node SDK;
+ * inbound webhook signature verification is HMAC-SHA256 over the raw body
+ * + the timestamp Stripe puts in the signature header.
+ *
+ * Constructor reads creds from env at boot. Key rotation needs an API
+ * restart — fine for now.
+ */
+@Injectable()
+export class StripePaymentProvider implements PaymentProvider {
+  private readonly logger = new Logger(StripePaymentProvider.name);
+  private readonly client: Stripe;
+  private readonly webhookSecret: string;
+
+  constructor() {
+    if (!env.STRIPE_SECRET_KEY || !env.STRIPE_WEBHOOK_SECRET) {
+      // The env validator already enforces this when PAYMENT_PROVIDER=stripe,
+      // but we double-check so a misconfigured factory call surfaces clearly.
+      throw new Error(
+        "StripePaymentProvider requires STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET",
+      );
+    }
+    this.client = new Stripe(env.STRIPE_SECRET_KEY);
+    this.webhookSecret = env.STRIPE_WEBHOOK_SECRET;
+  }
+
+  async createCheckoutSession(
+    args: CreateCheckoutSessionArgs,
+  ): Promise<CreateCheckoutSessionResult> {
+    const session = await this.client.checkout.sessions.create(
+      {
+        mode: "payment",
+        line_items: [
+          {
+            quantity: 1,
+            price_data: {
+              currency: args.currency.toLowerCase(),
+              unit_amount: args.amountCents,
+              product_data: { name: args.productName },
+            },
+          },
+        ],
+        success_url: args.successUrl,
+        cancel_url: args.cancelUrl,
+        customer_email: args.customerEmail,
+        metadata: args.metadata,
+      },
+      // Stripe's HTTP-level idempotency: a retry with the same key is a no-op
+      // and returns the original session. Pairing this with our DB-level
+      // Payment.id (which we use as the key) means a worker crash between
+      // INSERT and provider call is safe to retry.
+      { idempotencyKey: args.idempotencyKey },
+    );
+
+    if (!session.url) {
+      throw new Error(
+        `Stripe session ${session.id} returned no url — refusing to continue`,
+      );
+    }
+    this.logger.log(
+      `Created Stripe Checkout Session sid=${session.id} amount=${args.amountCents} ${args.currency}`,
+    );
+    return { providerSessionId: session.id, url: session.url };
+  }
+
+  verifyAndParseWebhook(rawBody: Buffer, signature: string): ParsedWebhookEvent {
+    // constructEvent throws on bad signature / replay (tolerance default 5 min).
+    // We let it bubble so the controller maps it to a 400.
+    const event = this.client.webhooks.constructEvent(
+      rawBody,
+      signature,
+      this.webhookSecret,
+    );
+    return { id: event.id, type: event.type, data: event.data };
+  }
+}

--- a/apps/api/src/webhooks/stripe-webhook.controller.ts
+++ b/apps/api/src/webhooks/stripe-webhook.controller.ts
@@ -1,0 +1,63 @@
+import {
+  BadRequestException,
+  Controller,
+  HttpCode,
+  Inject,
+  Logger,
+  Post,
+  Req,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { Public } from "../auth/public.decorator";
+import { SkipTenant } from "../tenant/skip-tenant.decorator";
+import {
+  PAYMENT_PROVIDER,
+  type PaymentProvider,
+} from "../payments/payment-provider.interface";
+import { StripeWebhookService } from "./stripe-webhook.service";
+
+/**
+ * Stripe → ShearSimplicity payment lifecycle. Configure in the Stripe
+ * dashboard: Developers → Webhooks → add endpoint, point at
+ * `<api>/webhooks/stripe`, copy the signing secret to STRIPE_WEBHOOK_SECRET,
+ * subscribe to: checkout.session.completed, payment_intent.payment_failed.
+ *
+ * Public + SkipTenant: trust is established by the signature, not a session.
+ */
+@Controller("webhooks/stripe")
+export class StripeWebhookController {
+  private readonly logger = new Logger(StripeWebhookController.name);
+
+  constructor(
+    @Inject(PAYMENT_PROVIDER)
+    private readonly provider: PaymentProvider,
+    private readonly service: StripeWebhookService,
+  ) {}
+
+  @Public()
+  @SkipTenant()
+  @Post()
+  @HttpCode(200)
+  async handle(@Req() req: Request): Promise<{ received: true }> {
+    const signature = req.header("stripe-signature");
+    if (!signature) {
+      throw new BadRequestException("Missing Stripe-Signature header");
+    }
+    const raw = (req as Request & { rawBody?: Buffer }).rawBody;
+    if (!raw) {
+      throw new BadRequestException("Raw body unavailable for signature check");
+    }
+
+    let event;
+    try {
+      event = this.provider.verifyAndParseWebhook(raw, signature);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Stripe webhook signature rejected: ${message}`);
+      throw new BadRequestException("Invalid Stripe signature");
+    }
+
+    await this.service.process(event);
+    return { received: true };
+  }
+}

--- a/apps/api/src/webhooks/stripe-webhook.service.ts
+++ b/apps/api/src/webhooks/stripe-webhook.service.ts
@@ -1,0 +1,211 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ActorType, PaymentStatus, Prisma } from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import type { ParsedWebhookEvent } from "../payments/payment-provider.interface";
+
+const SOURCE = "stripe";
+
+// Subset of Stripe payload shapes we read. Stripe's full types live behind
+// the `Stripe` namespace (heavy import); typing the bits we care about
+// keeps this file readable and avoids leaking Stripe types past the
+// provider boundary.
+interface CheckoutSessionPayload {
+  id: string;
+  payment_intent?: string | null;
+  payment_status?: string | null;
+  amount_total?: number | null;
+  currency?: string | null;
+  customer_details?: { email?: string | null } | null;
+  metadata?: Record<string, string | undefined> | null;
+}
+
+interface PaymentIntentPayload {
+  id: string;
+  last_payment_error?: { message?: string | null } | null;
+  metadata?: Record<string, string | undefined> | null;
+}
+
+/**
+ * Applies a verified Stripe event to our Payment rows. Wraps each handler
+ * in a transaction that:
+ *   1. Inserts a `processed_webhook_events` row keyed on (source, eventId).
+ *   2. Performs the side effect.
+ *
+ * The (source, externalEventId) unique constraint makes Stripe re-deliveries
+ * a no-op — a P2002 from the insert means we've seen this event before.
+ *
+ * Refunds + disputes intentionally skipped — those land in 5c.
+ */
+@Injectable()
+export class StripeWebhookService {
+  private readonly logger = new Logger(StripeWebhookService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async process(event: ParsedWebhookEvent): Promise<void> {
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.processedWebhookEvent.create({
+          data: {
+            source: SOURCE,
+            externalEventId: event.id,
+            eventType: event.type,
+          },
+        });
+        await this.apply(tx, event);
+      });
+    } catch (err) {
+      if (isProcessedWebhookEventDuplicate(err)) {
+        this.logger.log(`Stripe event ${event.id} already processed; skipping`);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async apply(
+    tx: Prisma.TransactionClient,
+    event: ParsedWebhookEvent,
+  ): Promise<void> {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        // payload.object is the standard Stripe shape; we tolerate the
+        // raw event body too in case a caller bypasses the wrapping.
+        const session = unwrap<CheckoutSessionPayload>(event.data);
+        if (!session?.id) {
+          this.logger.warn(
+            `Stripe checkout.session.completed event ${event.id} missing session id — skipping`,
+          );
+          return;
+        }
+        const payment = await tx.payment.findFirst({
+          where: { provider: "STRIPE", providerPaymentId: session.id },
+          select: { id: true, salonId: true, status: true },
+        });
+        if (!payment) {
+          this.logger.warn(
+            `Stripe checkout.session ${session.id} has no matching Payment row — skipping`,
+          );
+          return;
+        }
+        if (payment.status === PaymentStatus.SUCCEEDED) {
+          // Late-arriving duplicate of a status we already finalised.
+          // Don't re-emit the domain event.
+          return;
+        }
+        const succeeded = session.payment_status === "paid";
+        await tx.payment.update({
+          where: { id: payment.id },
+          data: {
+            status: succeeded ? PaymentStatus.SUCCEEDED : PaymentStatus.PENDING,
+            // Once we have the underlying payment_intent we replace the
+            // session id with it so future refund webhooks correlate.
+            providerPaymentId:
+              typeof session.payment_intent === "string"
+                ? session.payment_intent
+                : session.id,
+            capturedAt: succeeded ? new Date() : null,
+          },
+        });
+        if (succeeded) {
+          await tx.domainEvent.create({
+            data: {
+              salonId: payment.salonId,
+              aggregateType: "PAYMENT",
+              aggregateId: payment.id,
+              eventType: EventType.PAYMENT_SUCCEEDED,
+              payload: {
+                providerSessionId: session.id,
+                providerPaymentIntentId:
+                  typeof session.payment_intent === "string"
+                    ? session.payment_intent
+                    : null,
+                amountTotal: session.amount_total ?? null,
+                currency: session.currency ?? null,
+              } satisfies Prisma.InputJsonValue,
+              actorType: ActorType.WEBHOOK,
+            },
+          });
+        }
+        return;
+      }
+
+      case "payment_intent.payment_failed": {
+        const intent = unwrap<PaymentIntentPayload>(event.data);
+        if (!intent?.id) {
+          this.logger.warn(
+            `Stripe payment_intent.payment_failed event ${event.id} missing intent id — skipping`,
+          );
+          return;
+        }
+        // Match on payment_intent id (set by the checkout.session.completed
+        // handler) OR fall back to metadata.paymentId in case the intent
+        // failed before we ever saw a session.completed.
+        const payment = await tx.payment.findFirst({
+          where: {
+            OR: [
+              { provider: "STRIPE", providerPaymentId: intent.id },
+              ...(intent.metadata?.paymentId
+                ? [{ id: intent.metadata.paymentId }]
+                : []),
+            ],
+          },
+          select: { id: true, salonId: true, status: true },
+        });
+        if (!payment) {
+          this.logger.warn(
+            `Stripe payment_intent ${intent.id} has no matching Payment row — skipping`,
+          );
+          return;
+        }
+        if (payment.status === PaymentStatus.SUCCEEDED) {
+          // Stripe occasionally delivers a stale failed event after a
+          // successful retry. Don't downgrade a SUCCEEDED row.
+          return;
+        }
+        await tx.payment.update({
+          where: { id: payment.id },
+          data: {
+            status: PaymentStatus.FAILED,
+            failureReason:
+              intent.last_payment_error?.message?.slice(0, 500) ?? null,
+          },
+        });
+        return;
+      }
+
+      default:
+        this.logger.log(
+          `Stripe event ${event.id} (${event.type}) not handled — ignoring`,
+        );
+        return;
+    }
+  }
+}
+
+// Stripe wraps the resource we care about under `event.data.object`.
+// Some (dev / synthetic) callers send the resource directly under
+// `event.data` — accept both so the dev provider can drive this
+// without faking the Stripe wrapper.
+function unwrap<T>(data: unknown): T | null {
+  if (data == null || typeof data !== "object") return null;
+  const d = data as { object?: T } & T;
+  if (d.object && typeof d.object === "object") return d.object;
+  return d as T;
+}
+
+function isProcessedWebhookEventDuplicate(err: unknown): boolean {
+  if (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === "P2002"
+  ) {
+    const meta = err.meta as { target?: string | string[] } | undefined;
+    if (!meta?.target) return false;
+    const t = meta.target;
+    return Array.isArray(t)
+      ? t.some((c) => c.includes("source") || c.includes("externalEventId"))
+      : t.includes("source") || t.includes("externalEventId");
+  }
+  return false;
+}

--- a/apps/api/src/webhooks/stripe-webhook.service.ts
+++ b/apps/api/src/webhooks/stripe-webhook.service.ts
@@ -81,7 +81,12 @@ export class StripeWebhookService {
         }
         const payment = await tx.payment.findFirst({
           where: { provider: "STRIPE", providerPaymentId: session.id },
-          select: { id: true, salonId: true, status: true },
+          select: {
+            id: true,
+            salonId: true,
+            status: true,
+            appointmentId: true,
+          },
         });
         if (!payment) {
           this.logger.warn(
@@ -94,17 +99,57 @@ export class StripeWebhookService {
           // Don't re-emit the domain event.
           return;
         }
+
         const succeeded = session.payment_status === "paid";
+        const intentId =
+          typeof session.payment_intent === "string"
+            ? session.payment_intent
+            : null;
+
+        // Defence-in-depth against double-charge. createCheckoutForAppointment
+        // permits multiple PENDING sessions on one appointment so an
+        // abandoned link can be re-attempted without manual cleanup. If a
+        // newer session was completed first, an older one finishing later
+        // would otherwise mark the appointment paid twice — Stripe has
+        // already captured the second charge by the time we see this event,
+        // so the right move is: don't claim SUCCEEDED on this row, mark it
+        // FAILED with a manual-refund flag, and log loudly so ops can
+        // process the refund (auto-refund lands in 5c).
+        if (succeeded && payment.appointmentId) {
+          const otherSucceeded = await tx.payment.findFirst({
+            where: {
+              salonId: payment.salonId,
+              appointmentId: payment.appointmentId,
+              status: PaymentStatus.SUCCEEDED,
+              NOT: { id: payment.id },
+            },
+            select: { id: true },
+          });
+          if (otherSucceeded) {
+            this.logger.error(
+              `Stripe checkout.session ${session.id} succeeded on Payment ${payment.id}, ` +
+                `but Payment ${otherSucceeded.id} already SUCCEEDED for appointment ` +
+                `${payment.appointmentId}. Charge captured by Stripe — manual refund required.`,
+            );
+            await tx.payment.update({
+              where: { id: payment.id },
+              data: {
+                status: PaymentStatus.FAILED,
+                providerPaymentId: intentId ?? session.id,
+                failureReason: `Duplicate charge — appointment ${payment.appointmentId} already paid by Payment ${otherSucceeded.id}. Manual refund required (auto-refund handler arrives in 5c).`,
+              },
+            });
+            return;
+          }
+        }
+
         await tx.payment.update({
           where: { id: payment.id },
           data: {
             status: succeeded ? PaymentStatus.SUCCEEDED : PaymentStatus.PENDING,
             // Once we have the underlying payment_intent we replace the
             // session id with it so future refund webhooks correlate.
-            providerPaymentId:
-              typeof session.payment_intent === "string"
-                ? session.payment_intent
-                : session.id,
+            providerPaymentId: intentId ?? session.id,
             capturedAt: succeeded ? new Date() : null,
           },
         });
@@ -117,10 +162,7 @@ export class StripeWebhookService {
               eventType: EventType.PAYMENT_SUCCEEDED,
               payload: {
                 providerSessionId: session.id,
-                providerPaymentIntentId:
-                  typeof session.payment_intent === "string"
-                    ? session.payment_intent
-                    : null,
+                providerPaymentIntentId: intentId,
                 amountTotal: session.amount_total ?? null,
                 currency: session.currency ?? null,
               } satisfies Prisma.InputJsonValue,

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -2,9 +2,15 @@ import { Module } from "@nestjs/common";
 import { ClerkWebhookController } from "./clerk-webhook.controller";
 import { ClerkWebhookService } from "./clerk-webhook.service";
 import { TwilioWebhookController } from "./twilio-webhook.controller";
+import { StripeWebhookController } from "./stripe-webhook.controller";
+import { StripeWebhookService } from "./stripe-webhook.service";
 
 @Module({
-  controllers: [ClerkWebhookController, TwilioWebhookController],
-  providers: [ClerkWebhookService],
+  controllers: [
+    ClerkWebhookController,
+    TwilioWebhookController,
+    StripeWebhookController,
+  ],
+  providers: [ClerkWebhookService, StripeWebhookService],
 })
 export class WebhooksModule {}

--- a/apps/api/test/payments-service.test.ts
+++ b/apps/api/test/payments-service.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from "vitest";
+import { PaymentStatus } from "@prisma/client";
+import { PaymentsService } from "../src/payments/payments.service";
+import type { PaymentProvider } from "../src/payments/payment-provider.interface";
+
+const SALON_ID = "00000000-0000-0000-0000-000000000a01";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000b01";
+const ACTOR_ID = "00000000-0000-0000-0000-000000000d01";
+
+function fakeAppointment(overrides: Partial<{
+  services: { serviceNameSnapshot: string; priceSnapshotCents: number; currencySnapshot: string }[];
+}> = {}) {
+  return {
+    id: APPOINTMENT_ID,
+    salonId: SALON_ID,
+    clientId: "00000000-0000-0000-0000-000000000c01",
+    services: overrides.services ?? [
+      {
+        serviceNameSnapshot: "Single-process color",
+        priceSnapshotCents: 11000,
+        currencySnapshot: "USD",
+      },
+    ],
+    salon: { name: "Bella's Salon" },
+    client: {
+      id: "00000000-0000-0000-0000-000000000c01",
+      displayName: "Mira Castellanos",
+      email: "mira@example.com",
+    },
+    staffMember: { displayName: "Trina Bellweather" },
+  };
+}
+
+function buildService({
+  appointment = fakeAppointment(),
+  alreadyPaidPayment = null,
+}: {
+  appointment?: ReturnType<typeof fakeAppointment> | null;
+  alreadyPaidPayment?: { id: string } | null;
+} = {}) {
+  const createCheckoutSession = vi.fn().mockResolvedValue({
+    providerSessionId: "cs_test_dev_123",
+    url: "https://stripe.test/cs_test_dev_123",
+  });
+  const provider: PaymentProvider = {
+    createCheckoutSession,
+    verifyAndParseWebhook: vi.fn(),
+  };
+
+  const paymentCreate = vi.fn().mockResolvedValue({});
+  const domainEventCreate = vi.fn().mockResolvedValue({});
+
+  const prisma = {
+    appointment: {
+      findFirst: vi.fn().mockResolvedValue(appointment),
+    },
+    payment: {
+      findFirst: vi.fn().mockResolvedValue(alreadyPaidPayment),
+      create: paymentCreate,
+    },
+    domainEvent: {
+      create: domainEventCreate,
+    },
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn(prismaInstance),
+    ),
+  };
+  const prismaInstance = prisma;
+
+  const service = new PaymentsService(prisma as never, provider);
+  return { service, provider, createCheckoutSession, paymentCreate, domainEventCreate };
+}
+
+describe("PaymentsService.createCheckoutForAppointment", () => {
+  it("creates a session and persists a PENDING Payment row keyed by the same idempotency key", async () => {
+    const { service, createCheckoutSession, paymentCreate, domainEventCreate } =
+      buildService();
+
+    const result = await service.createCheckoutForAppointment(SALON_ID, ACTOR_ID, {
+      appointmentId: APPOINTMENT_ID,
+    });
+
+    expect(result.url).toBe("https://stripe.test/cs_test_dev_123");
+    expect(result.paymentId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+
+    expect(createCheckoutSession).toHaveBeenCalledTimes(1);
+    const sessionCall = createCheckoutSession.mock.calls[0]![0];
+    expect(sessionCall.amountCents).toBe(11000);
+    expect(sessionCall.currency).toBe("USD");
+    expect(sessionCall.idempotencyKey).toBe(result.paymentId);
+    expect(sessionCall.metadata).toMatchObject({
+      salonId: SALON_ID,
+      appointmentId: APPOINTMENT_ID,
+      paymentId: result.paymentId,
+    });
+
+    expect(paymentCreate).toHaveBeenCalledTimes(1);
+    expect(paymentCreate.mock.calls[0]![0].data).toMatchObject({
+      id: result.paymentId,
+      salonId: SALON_ID,
+      appointmentId: APPOINTMENT_ID,
+      status: PaymentStatus.PENDING,
+      providerPaymentId: "cs_test_dev_123",
+      amountCents: 11000,
+      idempotencyKey: result.paymentId,
+    });
+
+    expect(domainEventCreate).toHaveBeenCalledTimes(1);
+    expect(domainEventCreate.mock.calls[0]![0].data.eventType).toBe(
+      "payment.created",
+    );
+  });
+
+  it("sums prices across multiple services", async () => {
+    const { service, createCheckoutSession } = buildService({
+      appointment: fakeAppointment({
+        services: [
+          {
+            serviceNameSnapshot: "Color",
+            priceSnapshotCents: 11000,
+            currencySnapshot: "USD",
+          },
+          {
+            serviceNameSnapshot: "Cut",
+            priceSnapshotCents: 4500,
+            currencySnapshot: "USD",
+          },
+        ],
+      }),
+    });
+
+    await service.createCheckoutForAppointment(SALON_ID, ACTOR_ID, {
+      appointmentId: APPOINTMENT_ID,
+    });
+
+    expect(createCheckoutSession.mock.calls[0]![0].amountCents).toBe(15500);
+    expect(createCheckoutSession.mock.calls[0]![0].productName).toContain(
+      "Color, Cut",
+    );
+    expect(createCheckoutSession.mock.calls[0]![0].productName).toContain(
+      "Bella's Salon",
+    );
+  });
+
+  it("rejects when a SUCCEEDED payment already exists for the appointment", async () => {
+    const { service, createCheckoutSession, paymentCreate } = buildService({
+      alreadyPaidPayment: { id: "existing-payment-id" },
+    });
+
+    await expect(
+      service.createCheckoutForAppointment(SALON_ID, ACTOR_ID, {
+        appointmentId: APPOINTMENT_ID,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+
+    expect(createCheckoutSession).not.toHaveBeenCalled();
+    expect(paymentCreate).not.toHaveBeenCalled();
+  });
+
+  it("404s when the appointment is not in this salon", async () => {
+    const { service, createCheckoutSession } = buildService({
+      appointment: null,
+    });
+
+    await expect(
+      service.createCheckoutForAppointment(SALON_ID, ACTOR_ID, {
+        appointmentId: APPOINTMENT_ID,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+
+    expect(createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("400s when the appointment has no services to charge for", async () => {
+    const { service, createCheckoutSession } = buildService({
+      appointment: fakeAppointment({ services: [] }),
+    });
+
+    await expect(
+      service.createCheckoutForAppointment(SALON_ID, ACTOR_ID, {
+        appointmentId: APPOINTMENT_ID,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(createCheckoutSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -11,3 +11,4 @@ process.env.DEV_SALON_ID ??= "00000000-0000-0000-0000-0000000000a1";
 process.env.DEV_SALON_SLUG ??= "test-salon";
 process.env.MESSAGING_PROVIDER ??= "dev";
 process.env.TWILIO_FROM_NUMBER ??= "+15555550100";
+process.env.PAYMENT_PROVIDER ??= "dev";

--- a/apps/api/test/stripe-webhook.test.ts
+++ b/apps/api/test/stripe-webhook.test.ts
@@ -5,18 +5,41 @@ import type { ParsedWebhookEvent } from "../src/payments/payment-provider.interf
 
 const SALON_ID = "00000000-0000-0000-0000-000000000a01";
 
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000b01";
+
 function buildService({
-  payment = { id: "pay-1", salonId: SALON_ID, status: PaymentStatus.PENDING },
+  payment = {
+    id: "pay-1",
+    salonId: SALON_ID,
+    status: PaymentStatus.PENDING,
+    appointmentId: APPOINTMENT_ID,
+  },
+  otherSucceededPayment = null,
   processedThrows = null,
 }: {
-  payment?: { id: string; salonId: string; status: PaymentStatus } | null;
+  payment?: {
+    id: string;
+    salonId: string;
+    status: PaymentStatus;
+    appointmentId: string | null;
+  } | null;
+  /** Another row that has already SUCCEEDED for the same appointment —
+   *  used to drive the duplicate-charge defence-in-depth path. */
+  otherSucceededPayment?: { id: string } | null;
   processedThrows?: Error | null;
 } = {}) {
   const processedCreate = vi.fn().mockImplementation(async () => {
     if (processedThrows) throw processedThrows;
     return {};
   });
-  const paymentFindFirst = vi.fn().mockResolvedValue(payment);
+  // findFirst is called twice from the success handler:
+  //   1. to find the Payment row matching the session.id
+  //   2. to check whether ANOTHER SUCCEEDED row exists for the appointment
+  // The second call is gated on `succeeded && payment.appointmentId`.
+  const paymentFindFirst = vi
+    .fn()
+    .mockResolvedValueOnce(payment)
+    .mockResolvedValue(otherSucceededPayment);
   const paymentUpdate = vi.fn().mockResolvedValue({});
   const domainEventCreate = vi.fn().mockResolvedValue({});
 
@@ -118,12 +141,38 @@ describe("StripeWebhookService", () => {
         id: "pay-1",
         salonId: SALON_ID,
         status: PaymentStatus.SUCCEEDED,
+        appointmentId: APPOINTMENT_ID,
       },
     });
 
     await service.process(sessionEvent("paid"));
 
     expect(paymentUpdate).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("does not double-mark SUCCEEDED when another Payment for the same appointment already succeeded", async () => {
+    // Scenario: the customer was sent two checkout links (older one
+    // forgotten, newer one used and succeeded first). The older link is
+    // then completed afterwards — Stripe captures the second charge and
+    // sends checkout.session.completed for it. We must NOT mark a second
+    // SUCCEEDED row; instead flag the latecomer for manual refund.
+    const { service, paymentUpdate, domainEventCreate } = buildService({
+      otherSucceededPayment: { id: "pay-already-succeeded" },
+    });
+
+    await service.process(sessionEvent("paid"));
+
+    expect(paymentUpdate).toHaveBeenCalledTimes(1);
+    expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: PaymentStatus.FAILED,
+      failureReason: expect.stringContaining("Duplicate charge"),
+    });
+    expect(paymentUpdate.mock.calls[0]![0].data.failureReason).toContain(
+      "pay-already-succeeded",
+    );
+    // No payment.succeeded event for the duplicate — it didn't actually
+    // succeed from our books' perspective.
     expect(domainEventCreate).not.toHaveBeenCalled();
   });
 

--- a/apps/api/test/stripe-webhook.test.ts
+++ b/apps/api/test/stripe-webhook.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { PaymentStatus, Prisma } from "@prisma/client";
+import { StripeWebhookService } from "../src/webhooks/stripe-webhook.service";
+import type { ParsedWebhookEvent } from "../src/payments/payment-provider.interface";
+
+const SALON_ID = "00000000-0000-0000-0000-000000000a01";
+
+function buildService({
+  payment = { id: "pay-1", salonId: SALON_ID, status: PaymentStatus.PENDING },
+  processedThrows = null,
+}: {
+  payment?: { id: string; salonId: string; status: PaymentStatus } | null;
+  processedThrows?: Error | null;
+} = {}) {
+  const processedCreate = vi.fn().mockImplementation(async () => {
+    if (processedThrows) throw processedThrows;
+    return {};
+  });
+  const paymentFindFirst = vi.fn().mockResolvedValue(payment);
+  const paymentUpdate = vi.fn().mockResolvedValue({});
+  const domainEventCreate = vi.fn().mockResolvedValue({});
+
+  const prisma = {
+    processedWebhookEvent: { create: processedCreate },
+    payment: { findFirst: paymentFindFirst, update: paymentUpdate },
+    domainEvent: { create: domainEventCreate },
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn(prismaInstance),
+    ),
+  };
+  const prismaInstance = prisma;
+
+  const service = new StripeWebhookService(prisma as never);
+  return {
+    service,
+    processedCreate,
+    paymentFindFirst,
+    paymentUpdate,
+    domainEventCreate,
+  };
+}
+
+const sessionEvent = (
+  status: "paid" | "unpaid",
+  sid = "cs_test_dev_123",
+): ParsedWebhookEvent => ({
+  id: "evt_session_1",
+  type: "checkout.session.completed",
+  data: {
+    object: {
+      id: sid,
+      payment_intent: "pi_test_456",
+      payment_status: status,
+      amount_total: 11000,
+      currency: "usd",
+    },
+  },
+});
+
+const failedIntentEvent = (id = "pi_test_456"): ParsedWebhookEvent => ({
+  id: "evt_intent_failed",
+  type: "payment_intent.payment_failed",
+  data: {
+    object: {
+      id,
+      last_payment_error: { message: "card declined" },
+    },
+  },
+});
+
+describe("StripeWebhookService", () => {
+  it("marks the Payment SUCCEEDED on checkout.session.completed (paid) and emits payment.succeeded", async () => {
+    const { service, paymentUpdate, domainEventCreate } = buildService();
+
+    await service.process(sessionEvent("paid"));
+
+    expect(paymentUpdate).toHaveBeenCalledTimes(1);
+    expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: PaymentStatus.SUCCEEDED,
+      providerPaymentId: "pi_test_456",
+    });
+    expect(domainEventCreate).toHaveBeenCalledTimes(1);
+    expect(domainEventCreate.mock.calls[0]![0].data.eventType).toBe(
+      "payment.succeeded",
+    );
+  });
+
+  it("does not finalise SUCCEEDED when payment_status is unpaid", async () => {
+    const { service, paymentUpdate, domainEventCreate } = buildService();
+
+    await service.process(sessionEvent("unpaid"));
+
+    expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: PaymentStatus.PENDING,
+    });
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("dedupes a re-delivered event (P2002 on processed_webhook_events) without throwing", async () => {
+    const dupErr = new Prisma.PrismaClientKnownRequestError("duplicate", {
+      code: "P2002",
+      clientVersion: "x",
+      meta: { target: ["source", "externalEventId"] },
+    });
+    const { service, paymentUpdate, domainEventCreate } = buildService({
+      processedThrows: dupErr,
+    });
+
+    await service.process(sessionEvent("paid"));
+
+    expect(paymentUpdate).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a SUCCEEDED payment already finalised by an earlier webhook", async () => {
+    const { service, paymentUpdate, domainEventCreate } = buildService({
+      payment: {
+        id: "pay-1",
+        salonId: SALON_ID,
+        status: PaymentStatus.SUCCEEDED,
+      },
+    });
+
+    await service.process(sessionEvent("paid"));
+
+    expect(paymentUpdate).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("marks Payment FAILED with reason on payment_intent.payment_failed", async () => {
+    const { service, paymentUpdate } = buildService();
+
+    await service.process(failedIntentEvent());
+
+    expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: PaymentStatus.FAILED,
+      failureReason: "card declined",
+    });
+  });
+
+  it("does not downgrade a SUCCEEDED row when a stale failed event arrives", async () => {
+    const { service, paymentUpdate } = buildService({
+      payment: {
+        id: "pay-1",
+        salonId: SALON_ID,
+        status: PaymentStatus.SUCCEEDED,
+      },
+    });
+
+    await service.process(failedIntentEvent());
+
+    expect(paymentUpdate).not.toHaveBeenCalled();
+  });
+
+  it("logs and skips when no Payment row matches (handler does not throw)", async () => {
+    const { service, paymentUpdate } = buildService({ payment: null });
+
+    await service.process(sessionEvent("paid"));
+
+    expect(paymentUpdate).not.toHaveBeenCalled();
+  });
+
+  it("ignores unhandled event types (refunds, disputes — deferred to 5c)", async () => {
+    const { service, paymentUpdate, domainEventCreate } = buildService();
+
+    await service.process({
+      id: "evt_refund_1",
+      type: "charge.refunded",
+      data: { object: { id: "ch_x" } },
+    });
+
+    expect(paymentUpdate).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -355,3 +355,17 @@ export const salonSettingsUpdateSchema = z
 export type SalonSettingsUpdateInput = z.infer<
   typeof salonSettingsUpdateSchema
 >;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payments (Phase 5a — Stripe Checkout via PaymentProvider).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const checkoutCreateSchema = z.object({
+  appointmentId: z.string().uuid(),
+  // Optional overrides for the Stripe-hosted-checkout return URLs. When
+  // unset, the API generates routes on WEB_ORIGIN that the frontend
+  // handles. Validated as URLs to avoid passing junk to Stripe.
+  successUrl: z.string().url().optional(),
+  cancelUrl: z.string().url().optional(),
+});
+export type CheckoutCreateInput = z.infer<typeof checkoutCreateSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      stripe:
+        specifier: ^17.5.0
+        version: 17.7.0
       svix:
         specifier: '1'
         version: 1.92.2
@@ -3583,6 +3586,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@17.7.0:
+    resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
+    engines: {node: '>=12.*'}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -7595,6 +7602,11 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@17.7.0:
+    dependencies:
+      '@types/node': 22.19.17
+      qs: 6.14.2
 
   strtok3@10.3.5:
     dependencies:


### PR DESCRIPTION
## Summary

Mirrors the auth + messaging provider pattern. Pre-generates the Payment row id and uses it as Stripe's idempotency key, so any retry hits Stripe's HTTP-level idempotency cache instead of creating a duplicate Checkout Session.

No schema changes — \`Payment\` was already in the schema from Phase 1 with \`idempotencyKey\` and unique on \`(provider, providerPaymentId)\`.

## Provider

- \`PaymentProvider\` interface + \`Dev\` / \`Stripe\` adapters, switched on \`PAYMENT_PROVIDER\` env. Dev refuses to run when \`NODE_ENV=production\` and synthesizes \`dev_cs_*\` ids that can't collide with real Stripe ones. Stripe uses the official SDK + \`Webhook.constructEvent\` for HMAC-SHA256 signature verification.
- Module factory only constructs the selected implementation — \`StripePaymentProvider\`'s constructor throws when env is unset, so listing both classes in providers would crash dev/test bootstrap. (Same fix we landed in messaging.)

## Checkout endpoint

- \`POST /payments/checkout\` takes \`{ appointmentId }\` (zod-validated), computes amount + currency from service snapshots, generates the Payment row id up front, calls the provider with that id as the idempotency key, then INSERTs the PENDING row + \`payment.created\` domain event in the same transaction.
- \`409 ConflictException\` when a SUCCEEDED Payment already exists for the appointment — prevents accidental double-charge from a stale link.
- 404 / 400 for missing appointment / no services to charge for.

## Stripe webhook

- \`POST /webhooks/stripe\` verifies the \`X-Stripe-Signature\` header against the raw body, then dedupes via \`processed_webhook_events.(source, externalEventId)\` — Stripe re-deliveries become a no-op via the existing P2002 path.
- \`checkout.session.completed\` → SUCCEEDED, replaces the session id with payment_intent id (so future refund webhooks correlate), populates \`capturedAt\`, emits \`payment.succeeded\`.
- \`payment_intent.payment_failed\` → FAILED with the carrier reason trimmed to 500 chars. Refuses to downgrade an already-SUCCEEDED row when a stale failed event arrives.
- All other event types log + ignore.

## Out of scope (intentional)

- **UI** — \"Pay now\" buttons, payment column on the schedule, receipts. Lands in 5b.
- **Refunds + disputes** — \`charge.refunded\`, \`charge.dispute.*\`. Lands in 5c.
- **Stripe Connect** — single platform account for now; multi-tenant per-salon merchant accounts tracked as #18.
- **Stripe Terminal** — Phase 5.5 per the roadmap.
- **Tax / inventory / gift cards** — out per Phase 5.5 carve-out.

## Tests

56 / 56 passing (was 43, +13):

- **payments-service**: full flow with idempotency-key, amount sum across services, 409 on already-paid, 404 on missing appointment, 400 on no services.
- **stripe-webhook**: paid SUCCEEDED + event, unpaid stays PENDING, P2002 dedup, won't double-process an already-SUCCEEDED row, FAILED with reason, won't downgrade SUCCEEDED on stale fail, no Payment match → log + skip, unhandled types → ignored.

## Test plan

- [x] \`pnpm --filter @shearsimp/api typecheck\` / \`test\` (56/56)
- [x] \`pnpm --filter @shearsimp/db typecheck\` / \`test\` (enum parity)
- [x] \`pnpm --filter @shearsimp/web typecheck\` / \`shared build\`
- [ ] Smoke: \`POST /payments/checkout { appointmentId }\` → returns a \`url\` + \`paymentId\`; \`payments\` row inserted with status=PENDING, providerPaymentId set to the synthetic dev sid; \`domain_events\` has a payment.created row
- [ ] Repeat the same call → succeeds and creates a second Payment row (idempotency is per-call, the appointment doesn't have a SUCCEEDED row yet)
- [ ] POST a synthetic \`checkout.session.completed\` with the dev provider to \`/webhooks/stripe\` → Payment flips to SUCCEEDED, capturedAt populated, payment.succeeded domain event appended
- [ ] Re-POST the same event → 200 received, no second update, no duplicate domain event
- [ ] Re-POST POST /payments/checkout for the now-paid appointment → 409 with \"already paid\" message