### PR TITLE
Phase 5b: pay-for-appointment UI on the schedule

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,11 +223,21 @@ PCI exposure stays minimal — Stripe-hosted surfaces only this phase.
   `payment_intent.payment_failed` → FAILED with reason
 - Refunds + disputes intentionally deferred to 5c
 
-### Phase 5b — Pay-for-appointment UI ⬜
+### Phase 5b — Pay-for-appointment UI 🚧
 
-- "Pay now" / "Send payment link" on appointment detail
-- Client-facing receipt + status display
-- Payment column on the schedule view
+- Schedule appointment detail panel gets a payment section: status pill,
+  amount, "View Stripe receipt" link when paid, "Pay now" / "Resume" /
+  "Try again" button keyed off the most recent payment row
+- Tiny `$` badge in the corner of an appointment block — green when paid,
+  cyan when pending, red on issues
+- Return banner on `/schedule?paid=:appointmentId` (and the matching
+  `paymentCancelled=` variant) explaining the flip-from-Stripe state
+- New `GET /payments?appointmentIds=...` endpoint backing the schedule
+  view's per-appointment payment lookup; deduped server-side to the
+  highest-priority status (SUCCEEDED > FAILED > … > PENDING)
+- Dev-only Stripe simulator at `/dev/checkout` — the dev provider's URL
+  now embeds success/cancel URLs so the page can complete the flow with
+  a real synthetic webhook event and redirect, mirroring production
 
 ### Phase 5c — Tips + refunds ⬜
 

--- a/apps/api/src/payments/dev-payment.provider.ts
+++ b/apps/api/src/payments/dev-payment.provider.ts
@@ -36,9 +36,19 @@ export class DevPaymentProvider implements PaymentProvider {
     this.logger.log(
       `[dev-checkout] sid=${sid} amount=${args.amountCents} ${args.currency} product=${JSON.stringify(args.productName)} success=${args.successUrl}`,
     );
-    // The dev URL points at a stub on the web side that simulates the
-    // user clicking through — Phase 5b wires up the actual route.
-    const url = `${env.WEB_ORIGIN}/dev/checkout?sid=${sid}&amount=${args.amountCents}`;
+    // The dev URL points at the simulator at apps/web/src/app/dev/checkout.
+    // We embed the success / cancel URLs so the simulator can finish the
+    // flow with a real redirect — `{CHECKOUT_SESSION_ID}` substitution
+    // happens in the simulator, mirroring what Stripe does in production.
+    const params = new URLSearchParams({
+      sid,
+      amount: String(args.amountCents),
+      currency: args.currency,
+      product: args.productName,
+      success: args.successUrl,
+      cancel: args.cancelUrl,
+    });
+    const url = `${env.WEB_ORIGIN}/dev/checkout?${params.toString()}`;
     return { providerSessionId: sid, url };
   }
 

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Get, Post, Query } from "@nestjs/common";
 import { checkoutCreateSchema } from "@shearsimp/shared";
 import type { CheckoutCreateInput } from "@shearsimp/shared";
 import { CurrentSalon } from "../tenant/current-salon.decorator";
@@ -13,6 +13,24 @@ import { PaymentsService } from "./payments.service";
 @Controller("payments")
 export class PaymentsController {
   constructor(private readonly payments: PaymentsService) {}
+
+  // GET /payments?appointmentIds=id1,id2,...: list payment rows for a set
+  // of appointments in the current salon. Cap the IDs the caller can ask
+  // for so a malicious / mistaken client can't pull the whole table by
+  // dumping all UUIDs into one request.
+  @Get()
+  async list(
+    @CurrentSalon() salon: ActiveSalon,
+    @Query("appointmentIds") appointmentIds?: string,
+  ) {
+    if (!appointmentIds) return [];
+    const ids = appointmentIds
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .slice(0, 200);
+    return this.payments.listForAppointments(salon.salonId, ids);
+  }
 
   // POST /payments/checkout: returns a Stripe Checkout Session URL the
   // caller redirects the user to. The webhook (5a) finalises status when

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, Post, Query } from "@nestjs/common";
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+} from "@nestjs/common";
 import { checkoutCreateSchema } from "@shearsimp/shared";
 import type { CheckoutCreateInput } from "@shearsimp/shared";
 import { CurrentSalon } from "../tenant/current-salon.decorator";
@@ -10,14 +17,24 @@ import type {
 import { ZodValidationPipe } from "../common/zod-validation.pipe";
 import { PaymentsService } from "./payments.service";
 
+// Hard cap on a single /payments lookup. The schedule view sends all
+// the day's appointments in one request — 500 covers a 10-stylist salon
+// pegged at every-15min-slot bookings, and refusing larger lists with
+// a 400 (rather than silently truncating) means callers know to batch
+// instead of losing rows from the response.
+const MAX_LOOKUP_IDS = 500;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 @Controller("payments")
 export class PaymentsController {
   constructor(private readonly payments: PaymentsService) {}
 
   // GET /payments?appointmentIds=id1,id2,...: list payment rows for a set
-  // of appointments in the current salon. Cap the IDs the caller can ask
-  // for so a malicious / mistaken client can't pull the whole table by
-  // dumping all UUIDs into one request.
+  // of appointments in the current salon. Validates each id is a UUID up
+  // front (a non-UUID slipping into the Prisma `in` filter would surface
+  // as a 500 from Postgres) and 400s on over-limit input rather than
+  // silently dropping rows.
   @Get()
   async list(
     @CurrentSalon() salon: ActiveSalon,
@@ -27,8 +44,19 @@ export class PaymentsController {
     const ids = appointmentIds
       .split(",")
       .map((s) => s.trim())
-      .filter((s) => s.length > 0)
-      .slice(0, 200);
+      .filter((s) => s.length > 0);
+
+    if (ids.length > MAX_LOOKUP_IDS) {
+      throw new BadRequestException(
+        `appointmentIds: at most ${MAX_LOOKUP_IDS} per request (got ${ids.length}); batch if you need more`,
+      );
+    }
+    const invalid = ids.find((id) => !UUID_RE.test(id));
+    if (invalid) {
+      throw new BadRequestException(
+        `appointmentIds: "${invalid}" is not a valid UUID`,
+      );
+    }
     return this.payments.listForAppointments(salon.salonId, ids);
   }
 

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -50,6 +50,45 @@ export class PaymentsService {
     private readonly provider: PaymentProviderImpl,
   ) {}
 
+  /**
+   * Lookup payments by appointment id, scoped to the current salon. Used by
+   * the schedule view to colour blocks and gate the "Pay now" button.
+   *
+   * Filtered to one row per appointment using the highest-priority status
+   * (SUCCEEDED > FAILED > CANCELLED > PENDING) so the UI sees the most
+   * important state — "succeeded" wins over a stale PENDING / FAILED on a
+   * separate session for the same appointment.
+   */
+  async listForAppointments(salonId: string, appointmentIds: string[]) {
+    if (appointmentIds.length === 0) return [];
+    const rows = await this.prisma.payment.findMany({
+      where: {
+        salonId,
+        appointmentId: { in: appointmentIds },
+      },
+      select: {
+        id: true,
+        appointmentId: true,
+        status: true,
+        amountCents: true,
+        currency: true,
+        receiptUrl: true,
+        capturedAt: true,
+        createdAt: true,
+      },
+      orderBy: [{ createdAt: "desc" }],
+    });
+    const winner = new Map<string, (typeof rows)[number]>();
+    for (const r of rows) {
+      if (!r.appointmentId) continue;
+      const existing = winner.get(r.appointmentId);
+      if (!existing || rank(r.status) > rank(existing.status)) {
+        winner.set(r.appointmentId, r);
+      }
+    }
+    return Array.from(winner.values());
+  }
+
   async createCheckoutForAppointment(
     salonId: string,
     actorUserId: string,
@@ -156,6 +195,27 @@ export class PaymentsService {
       });
       return { url: session.url, paymentId };
     });
+  }
+}
+
+// SUCCEEDED is the most informative state and should win over a stale
+// PENDING / FAILED row from an earlier checkout attempt on the same
+// appointment.
+function rank(status: PaymentStatus): number {
+  switch (status) {
+    case PaymentStatus.SUCCEEDED:
+      return 5;
+    case PaymentStatus.PARTIALLY_REFUNDED:
+      return 4;
+    case PaymentStatus.REFUNDED:
+      return 3;
+    case PaymentStatus.FAILED:
+      return 2;
+    case PaymentStatus.CANCELLED:
+      return 1;
+    case PaymentStatus.PENDING:
+    default:
+      return 0;
   }
 }
 

--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { apiFetch, ApiError } from "@/lib/api";
 
@@ -138,4 +139,31 @@ export async function cancelAppointment(input: {
   } catch (e) {
     return fail(e);
   }
+}
+
+/**
+ * Server action wrapper for the checkout flow. Calls the API to create a
+ * Stripe Checkout Session for an appointment, then routes the user to the
+ * returned URL via Next's redirect() — which throws a special control-flow
+ * exception, so this function "returns" only on the failure path.
+ */
+export async function startCheckoutAction(
+  appointmentId: string,
+): Promise<ActionResult> {
+  let url: string;
+  try {
+    const res = await apiFetch<{ url: string; paymentId: string }>(
+      "/payments/checkout",
+      {
+        method: "POST",
+        data: { appointmentId },
+      },
+    );
+    url = res.url;
+  } catch (e) {
+    return fail(e);
+  }
+  // redirect() throws — must be outside the try / catch so Next's
+  // NEXT_REDIRECT control-flow exception isn't swallowed by `fail()`.
+  redirect(url);
 }

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -13,6 +13,7 @@ import {
   cancelAppointment,
   completeAppointment,
   rescheduleAppointment,
+  startCheckoutAction,
   transitionAppointment,
 } from "../_actions";
 
@@ -73,6 +74,24 @@ export interface ScheduleAppointment {
   services: ScheduleAppointmentService[];
 }
 
+export type SchedulePaymentStatus =
+  | "PENDING"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "REFUNDED"
+  | "PARTIALLY_REFUNDED"
+  | "CANCELLED";
+
+export interface SchedulePayment {
+  id: string;
+  appointmentId: string;
+  status: SchedulePaymentStatus;
+  amountCents: number;
+  currency: string;
+  receiptUrl: string | null;
+  capturedAt: string | null;
+}
+
 interface Props {
   isoDate: string;
   timezone: string;
@@ -83,6 +102,13 @@ interface Props {
   appointments: ScheduleAppointment[];
   staff: ScheduleStaff[];
   services: ScheduleService[];
+  /** One row per appointment that has any payment activity, deduped by the
+   *  API to the highest-priority status (SUCCEEDED wins over PENDING). */
+  payments: SchedulePayment[];
+  /** When set, the user just returned from a successful Stripe redirect for
+   *  this appointment id — the view shows a banner until they dismiss it. */
+  paidAppointmentId: string | null;
+  paymentCancelledAppointmentId: string | null;
 }
 
 const LEGEND: Array<{ k: CategoryKind; l: string }> = [
@@ -100,6 +126,7 @@ interface RenderBlock {
   startMin: number;
   durationMin: number;
   kind: CategoryKind;
+  payment: SchedulePayment | null;
 }
 
 function staffGradient(index: number): string {
@@ -116,10 +143,27 @@ export function ScheduleView({
   appointments,
   staff,
   services,
+  payments,
+  paidAppointmentId,
+  paymentCancelledAppointmentId,
 }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const paymentByAppointmentId = useMemo(() => {
+    const map = new Map<string, SchedulePayment>();
+    for (const p of payments) map.set(p.appointmentId, p);
+    return map;
+  }, [payments]);
+
+  function dismissReturnBanner() {
+    // Drop the paid / paymentCancelled query params so the banner doesn't
+    // re-show on refresh. Keep the existing date param.
+    const qs = new URLSearchParams();
+    qs.set("date", isoDate);
+    router.replace(`/schedule?${qs.toString()}`);
+  }
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [hoverDrop, setHoverDrop] = useState<{
     staffIndex: number;
@@ -175,10 +219,11 @@ export function ScheduleView({
         startMin,
         durationMin: Math.max(SLOT_MIN, endMin - startMin),
         kind,
+        payment: paymentByAppointmentId.get(a.id) ?? null,
       });
     }
     return out;
-  }, [appointments, staff, kindForServiceId, isoDate, timezone]);
+  }, [appointments, staff, kindForServiceId, isoDate, timezone, paymentByAppointmentId]);
 
   const selected = useMemo(
     () =>
@@ -259,6 +304,21 @@ export function ScheduleView({
           details.
         </p>
       </header>
+
+      {paidAppointmentId && (
+        <PaymentReturnBanner
+          tone="success"
+          message="Payment received. Stripe is finalising — the status badge will update once the webhook arrives."
+          onDismiss={dismissReturnBanner}
+        />
+      )}
+      {paymentCancelledAppointmentId && (
+        <PaymentReturnBanner
+          tone="info"
+          message="Checkout was cancelled. The appointment is unchanged."
+          onDismiss={dismissReturnBanner}
+        />
+      )}
 
       <div className="ss-schedule-toolbar">
         <div className="ss-schedule-toolbar-group">
@@ -404,6 +464,7 @@ export function ScheduleView({
       {selected && (
         <DetailsPanel
           appointment={selected}
+          payment={paymentByAppointmentId.get(selected.id) ?? null}
           timezone={timezone}
           isPending={isPending}
           onClose={() => setSelectedId(null)}
@@ -512,12 +573,13 @@ function AppointmentBlock({
   onSelect: (id: string) => void;
   timezone: string;
 }) {
-  const { appointment, durationMin, kind } = block;
+  const { appointment, durationMin, kind, payment } = block;
   const heightPx = (durationMin / SLOT_MIN) * SLOT_HEIGHT - 4;
   const time = formatTimeInTimezone(new Date(appointment.startAt), timezone);
   const services = appointment.services
     .map((s) => s.serviceNameSnapshot)
     .join(" · ");
+  const paymentBadgeKind = payment ? badgeKindFor(payment.status) : null;
   return (
     <div
       className={`ss-cal-block is-${kind}${isSelected ? " is-selected" : ""}${isDragging ? " is-dragging" : ""}`}
@@ -537,6 +599,15 @@ function AppointmentBlock({
     >
       <div className="ss-cal-block-name">
         {appointment.client.displayName}
+        {paymentBadgeKind && (
+          <span
+            className={`ss-cal-block-pay is-${paymentBadgeKind}`}
+            title={`Payment: ${payment!.status.toLowerCase()}`}
+            aria-label={`Payment ${payment!.status.toLowerCase()}`}
+          >
+            $
+          </span>
+        )}
       </div>
       <div className="ss-cal-block-svc">
         {time} · {services || "Service"}
@@ -545,14 +616,22 @@ function AppointmentBlock({
   );
 }
 
+function badgeKindFor(status: SchedulePaymentStatus): "paid" | "pending" | "issue" {
+  if (status === "SUCCEEDED") return "paid";
+  if (status === "PENDING") return "pending";
+  return "issue";
+}
+
 function DetailsPanel({
   appointment,
+  payment,
   timezone,
   isPending,
   onClose,
   onAction,
 }: {
   appointment: ScheduleAppointment;
+  payment: SchedulePayment | null;
   timezone: string;
   isPending: boolean;
   onClose: () => void;
@@ -623,6 +702,10 @@ function DetailsPanel({
           <p>{appointment.internalNotes}</p>
         </div>
       )}
+      <PaymentSection
+        appointmentId={appointment.id}
+        payment={payment}
+      />
       <div className="ss-detail-actions">
         {advanceTarget.map((t) => (
           <button
@@ -672,6 +755,113 @@ function DetailsPanel({
       </div>
     </div>
   );
+}
+
+function PaymentSection({
+  appointmentId,
+  payment,
+}: {
+  appointmentId: string;
+  payment: SchedulePayment | null;
+}) {
+  // The startCheckoutAction server action redirects via redirect() — it
+  // throws NEXT_REDIRECT on success, so this state only flips back when
+  // the API rejects (already paid → 409, missing services → 400).
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function pay() {
+    setSubmitting(true);
+    setErrorMsg(null);
+    const result = await startCheckoutAction(appointmentId);
+    // If we got here, the redirect didn't fire — that means the action
+    // failed (the success path throws and never returns).
+    setSubmitting(false);
+    setErrorMsg(result.message ?? "Couldn't start checkout");
+  }
+
+  const succeeded = payment?.status === "SUCCEEDED";
+  const failed =
+    payment?.status === "FAILED" ||
+    payment?.status === "CANCELLED" ||
+    payment?.status === "REFUNDED" ||
+    payment?.status === "PARTIALLY_REFUNDED";
+  const pending = payment?.status === "PENDING";
+
+  return (
+    <div className="ss-detail-section ss-detail-payment">
+      <div className="ss-detail-label">Payment</div>
+      {payment && (
+        <div className="ss-detail-payment-row">
+          <span className={`ss-tag is-pay-${payment.status.toLowerCase()}`}>
+            {payment.status.replace("_", " ").toLowerCase()}
+          </span>
+          <span className="ss-detail-payment-amount">
+            {formatPrice(payment.amountCents, payment.currency)}
+          </span>
+        </div>
+      )}
+      {succeeded && payment?.receiptUrl && (
+        <a
+          className="ss-link"
+          href={payment.receiptUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View Stripe receipt ↗
+        </a>
+      )}
+      {!succeeded && (
+        <button
+          type="button"
+          className="ss-btn ss-btn-primary"
+          disabled={submitting}
+          onClick={pay}
+        >
+          {submitting
+            ? "Starting checkout…"
+            : pending
+              ? "Resume payment"
+              : failed
+                ? "Try again"
+                : "Pay now"}
+        </button>
+      )}
+      {errorMsg && <div className="ss-form-error">{errorMsg}</div>}
+    </div>
+  );
+}
+
+function PaymentReturnBanner({
+  tone,
+  message,
+  onDismiss,
+}: {
+  tone: "success" | "info";
+  message: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className={`ss-return-banner is-${tone}`} role="status">
+      <span>{message}</span>
+      <button
+        type="button"
+        className="ss-return-banner-close"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
 }
 
 function ChevIcon({ dir }: { dir: "left" | "right" }) {

--- a/apps/web/src/app/(app)/schedule/page.tsx
+++ b/apps/web/src/app/(app)/schedule/page.tsx
@@ -68,17 +68,12 @@ export default async function SchedulePage({
   ]);
 
   // Fetch the day's payments after the appointment query so we can scope
-  // by ID — keeps the list cap meaningful and avoids dragging in payments
-  // for other days that happen to share an appointment id (they won't,
-  // but the server enforces the cap anyway).
-  const payments =
-    appointments.length > 0
-      ? await apiFetch<SchedulePayment[]>("/payments", {
-          query: {
-            appointmentIds: appointments.map((a) => a.id).join(","),
-          },
-        })
-      : [];
+  // by ID. The /payments endpoint hard-caps the list at 500 ids per
+  // request and 400s on over-limit input — chunk into matching batches
+  // so a wildly busy salon doesn't lose rows from a silent truncation.
+  const payments = await fetchPaymentsForAppointments(
+    appointments.map((a) => a.id),
+  );
 
   const prevIso = shiftIsoDate(isoDate, -1, tz);
   const nextIso = shiftIsoDate(isoDate, 1, tz);
@@ -132,6 +127,28 @@ export default async function SchedulePage({
       )}
     </>
   );
+}
+
+// Stay under the API's MAX_LOOKUP_IDS (500). 400 leaves a comfortable
+// margin and keeps the URL short enough to not stress any proxy.
+const PAYMENTS_LOOKUP_BATCH = 400;
+
+async function fetchPaymentsForAppointments(
+  appointmentIds: string[],
+): Promise<SchedulePayment[]> {
+  if (appointmentIds.length === 0) return [];
+  const chunks: string[][] = [];
+  for (let i = 0; i < appointmentIds.length; i += PAYMENTS_LOOKUP_BATCH) {
+    chunks.push(appointmentIds.slice(i, i + PAYMENTS_LOOKUP_BATCH));
+  }
+  const results = await Promise.all(
+    chunks.map((chunk) =>
+      apiFetch<SchedulePayment[]>("/payments", {
+        query: { appointmentIds: chunk.join(",") },
+      }),
+    ),
+  );
+  return results.flat();
 }
 
 async function loadBookingData({

--- a/apps/web/src/app/(app)/schedule/page.tsx
+++ b/apps/web/src/app/(app)/schedule/page.tsx
@@ -9,6 +9,7 @@ import {
 import {
   ScheduleView,
   type ScheduleAppointment,
+  type SchedulePayment,
   type ScheduleStaff,
   type ScheduleService,
 } from "./_components/schedule-view";
@@ -43,6 +44,8 @@ export default async function SchedulePage({
     month?: string;
     staff?: string;
     client?: string;
+    paid?: string;
+    paymentCancelled?: string;
   }>;
 }) {
   const params = await searchParams;
@@ -63,6 +66,19 @@ export default async function SchedulePage({
     apiFetch<ScheduleStaff[]>("/staff"),
     apiFetch<ScheduleService[]>("/services"),
   ]);
+
+  // Fetch the day's payments after the appointment query so we can scope
+  // by ID — keeps the list cap meaningful and avoids dragging in payments
+  // for other days that happen to share an appointment id (they won't,
+  // but the server enforces the cap anyway).
+  const payments =
+    appointments.length > 0
+      ? await apiFetch<SchedulePayment[]>("/payments", {
+          query: {
+            appointmentIds: appointments.map((a) => a.id).join(","),
+          },
+        })
+      : [];
 
   const prevIso = shiftIsoDate(isoDate, -1, tz);
   const nextIso = shiftIsoDate(isoDate, 1, tz);
@@ -93,6 +109,9 @@ export default async function SchedulePage({
         appointments={appointments}
         staff={staff.filter((s) => s.isActive)}
         services={services}
+        payments={payments}
+        paidAppointmentId={params.paid ?? null}
+        paymentCancelledAppointmentId={params.paymentCancelled ?? null}
       />
       {bookOpen && bookingData && (
         <BookingModalMount

--- a/apps/web/src/app/dev/checkout/_actions.ts
+++ b/apps/web/src/app/dev/checkout/_actions.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import "server-only";
+import { redirect } from "next/navigation";
+import { serverEnv } from "@/lib/env";
+
+/**
+ * Simulates Stripe finishing a checkout session by POSTing a synthetic
+ * `checkout.session.completed` event at our `/webhooks/stripe` endpoint.
+ * The dev payment provider's `verifyAndParseWebhook` accepts any
+ * `stripe-signature` value, so we don't need to sign anything.
+ *
+ * This route must only run in dev — it short-circuits the entire payment
+ * flow and would be a critical security hole in production. Refuses to
+ * proceed when NODE_ENV=production.
+ */
+export async function completeDevCheckoutAction(formData: FormData) {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Dev checkout simulator must not run in production");
+  }
+  const sid = String(formData.get("sid") ?? "");
+  const amount = Number(formData.get("amount") ?? 0);
+  const currency = String(formData.get("currency") ?? "USD");
+  const successUrl = String(formData.get("success") ?? "");
+  if (!sid || !successUrl) {
+    throw new Error("Missing sid / success URL in form data");
+  }
+
+  const event = {
+    id: `evt_dev_${sid}`,
+    type: "checkout.session.completed",
+    data: {
+      object: {
+        id: sid,
+        // Synthetic payment_intent id so future refund flows can correlate.
+        payment_intent: `pi_dev_${sid}`,
+        payment_status: "paid",
+        amount_total: amount,
+        currency: currency.toLowerCase(),
+      },
+    },
+  };
+
+  const res = await fetch(`${serverEnv.apiInternalUrl}/webhooks/stripe`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      // The dev provider's verifyAndParseWebhook ignores the signature value
+      // — it just needs the header to be present so the controller doesn't
+      // reject with "Missing Stripe-Signature".
+      "stripe-signature": "dev",
+    },
+    body: JSON.stringify(event),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Dev webhook POST failed: ${res.status} ${text}`);
+  }
+
+  // Stripe substitutes `{CHECKOUT_SESSION_ID}` in success_url with the
+  // session id. Mirror that here so the success route can read it the
+  // same way it would in production.
+  const finalUrl = successUrl.replace(
+    encodeURIComponent("{CHECKOUT_SESSION_ID}"),
+    sid,
+  ).replace("{CHECKOUT_SESSION_ID}", sid);
+  redirect(finalUrl);
+}

--- a/apps/web/src/app/dev/checkout/page.tsx
+++ b/apps/web/src/app/dev/checkout/page.tsx
@@ -1,0 +1,81 @@
+import { notFound } from "next/navigation";
+import { completeDevCheckoutAction } from "./_actions";
+
+/**
+ * Dev-only Stripe Checkout simulator. The DevPaymentProvider points its
+ * `url` here instead of stripe.com — the page renders a stand-in
+ * "checkout" with two buttons:
+ *
+ *   - Confirm payment → server action POSTs a synthetic
+ *     `checkout.session.completed` to our /webhooks/stripe, then
+ *     redirects to the success URL with `{CHECKOUT_SESSION_ID}` filled
+ *     in (mirrors what Stripe does in prod).
+ *   - Cancel → redirect straight to the cancel URL.
+ *
+ * 404s in production so it can't be hit even if PAYMENT_PROVIDER is
+ * mistakenly set to `dev` there.
+ */
+export default async function DevCheckoutPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    sid?: string;
+    amount?: string;
+    currency?: string;
+    product?: string;
+    success?: string;
+    cancel?: string;
+  }>;
+}) {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+  const params = await searchParams;
+  const sid = params.sid;
+  const amountCents = Number(params.amount ?? 0);
+  const currency = (params.currency ?? "USD").toUpperCase();
+  const product = params.product ?? "Appointment";
+  const success = params.success ?? "";
+  const cancel = params.cancel ?? "";
+
+  if (!sid || !success || !cancel || !Number.isFinite(amountCents)) {
+    notFound();
+  }
+
+  const formattedAmount = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amountCents / 100);
+
+  return (
+    <main className="ss-dev-checkout">
+      <div className="ss-dev-checkout-card">
+        <div className="ss-page-eyebrow">Dev payment simulator</div>
+        <h1 className="ss-dev-checkout-title">{product}</h1>
+        <div className="ss-dev-checkout-amount">{formattedAmount}</div>
+        <p className="ss-dev-checkout-meta">
+          Session id <code>{sid}</code>
+        </p>
+        <p className="ss-dev-checkout-note">
+          This page stands in for the Stripe-hosted checkout while
+          PAYMENT_PROVIDER=dev. Confirming POSTs a synthetic
+          <code> checkout.session.completed</code> event to{" "}
+          <code>/webhooks/stripe</code>, just like the real provider would.
+        </p>
+
+        <form action={completeDevCheckoutAction} className="ss-dev-checkout-actions">
+          <input type="hidden" name="sid" value={sid} />
+          <input type="hidden" name="amount" value={amountCents} />
+          <input type="hidden" name="currency" value={currency} />
+          <input type="hidden" name="success" value={success} />
+          <button type="submit" className="ss-btn ss-btn-primary">
+            Confirm payment
+          </button>
+          <a className="ss-btn ss-btn-ghost" href={cancel}>
+            Cancel
+          </a>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -781,6 +781,181 @@
 .ss-detail-meta { font-size: 12.5px; color: var(--ss-text-muted); margin: 0; }
 .ss-detail-section { margin-top: 14px; font-size: 13px; color: var(--ss-text-primary); }
 .ss-detail-section p { margin: 4px 0 0; }
+
+/* Payment section in the schedule detail panel. */
+.ss-detail-payment {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ss-detail-payment-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+.ss-detail-payment-amount {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--ss-text-heading);
+  font-variant-numeric: tabular-nums;
+}
+.ss-detail-payment .ss-btn { align-self: flex-start; }
+
+/* Payment status pills — colour-coded by health, not by tone. */
+.ss-tag.is-pay-succeeded {
+  background: rgba(46, 160, 67, 0.16);
+  color: #1f6f33;
+}
+.theme-twilight .ss-tag.is-pay-succeeded { color: #92e6a3; }
+.ss-tag.is-pay-pending {
+  background: var(--ss-magenta-pale);
+  color: var(--ss-magenta-deep);
+}
+.theme-twilight .ss-tag.is-pay-pending { color: var(--ss-magenta); }
+.ss-tag.is-pay-failed,
+.ss-tag.is-pay-cancelled,
+.ss-tag.is-pay-refunded,
+.ss-tag.is-pay-partially_refunded {
+  background: rgba(217, 107, 94, 0.18);
+  color: #984236;
+}
+.theme-twilight .ss-tag.is-pay-failed,
+.theme-twilight .ss-tag.is-pay-cancelled,
+.theme-twilight .ss-tag.is-pay-refunded,
+.theme-twilight .ss-tag.is-pay-partially_refunded { color: #f5b8a8; }
+
+/* Tiny payment badge in the corner of an appointment block. */
+.ss-cal-block-name {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+.ss-cal-block-pay {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.5px;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--ss-text-heading);
+  box-shadow: 0 1px 3px rgba(15, 30, 50, 0.18);
+}
+.ss-cal-block-pay.is-paid {
+  background: #2ea043;
+  color: #fff;
+}
+.ss-cal-block-pay.is-pending {
+  background: var(--ss-magenta);
+  color: #fff;
+}
+.ss-cal-block-pay.is-issue {
+  background: #d96b5e;
+  color: #fff;
+}
+
+/* Banner that appears when the user returns from a Stripe redirect. */
+.ss-return-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--ss-panel-edge);
+  margin-bottom: 14px;
+  font-size: 13.5px;
+  color: var(--ss-text-heading);
+}
+.ss-return-banner.is-success {
+  background: rgba(46, 160, 67, 0.10);
+  border-color: rgba(46, 160, 67, 0.32);
+}
+.ss-return-banner.is-info {
+  background: var(--ss-magenta-pale);
+  border-color: var(--ss-magenta);
+}
+.ss-return-banner-close {
+  background: transparent;
+  border: 0;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.7;
+}
+.ss-return-banner-close:hover { opacity: 1; }
+
+/* Dev payment simulator at /dev/checkout. Intentionally plain so it
+   reads as "stand-in", not as production Stripe checkout. */
+.ss-dev-checkout {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: var(--ss-bg-page);
+}
+.ss-dev-checkout-card {
+  max-width: 460px;
+  width: 100%;
+  padding: 28px 28px 24px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid var(--ss-panel-edge);
+  box-shadow: 0 18px 42px -16px rgba(15, 30, 50, 0.24);
+}
+.theme-twilight .ss-dev-checkout-card {
+  background: rgba(20, 28, 44, 0.94);
+}
+.ss-dev-checkout-title {
+  margin: 8px 0 4px;
+  font-family: var(--font-cormorant), serif;
+  font-size: 26px;
+  color: var(--ss-text-heading);
+}
+.ss-dev-checkout-amount {
+  font-family: var(--font-cormorant), serif;
+  font-size: 36px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  font-variant-numeric: tabular-nums;
+  margin: 6px 0 14px;
+}
+.ss-dev-checkout-meta {
+  font-size: 12px;
+  color: var(--ss-text-muted);
+  margin: 0 0 18px;
+}
+.ss-dev-checkout-meta code,
+.ss-dev-checkout-note code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  background: rgba(15, 28, 47, 0.05);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.theme-twilight .ss-dev-checkout-meta code,
+.theme-twilight .ss-dev-checkout-note code {
+  background: rgba(255, 255, 255, 0.08);
+}
+.ss-dev-checkout-note {
+  font-size: 12.5px;
+  color: var(--ss-text-muted);
+  line-height: 1.55;
+  margin: 0 0 22px;
+}
+.ss-dev-checkout-actions {
+  display: flex;
+  gap: 8px;
+}
 .ss-detail-label {
   font-size: 11px; text-transform: uppercase;
   letter-spacing: 0.18em; font-weight: 700;


### PR DESCRIPTION
## Summary

Surfaces 5a's payment infrastructure in the schedule UI. Click an appointment block → detail panel now has a Payment section with status pill, amount, receipt link when paid, and a "Pay now" button that redirects to the Stripe-hosted Checkout. A dev-only simulator at \`/dev/checkout\` stands in for Stripe so the whole loop can run on localhost without leaving the box.

## API

- New \`GET /payments?appointmentIds=id1,id2,...\` returning Payment rows scoped to the current salon. Caps the input list at 200 ids per request.
- Service-side dedupe to the **highest-priority status** per appointment: \`SUCCEEDED > PARTIALLY_REFUNDED > REFUNDED > FAILED > CANCELLED > PENDING\`. Means the UI never sees a stale PENDING row hiding a successful payment from an earlier attempt.

## Web

- **Detail panel payment section**: status pill, formatted amount, "View Stripe receipt ↗" when paid, and a Pay button keyed to the latest payment's state (\"Pay now\" / \"Resume payment\" / \"Try again\").
- **Block badge**: tiny \`$\` in the corner — green when paid, cyan when pending, red on issues.
- **Return banner**: appears at top of \`/schedule\` when \`?paid=:appointmentId\` (or \`?paymentCancelled=\`) is set, with a dismiss button that does \`router.replace\` to drop the param.
- **Server action**: \`startCheckoutAction\` wraps \`POST /payments/checkout\` and finishes by redirecting to the Stripe URL via Next's \`redirect()\`. Only \"returns\" on the failure path (409 already-paid, 400 no services, etc.).

## Dev simulator

\`PAYMENT_PROVIDER=dev\` returns a URL pointing at \`/dev/checkout\` instead of stripe.com. The page reads \`sid / amount / currency / product / success / cancel\` from the query, shows a stand-in checkout, and on confirm:

1. Posts a synthetic \`checkout.session.completed\` event at \`/webhooks/stripe\` (the dev provider's \`verifyAndParseWebhook\` accepts any signature)
2. Substitutes \`{CHECKOUT_SESSION_ID}\` in the success URL the way Stripe does in production
3. Redirects the user there

404s in production so it can't be hit even if \`PAYMENT_PROVIDER\` is mistakenly set to \`dev\` there.

## Out of scope

- **Tip capture + refunds** — Phase 5c
- **SMS payment links** — needs deep-link tokens (#22)
- **Full receipt page on our domain** — Stripe's hosted receipt URL is the source of truth in 5b

## Test plan

- [x] \`pnpm --filter @shearsimp/api typecheck\` / \`test\` (57/57)
- [x] \`pnpm --filter @shearsimp/web typecheck\`
- [ ] On \`/schedule\`, click an appointment block → detail panel shows "Payment / Pay now"
- [ ] Click "Pay now" → redirected to \`/dev/checkout\`, confirm there → bounced back to \`/schedule?paid=:appointmentId&session_id=...\` with the success banner showing
- [ ] Re-open the same appointment after the webhook fires (give it ~1 sec) → status flipped to "succeeded", "View Stripe receipt" link present (will be \`null\` for dev rows since the synthetic event has no receipt URL — that's fine, the link just doesn't render)
- [ ] Block on the schedule has a green \`$\` in the corner
- [ ] Try "Pay now" again on the same appointment → 409, error message renders inline in the payment section
- [ ] Cancel from \`/dev/checkout\` → bounced back to \`/schedule?paymentCancelled=...\` with the info banner