### PR TITLE
Phase 5c: tips at checkout + full refunds via Stripe

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -239,11 +239,24 @@ PCI exposure stays minimal — Stripe-hosted surfaces only this phase.
   now embeds success/cancel URLs so the page can complete the flow with
   a real synthetic webhook event and redirect, mirroring production
 
-### Phase 5c — Tips + refunds ⬜
+### Phase 5c — Tips + refunds 🚧
 
-- Tip capture flow at checkout
-- Refund initiation + UI
-- `charge.refunded` / `charge.dispute.*` webhook handlers
+- Inline tip picker on the appointment detail panel — preset percents
+  (15 / 18 / 20 / 25) plus a custom dollar input. "Pay now" expands the
+  picker; "Confirm" creates the Stripe Checkout Session with a separate
+  "Tip" line item so the customer sees the breakdown on the receipt.
+- `Payment.amountCents` stores the services subtotal; `tipCents` is the
+  breakdown. Total charged = `amountCents + tipCents`.
+- Refund button on SUCCEEDED payments — `POST /payments/:id/refund`,
+  inline DB update for instant UI feedback, and `charge.refunded`
+  webhook for Stripe-side confirmation (idempotent against the inline
+  update).
+- `charge.refunded` updates `refundedCents` and flips status to
+  `REFUNDED` (full) or `PARTIALLY_REFUNDED` (partial).
+- 5c MVP supports full refunds via UI; partial refunds work end-to-end
+  but the picker is full-only. Partial-refund UI is a follow-up.
+- Disputes (`charge.dispute.*`) intentionally not handled — needs a new
+  `DISPUTED` status on `PaymentStatus`. Tracked separately.
 
 **Single platform Stripe account for now.** Migration to Stripe Connect (per-salon merchant accounts, platform fee on each charge) tracked as [#18](https://github.com/jnoecker/ShearSimplicity/issues/18) — not on the critical path until a salon needs their own merchant account.
 

--- a/apps/api/src/payments/dev-payment.provider.ts
+++ b/apps/api/src/payments/dev-payment.provider.ts
@@ -6,6 +6,8 @@ import type {
   CreateCheckoutSessionResult,
   ParsedWebhookEvent,
   PaymentProvider,
+  RefundArgs,
+  RefundResult,
 } from "./payment-provider.interface";
 
 /**
@@ -33,8 +35,10 @@ export class DevPaymentProvider implements PaymentProvider {
       throw new Error("DevPaymentProvider must not run in production");
     }
     const sid = `dev_cs_${randomUUID()}`;
+    const tipCents = args.tipCents ?? 0;
+    const totalCents = args.amountCents + tipCents;
     this.logger.log(
-      `[dev-checkout] sid=${sid} amount=${args.amountCents} ${args.currency} product=${JSON.stringify(args.productName)} success=${args.successUrl}`,
+      `[dev-checkout] sid=${sid} subtotal=${args.amountCents} tip=${tipCents} total=${totalCents} ${args.currency} product=${JSON.stringify(args.productName)} success=${args.successUrl}`,
     );
     // The dev URL points at the simulator at apps/web/src/app/dev/checkout.
     // We embed the success / cancel URLs so the simulator can finish the
@@ -42,7 +46,9 @@ export class DevPaymentProvider implements PaymentProvider {
     // happens in the simulator, mirroring what Stripe does in production.
     const params = new URLSearchParams({
       sid,
-      amount: String(args.amountCents),
+      amount: String(totalCents),
+      subtotal: String(args.amountCents),
+      tip: String(tipCents),
       currency: args.currency,
       product: args.productName,
       success: args.successUrl,
@@ -50,6 +56,21 @@ export class DevPaymentProvider implements PaymentProvider {
     });
     const url = `${env.WEB_ORIGIN}/dev/checkout?${params.toString()}`;
     return { providerSessionId: sid, url };
+  }
+
+  async refundPayment(args: RefundArgs): Promise<RefundResult> {
+    if (env.NODE_ENV === "production") {
+      throw new Error("DevPaymentProvider must not run in production");
+    }
+    const refundId = `dev_re_${randomUUID()}`;
+    this.logger.log(
+      `[dev-refund] refundId=${refundId} target=${args.providerPaymentId} amount=${args.amountCents ?? "full"}`,
+    );
+    return {
+      providerRefundId: refundId,
+      status: "succeeded",
+      amountCents: args.amountCents ?? 0,
+    };
   }
 
   verifyAndParseWebhook(rawBody: Buffer, _signature: string): ParsedWebhookEvent {

--- a/apps/api/src/payments/payment-provider.interface.ts
+++ b/apps/api/src/payments/payment-provider.interface.ts
@@ -3,7 +3,11 @@ export const PAYMENT_PROVIDER = Symbol("PaymentProvider");
 export interface CreateCheckoutSessionArgs {
   /** Our internal Payment.id; passed to the provider as their idempotency key. */
   idempotencyKey: string;
+  /** Subtotal — the services portion only, no tip. */
   amountCents: number;
+  /** Optional gratuity. Rendered as a separate line item on the checkout
+   *  page + receipt so customers can see what they tipped. Defaults to 0. */
+  tipCents?: number;
   currency: string;
   /** Where Stripe redirects on success / cancel. The provider may append
    *  query params (e.g. session_id) — both URLs end up in the user's browser. */
@@ -20,6 +24,23 @@ export interface CreateCheckoutSessionArgs {
 export interface CreateCheckoutSessionResult {
   providerSessionId: string;
   url: string;
+}
+
+export interface RefundArgs {
+  /** The provider's payment-intent id (or session id when intent isn't yet
+   *  known — Stripe is happy with either for refunds). */
+  providerPaymentId: string;
+  /** Optional partial-refund amount. Omit for a full refund. */
+  amountCents?: number;
+  /** Idempotency key — typically a uuid scoped to one refund attempt. */
+  idempotencyKey: string;
+}
+
+export interface RefundResult {
+  providerRefundId: string;
+  /** Stripe-reported refund status: succeeded / pending / failed. */
+  status: "succeeded" | "pending" | "failed" | "canceled" | "requires_action";
+  amountCents: number;
 }
 
 export interface ParsedWebhookEvent {
@@ -46,5 +67,6 @@ export interface PaymentProvider {
   createCheckoutSession(
     args: CreateCheckoutSessionArgs,
   ): Promise<CreateCheckoutSessionResult>;
+  refundPayment(args: RefundArgs): Promise<RefundResult>;
   verifyAndParseWebhook(rawBody: Buffer, signature: string): ParsedWebhookEvent;
 }

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -3,11 +3,18 @@ import {
   Body,
   Controller,
   Get,
+  Param,
   Post,
   Query,
 } from "@nestjs/common";
-import { checkoutCreateSchema } from "@shearsimp/shared";
-import type { CheckoutCreateInput } from "@shearsimp/shared";
+import {
+  checkoutCreateSchema,
+  refundCreateSchema,
+} from "@shearsimp/shared";
+import type {
+  CheckoutCreateInput,
+  RefundCreateInput,
+} from "@shearsimp/shared";
 import { CurrentSalon } from "../tenant/current-salon.decorator";
 import { CurrentUser } from "../auth/current-user.decorator";
 import type {
@@ -75,5 +82,23 @@ export class PaymentsController {
       user.userId,
       input,
     );
+  }
+
+  // POST /payments/:id/refund: issues a refund against a SUCCEEDED
+  // payment. Body is empty for a full refund or { amountCents } for
+  // partial. The charge.refunded webhook updates status idempotently
+  // shortly after; the inline update lets the UI flip immediately.
+  @Post(":id/refund")
+  async refund(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id") id: string,
+    @Body(new ZodValidationPipe(refundCreateSchema))
+    input: RefundCreateInput,
+  ): Promise<{ providerRefundId: string; refundedCents: number }> {
+    if (!UUID_RE.test(id)) {
+      throw new BadRequestException(`"${id}" is not a valid UUID`);
+    }
+    return this.payments.refund(salon.salonId, user.userId, id, input);
   }
 }

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -22,10 +22,18 @@ import {
 
 export interface CreateCheckoutInput {
   appointmentId: string;
+  /** Optional gratuity in cents — added as a separate line item on the
+   *  Stripe-hosted page and persisted as Payment.tipCents. */
+  tipCents?: number;
   /** Optional override of the post-payment redirect; falls back to a route on
    *  WEB_ORIGIN that the frontend handles. Stripe requires both URLs. */
   successUrl?: string;
   cancelUrl?: string;
+}
+
+export interface RefundInput {
+  /** Optional partial-refund amount in cents. Omit for a full refund. */
+  amountCents?: number;
 }
 
 const APPOINTMENT_INCLUDE = {
@@ -71,6 +79,8 @@ export class PaymentsService {
         appointmentId: true,
         status: true,
         amountCents: true,
+        tipCents: true,
+        refundedCents: true,
         currency: true,
         receiptUrl: true,
         capturedAt: true,
@@ -124,10 +134,11 @@ export class PaymentsService {
       });
     }
 
-    const amountCents = appointment.services.reduce(
+    const subtotalCents = appointment.services.reduce(
       (acc, s) => acc + s.priceSnapshotCents,
       0,
     );
+    const tipCents = input.tipCents ?? 0;
     const currency = appointment.services[0]?.currencySnapshot ?? "USD";
     const productName = formatProductName(
       appointment.services.map((s) => s.serviceNameSnapshot),
@@ -149,7 +160,8 @@ export class PaymentsService {
 
     const session = await this.provider.createCheckoutSession({
       idempotencyKey: paymentId,
-      amountCents,
+      amountCents: subtotalCents,
+      tipCents,
       currency,
       successUrl,
       cancelUrl,
@@ -172,7 +184,11 @@ export class PaymentsService {
           status: PaymentStatus.PENDING,
           provider: PaymentProviderEnum.STRIPE,
           providerPaymentId: session.providerSessionId,
-          amountCents,
+          // amountCents is the subtotal (services-only). tipCents is the
+          // breakdown; the total charged is amountCents + tipCents and is
+          // computed at read time wherever the UI needs it.
+          amountCents: subtotalCents,
+          tipCents,
           currency,
           idempotencyKey: paymentId,
         },
@@ -185,7 +201,8 @@ export class PaymentsService {
           eventType: EventType.PAYMENT_CREATED,
           payload: {
             appointmentId: appointment.id,
-            amountCents,
+            amountCents: subtotalCents,
+            tipCents,
             currency,
             providerSessionId: session.providerSessionId,
           } satisfies Prisma.InputJsonValue,
@@ -195,6 +212,111 @@ export class PaymentsService {
       });
       return { url: session.url, paymentId };
     });
+  }
+
+  /**
+   * Issues a refund against a successful Payment. The webhook
+   * (`charge.refunded`) is the source of truth for refund accounting,
+   * but we update the row inline here too so the UI flips immediately
+   * — the webhook's idempotent finalize won't re-process if the values
+   * already match.
+   *
+   * 5c MVP supports only full refunds — passing `amountCents` smaller
+   * than the captured total goes to Stripe but the inline update stays
+   * conservative (status flips to PARTIALLY_REFUNDED). Partial-refund UI
+   * lives in a follow-up issue.
+   */
+  async refund(
+    salonId: string,
+    actorUserId: string,
+    paymentId: string,
+    input: RefundInput,
+  ): Promise<{ providerRefundId: string; refundedCents: number }> {
+    const payment = await this.prisma.payment.findFirst({
+      where: { id: paymentId, salonId },
+      select: {
+        id: true,
+        salonId: true,
+        appointmentId: true,
+        status: true,
+        provider: true,
+        providerPaymentId: true,
+        amountCents: true,
+        tipCents: true,
+        refundedCents: true,
+      },
+    });
+    if (!payment) throw new NotFoundException("Payment not found");
+    if (payment.status !== PaymentStatus.SUCCEEDED) {
+      throw new ConflictException({
+        message: `Cannot refund a payment in status ${payment.status}`,
+        paymentId,
+      });
+    }
+    if (!payment.providerPaymentId) {
+      // Shouldn't happen in 5a's flow — every SUCCEEDED row has a
+      // payment_intent id by the time the webhook flips it. Guard anyway
+      // so a pre-finalised state can't crash the refund call.
+      throw new ConflictException(
+        "Payment has no provider id yet; webhook hasn't finalised",
+      );
+    }
+
+    const totalCharged = payment.amountCents + payment.tipCents;
+    const requested = input.amountCents ?? totalCharged - payment.refundedCents;
+    if (requested <= 0) {
+      throw new BadRequestException("Nothing left to refund");
+    }
+    if (requested > totalCharged - payment.refundedCents) {
+      throw new BadRequestException(
+        `Refund (${requested}) exceeds remaining balance (${totalCharged - payment.refundedCents})`,
+      );
+    }
+
+    const result = await this.provider.refundPayment({
+      providerPaymentId: payment.providerPaymentId,
+      amountCents: requested,
+      // Scope idempotency to the refund attempt — Stripe will return the
+      // same refund object on retry rather than issuing a second one.
+      idempotencyKey: `${payment.id}:refund:${randomUUID()}`,
+    });
+
+    const newRefundedCents = payment.refundedCents + result.amountCents;
+    const fullyRefunded = newRefundedCents >= totalCharged;
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.payment.update({
+        where: { id: payment.id },
+        data: {
+          status: fullyRefunded
+            ? PaymentStatus.REFUNDED
+            : PaymentStatus.PARTIALLY_REFUNDED,
+          refundedCents: newRefundedCents,
+        },
+      });
+      await tx.domainEvent.create({
+        data: {
+          salonId,
+          aggregateType: "PAYMENT",
+          aggregateId: payment.id,
+          eventType: EventType.PAYMENT_REFUNDED,
+          payload: {
+            appointmentId: payment.appointmentId,
+            providerRefundId: result.providerRefundId,
+            amountCents: result.amountCents,
+            refundedCentsTotal: newRefundedCents,
+            fullyRefunded,
+          } satisfies Prisma.InputJsonValue,
+          actorType: actorUserId ? ActorType.USER : ActorType.SYSTEM,
+          actorId: actorUserId ?? null,
+        },
+      });
+    });
+
+    return {
+      providerRefundId: result.providerRefundId,
+      refundedCents: newRefundedCents,
+    };
   }
 }
 

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -1,8 +1,10 @@
 import {
+  BadGatewayException,
   BadRequestException,
   ConflictException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from "@nestjs/common";
 import {
@@ -52,6 +54,8 @@ const APPOINTMENT_INCLUDE = {
 
 @Injectable()
 export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     @Inject(PAYMENT_PROVIDER)
@@ -280,6 +284,35 @@ export class PaymentsService {
       // same refund object on retry rather than issuing a second one.
       idempotencyKey: `${payment.id}:refund:${randomUUID()}`,
     });
+
+    // Only update accounting when the provider actually returned the funds.
+    // For `pending` (typically ACH), the charge.refunded webhook will fire
+    // when the transfer settles and update the row then. For terminal
+    // failure modes we surface a 502 so the operator knows nothing
+    // happened — without this, the row would be marked REFUNDED with
+    // refundedCents bumped even though the customer hasn't been credited.
+    if (result.status !== "succeeded") {
+      if (result.status === "pending") {
+        this.logger.log(
+          `Refund ${result.providerRefundId} on Payment ${payment.id} is pending; charge.refunded webhook will finalise.`,
+        );
+        return {
+          providerRefundId: result.providerRefundId,
+          refundedCents: payment.refundedCents,
+        };
+      }
+      // failed / canceled / requires_action — refund did not (yet) move
+      // any money. Surface to the caller so they don't think the
+      // customer was credited.
+      this.logger.warn(
+        `Refund ${result.providerRefundId} on Payment ${payment.id} returned status=${result.status}; no accounting update.`,
+      );
+      throw new BadGatewayException({
+        message: `Refund did not complete (status: ${result.status})`,
+        refundStatus: result.status,
+        providerRefundId: result.providerRefundId,
+      });
+    }
 
     const newRefundedCents = payment.refundedCents + result.amountCents;
     const fullyRefunded = newRefundedCents >= totalCharged;

--- a/apps/api/src/payments/stripe-payment.provider.ts
+++ b/apps/api/src/payments/stripe-payment.provider.ts
@@ -6,6 +6,8 @@ import type {
   CreateCheckoutSessionResult,
   ParsedWebhookEvent,
   PaymentProvider,
+  RefundArgs,
+  RefundResult,
 } from "./payment-provider.interface";
 
 /**
@@ -37,19 +39,35 @@ export class StripePaymentProvider implements PaymentProvider {
   async createCheckoutSession(
     args: CreateCheckoutSessionArgs,
   ): Promise<CreateCheckoutSessionResult> {
+    const tipCents = args.tipCents ?? 0;
+    const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [
+      {
+        quantity: 1,
+        price_data: {
+          currency: args.currency.toLowerCase(),
+          unit_amount: args.amountCents,
+          product_data: { name: args.productName },
+        },
+      },
+    ];
+    if (tipCents > 0) {
+      // Render tip as its own line item so the customer sees the breakdown
+      // on the Stripe-hosted checkout page and on the receipt. The
+      // PaymentIntent we get back is for the sum (services + tip).
+      lineItems.push({
+        quantity: 1,
+        price_data: {
+          currency: args.currency.toLowerCase(),
+          unit_amount: tipCents,
+          product_data: { name: "Tip" },
+        },
+      });
+    }
+
     const session = await this.client.checkout.sessions.create(
       {
         mode: "payment",
-        line_items: [
-          {
-            quantity: 1,
-            price_data: {
-              currency: args.currency.toLowerCase(),
-              unit_amount: args.amountCents,
-              product_data: { name: args.productName },
-            },
-          },
-        ],
+        line_items: lineItems,
         success_url: args.successUrl,
         cancel_url: args.cancelUrl,
         customer_email: args.customerEmail,
@@ -75,9 +93,29 @@ export class StripePaymentProvider implements PaymentProvider {
       );
     }
     this.logger.log(
-      `Created Stripe Checkout Session sid=${session.id} amount=${args.amountCents} ${args.currency}`,
+      `Created Stripe Checkout Session sid=${session.id} subtotal=${args.amountCents} tip=${tipCents} ${args.currency}`,
     );
     return { providerSessionId: session.id, url: session.url };
+  }
+
+  async refundPayment(args: RefundArgs): Promise<RefundResult> {
+    const refund = await this.client.refunds.create(
+      {
+        payment_intent: args.providerPaymentId,
+        ...(args.amountCents !== undefined
+          ? { amount: args.amountCents }
+          : {}),
+      },
+      { idempotencyKey: args.idempotencyKey },
+    );
+    this.logger.log(
+      `Issued Stripe refund id=${refund.id} target=${args.providerPaymentId} amount=${refund.amount} status=${refund.status}`,
+    );
+    return {
+      providerRefundId: refund.id,
+      status: (refund.status ?? "pending") as RefundResult["status"],
+      amountCents: refund.amount,
+    };
   }
 
   verifyAndParseWebhook(rawBody: Buffer, signature: string): ParsedWebhookEvent {

--- a/apps/api/src/webhooks/stripe-webhook.service.ts
+++ b/apps/api/src/webhooks/stripe-webhook.service.ts
@@ -26,6 +26,15 @@ interface PaymentIntentPayload {
   metadata?: Record<string, string | undefined> | null;
 }
 
+interface ChargePayload {
+  id: string;
+  payment_intent?: string | null;
+  amount?: number | null;
+  amount_refunded?: number | null;
+  refunded?: boolean | null;
+  metadata?: Record<string, string | undefined> | null;
+}
+
 /**
  * Applies a verified Stripe event to our Payment rows. Wraps each handler
  * in a transaction that:
@@ -35,7 +44,8 @@ interface PaymentIntentPayload {
  * The (source, externalEventId) unique constraint makes Stripe re-deliveries
  * a no-op — a P2002 from the insert means we've seen this event before.
  *
- * Refunds + disputes intentionally skipped — those land in 5c.
+ * Disputes (charge.dispute.*) intentionally skipped — those land in
+ * a follow-up that needs a DISPUTED status on PaymentStatus.
  */
 @Injectable()
 export class StripeWebhookService {
@@ -212,6 +222,79 @@ export class StripeWebhookService {
             status: PaymentStatus.FAILED,
             failureReason:
               intent.last_payment_error?.message?.slice(0, 500) ?? null,
+          },
+        });
+        return;
+      }
+
+      case "charge.refunded": {
+        const charge = unwrap<ChargePayload>(event.data);
+        if (!charge?.id) {
+          this.logger.warn(
+            `Stripe charge.refunded event ${event.id} missing charge id — skipping`,
+          );
+          return;
+        }
+        const refundedTotal = charge.amount_refunded ?? 0;
+        if (refundedTotal <= 0) {
+          // Either a stub event or a refund of $0 (which Stripe rejects
+          // upstream anyway). Nothing to do.
+          return;
+        }
+
+        // Match on the payment_intent id we previously stored on the
+        // Payment row when checkout.session.completed fired.
+        const intentId = charge.payment_intent ?? null;
+        const payment = intentId
+          ? await tx.payment.findFirst({
+              where: { provider: "STRIPE", providerPaymentId: intentId },
+              select: {
+                id: true,
+                salonId: true,
+                appointmentId: true,
+                amountCents: true,
+                tipCents: true,
+                refundedCents: true,
+              },
+            })
+          : null;
+        if (!payment) {
+          this.logger.warn(
+            `Stripe charge.refunded for intent ${intentId ?? "?"} has no matching Payment row — skipping`,
+          );
+          return;
+        }
+        if (refundedTotal <= payment.refundedCents) {
+          // Already accounted for (refund-then-webhook ordering, or a
+          // re-delivery that beat us to the punch). Nothing to do.
+          return;
+        }
+
+        const totalCharged = payment.amountCents + payment.tipCents;
+        const fullyRefunded = refundedTotal >= totalCharged;
+        await tx.payment.update({
+          where: { id: payment.id },
+          data: {
+            status: fullyRefunded
+              ? PaymentStatus.REFUNDED
+              : PaymentStatus.PARTIALLY_REFUNDED,
+            refundedCents: refundedTotal,
+          },
+        });
+        await tx.domainEvent.create({
+          data: {
+            salonId: payment.salonId,
+            aggregateType: "PAYMENT",
+            aggregateId: payment.id,
+            eventType: EventType.PAYMENT_REFUNDED,
+            payload: {
+              appointmentId: payment.appointmentId,
+              chargeId: charge.id,
+              refundedCentsTotal: refundedTotal,
+              fullyRefunded,
+              source: "webhook",
+            } satisfies Prisma.InputJsonValue,
+            actorType: ActorType.WEBHOOK,
           },
         });
         return;

--- a/apps/api/test/payments-service.test.ts
+++ b/apps/api/test/payments-service.test.ts
@@ -388,4 +388,65 @@ describe("PaymentsService.refund", () => {
       service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {}),
     ).rejects.toMatchObject({ status: 404 });
   });
+
+  it("does not update Payment when the provider returns pending (ACH-style)", async () => {
+    const { service, paymentUpdate, domainEventCreate } = buildService({
+      refundTargetPayment: {
+        id: PAYMENT_ID,
+        salonId: SALON_ID,
+        appointmentId: APPOINTMENT_ID,
+        status: PaymentStatus.SUCCEEDED,
+        provider: "STRIPE",
+        providerPaymentId: "pi_test_456",
+        amountCents: 11000,
+        tipCents: 0,
+        refundedCents: 0,
+      },
+      refundProviderResult: {
+        providerRefundId: "re_test_pending",
+        status: "pending",
+        amountCents: 11000,
+      },
+    });
+
+    const result = await service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {});
+
+    expect(result).toMatchObject({
+      providerRefundId: "re_test_pending",
+      // Status didn't actually settle — the row's refundedCents stays
+      // at the pre-call value. The charge.refunded webhook will catch
+      // up when the funds move.
+      refundedCents: 0,
+    });
+    expect(paymentUpdate).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  it("throws 502 (no Payment update) when the provider returns failed", async () => {
+    const { service, paymentUpdate, domainEventCreate } = buildService({
+      refundTargetPayment: {
+        id: PAYMENT_ID,
+        salonId: SALON_ID,
+        appointmentId: APPOINTMENT_ID,
+        status: PaymentStatus.SUCCEEDED,
+        provider: "STRIPE",
+        providerPaymentId: "pi_test_456",
+        amountCents: 11000,
+        tipCents: 0,
+        refundedCents: 0,
+      },
+      refundProviderResult: {
+        providerRefundId: "re_test_failed",
+        status: "failed",
+        amountCents: 0,
+      },
+    });
+
+    await expect(
+      service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {}),
+    ).rejects.toMatchObject({ status: 502 });
+
+    expect(paymentUpdate).not.toHaveBeenCalled();
+    expect(domainEventCreate).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/test/payments-service.test.ts
+++ b/apps/api/test/payments-service.test.ts
@@ -3,6 +3,8 @@ import { PaymentStatus } from "@prisma/client";
 import { PaymentsService } from "../src/payments/payments.service";
 import type { PaymentProvider } from "../src/payments/payment-provider.interface";
 
+const PAYMENT_ID = "00000000-0000-0000-0000-0000000000e1";
+
 const SALON_ID = "00000000-0000-0000-0000-000000000a01";
 const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000b01";
 const ACTOR_ID = "00000000-0000-0000-0000-000000000d01";
@@ -34,29 +36,67 @@ function fakeAppointment(overrides: Partial<{
 function buildService({
   appointment = fakeAppointment(),
   alreadyPaidPayment = null,
+  refundTargetPayment = null,
+  refundProviderResult = {
+    providerRefundId: "re_dev_123",
+    status: "succeeded" as const,
+    amountCents: 0,
+  },
 }: {
   appointment?: ReturnType<typeof fakeAppointment> | null;
   alreadyPaidPayment?: { id: string } | null;
+  /** Used by .refund() — the row returned by the lookup-before-call. */
+  refundTargetPayment?: {
+    id: string;
+    salonId: string;
+    appointmentId: string;
+    status: PaymentStatus;
+    provider: "STRIPE";
+    providerPaymentId: string | null;
+    amountCents: number;
+    tipCents: number;
+    refundedCents: number;
+  } | null;
+  refundProviderResult?: {
+    providerRefundId: string;
+    status: "succeeded" | "pending" | "failed" | "canceled" | "requires_action";
+    amountCents: number;
+  };
 } = {}) {
   const createCheckoutSession = vi.fn().mockResolvedValue({
     providerSessionId: "cs_test_dev_123",
     url: "https://stripe.test/cs_test_dev_123",
   });
+  const refundPayment = vi.fn().mockResolvedValue(refundProviderResult);
   const provider: PaymentProvider = {
     createCheckoutSession,
+    refundPayment,
     verifyAndParseWebhook: vi.fn(),
   };
 
   const paymentCreate = vi.fn().mockResolvedValue({});
+  const paymentUpdate = vi.fn().mockResolvedValue({});
   const domainEventCreate = vi.fn().mockResolvedValue({});
+
+  // findFirst is called once for "is there a SUCCEEDED payment for this
+  // appointment already?" in the create-checkout flow, and once for "load
+  // the target payment" in the refund flow. We hand back different rows
+  // per call site by making the mock context-aware.
+  const paymentFindFirst = vi
+    .fn()
+    .mockImplementation(async (args: { where?: { id?: string; status?: string } }) => {
+      if (args.where?.id) return refundTargetPayment;
+      return alreadyPaidPayment;
+    });
 
   const prisma = {
     appointment: {
       findFirst: vi.fn().mockResolvedValue(appointment),
     },
     payment: {
-      findFirst: vi.fn().mockResolvedValue(alreadyPaidPayment),
+      findFirst: paymentFindFirst,
       create: paymentCreate,
+      update: paymentUpdate,
     },
     domainEvent: {
       create: domainEventCreate,
@@ -68,7 +108,15 @@ function buildService({
   const prismaInstance = prisma;
 
   const service = new PaymentsService(prisma as never, provider);
-  return { service, provider, createCheckoutSession, paymentCreate, domainEventCreate };
+  return {
+    service,
+    provider,
+    createCheckoutSession,
+    refundPayment,
+    paymentCreate,
+    paymentUpdate,
+    domainEventCreate,
+  };
 }
 
 describe("PaymentsService.createCheckoutForAppointment", () => {
@@ -88,6 +136,7 @@ describe("PaymentsService.createCheckoutForAppointment", () => {
     expect(createCheckoutSession).toHaveBeenCalledTimes(1);
     const sessionCall = createCheckoutSession.mock.calls[0]![0];
     expect(sessionCall.amountCents).toBe(11000);
+    expect(sessionCall.tipCents).toBe(0);
     expect(sessionCall.currency).toBe("USD");
     expect(sessionCall.idempotencyKey).toBe(result.paymentId);
     expect(sessionCall.metadata).toMatchObject({
@@ -104,6 +153,7 @@ describe("PaymentsService.createCheckoutForAppointment", () => {
       status: PaymentStatus.PENDING,
       providerPaymentId: "cs_test_dev_123",
       amountCents: 11000,
+      tipCents: 0,
       idempotencyKey: result.paymentId,
     });
 
@@ -185,5 +235,157 @@ describe("PaymentsService.createCheckoutForAppointment", () => {
     ).rejects.toMatchObject({ status: 400 });
 
     expect(createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("forwards tipCents to the provider and persists it on the row", async () => {
+    const { service, createCheckoutSession, paymentCreate, domainEventCreate } =
+      buildService();
+
+    await service.createCheckoutForAppointment(SALON_ID, ACTOR_ID, {
+      appointmentId: APPOINTMENT_ID,
+      tipCents: 1500,
+    });
+
+    expect(createCheckoutSession.mock.calls[0]![0].tipCents).toBe(1500);
+    // Subtotal stays at 11000; tipCents is the breakdown.
+    expect(createCheckoutSession.mock.calls[0]![0].amountCents).toBe(11000);
+    expect(paymentCreate.mock.calls[0]![0].data).toMatchObject({
+      amountCents: 11000,
+      tipCents: 1500,
+    });
+    expect(domainEventCreate.mock.calls[0]![0].data.payload).toMatchObject({
+      amountCents: 11000,
+      tipCents: 1500,
+    });
+  });
+});
+
+describe("PaymentsService.refund", () => {
+  it("issues a full refund on a SUCCEEDED payment, updates the row, emits payment.refunded", async () => {
+    const { service, refundPayment, paymentUpdate, domainEventCreate } =
+      buildService({
+        refundTargetPayment: {
+          id: PAYMENT_ID,
+          salonId: SALON_ID,
+          appointmentId: APPOINTMENT_ID,
+          status: PaymentStatus.SUCCEEDED,
+          provider: "STRIPE",
+          providerPaymentId: "pi_test_456",
+          amountCents: 11000,
+          tipCents: 1500,
+          refundedCents: 0,
+        },
+        refundProviderResult: {
+          providerRefundId: "re_test_777",
+          status: "succeeded",
+          amountCents: 12500, // requested = remaining (11000 + 1500)
+        },
+      });
+
+    const result = await service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {});
+
+    expect(refundPayment).toHaveBeenCalledTimes(1);
+    expect(refundPayment.mock.calls[0]![0]).toMatchObject({
+      providerPaymentId: "pi_test_456",
+      amountCents: 12500,
+    });
+    expect(refundPayment.mock.calls[0]![0].idempotencyKey).toMatch(
+      new RegExp(`^${PAYMENT_ID}:refund:`),
+    );
+    expect(result).toMatchObject({
+      providerRefundId: "re_test_777",
+      refundedCents: 12500,
+    });
+    expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: PaymentStatus.REFUNDED,
+      refundedCents: 12500,
+    });
+    expect(domainEventCreate.mock.calls[0]![0].data.eventType).toBe(
+      "payment.refunded",
+    );
+  });
+
+  it("flips to PARTIALLY_REFUNDED when the requested amount is below the remaining balance", async () => {
+    const { service, paymentUpdate, refundPayment } = buildService({
+      refundTargetPayment: {
+        id: PAYMENT_ID,
+        salonId: SALON_ID,
+        appointmentId: APPOINTMENT_ID,
+        status: PaymentStatus.SUCCEEDED,
+        provider: "STRIPE",
+        providerPaymentId: "pi_test_456",
+        amountCents: 11000,
+        tipCents: 0,
+        refundedCents: 0,
+      },
+      refundProviderResult: {
+        providerRefundId: "re_test_partial",
+        status: "succeeded",
+        amountCents: 5000,
+      },
+    });
+
+    await service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {
+      amountCents: 5000,
+    });
+
+    expect(refundPayment.mock.calls[0]![0].amountCents).toBe(5000);
+    expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+      status: PaymentStatus.PARTIALLY_REFUNDED,
+      refundedCents: 5000,
+    });
+  });
+
+  it("409s when the payment isn't SUCCEEDED yet", async () => {
+    const { service, refundPayment } = buildService({
+      refundTargetPayment: {
+        id: PAYMENT_ID,
+        salonId: SALON_ID,
+        appointmentId: APPOINTMENT_ID,
+        status: PaymentStatus.PENDING,
+        provider: "STRIPE",
+        providerPaymentId: null,
+        amountCents: 11000,
+        tipCents: 0,
+        refundedCents: 0,
+      },
+    });
+
+    await expect(
+      service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {}),
+    ).rejects.toMatchObject({ status: 409 });
+
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("400s when the requested refund exceeds the remaining balance", async () => {
+    const { service, refundPayment } = buildService({
+      refundTargetPayment: {
+        id: PAYMENT_ID,
+        salonId: SALON_ID,
+        appointmentId: APPOINTMENT_ID,
+        status: PaymentStatus.SUCCEEDED,
+        provider: "STRIPE",
+        providerPaymentId: "pi_test_456",
+        amountCents: 11000,
+        tipCents: 0,
+        refundedCents: 0,
+      },
+    });
+
+    await expect(
+      service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {
+        amountCents: 999_999,
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(refundPayment).not.toHaveBeenCalled();
+  });
+
+  it("404s when the payment doesn't exist in the salon", async () => {
+    const { service } = buildService({ refundTargetPayment: null });
+    await expect(
+      service.refund(SALON_ID, ACTOR_ID, PAYMENT_ID, {}),
+    ).rejects.toMatchObject({ status: 404 });
   });
 });

--- a/apps/api/test/stripe-webhook.test.ts
+++ b/apps/api/test/stripe-webhook.test.ts
@@ -14,6 +14,7 @@ function buildService({
     status: PaymentStatus.PENDING,
     appointmentId: APPOINTMENT_ID,
   },
+  refundLookupPayment,
   otherSucceededPayment = null,
   processedThrows = null,
 }: {
@@ -22,6 +23,17 @@ function buildService({
     salonId: string;
     status: PaymentStatus;
     appointmentId: string | null;
+  } | null;
+  /** Used by charge.refunded — the row matched by payment_intent id with
+   *  the extra fields (amountCents, tipCents, refundedCents) the handler
+   *  needs to compute fully-vs-partially-refunded. */
+  refundLookupPayment?: {
+    id: string;
+    salonId: string;
+    appointmentId: string | null;
+    amountCents: number;
+    tipCents: number;
+    refundedCents: number;
   } | null;
   /** Another row that has already SUCCEEDED for the same appointment —
    *  used to drive the duplicate-charge defence-in-depth path. */
@@ -36,10 +48,23 @@ function buildService({
   //   1. to find the Payment row matching the session.id
   //   2. to check whether ANOTHER SUCCEEDED row exists for the appointment
   // The second call is gated on `succeeded && payment.appointmentId`.
+  // For charge.refunded we use refundLookupPayment in the first call and
+  // ignore the second.
   const paymentFindFirst = vi
     .fn()
-    .mockResolvedValueOnce(payment)
-    .mockResolvedValue(otherSucceededPayment);
+    .mockImplementation(async (args: { where?: Record<string, unknown> }) => {
+      // The refund handler queries for { provider, providerPaymentId };
+      // the success handler queries the same the first time and then a
+      // different shape (NOT + status) for the dup-check.
+      if (args.where && "NOT" in args.where) {
+        return otherSucceededPayment;
+      }
+      // First call from either handler. Tri-state: explicit `null` →
+      // "no Payment matches" path (refund test); object → use that;
+      // undefined → fall back to the success-handler default.
+      if (refundLookupPayment !== undefined) return refundLookupPayment;
+      return payment;
+    });
   const paymentUpdate = vi.fn().mockResolvedValue({});
   const domainEventCreate = vi.fn().mockResolvedValue({});
 
@@ -209,16 +234,105 @@ describe("StripeWebhookService", () => {
     expect(paymentUpdate).not.toHaveBeenCalled();
   });
 
-  it("ignores unhandled event types (refunds, disputes — deferred to 5c)", async () => {
+  it("ignores unhandled event types (disputes — deferred)", async () => {
     const { service, paymentUpdate, domainEventCreate } = buildService();
 
     await service.process({
-      id: "evt_refund_1",
-      type: "charge.refunded",
-      data: { object: { id: "ch_x" } },
+      id: "evt_dispute_1",
+      type: "charge.dispute.created",
+      data: { object: { id: "du_x" } },
     });
 
     expect(paymentUpdate).not.toHaveBeenCalled();
     expect(domainEventCreate).not.toHaveBeenCalled();
+  });
+
+  describe("charge.refunded", () => {
+    const refundEvent = (overrides: {
+      amount_refunded: number;
+      payment_intent?: string;
+    }) => ({
+      id: `evt_refund_${overrides.amount_refunded}`,
+      type: "charge.refunded",
+      data: {
+        object: {
+          id: "ch_test_001",
+          payment_intent: overrides.payment_intent ?? "pi_test_456",
+          amount: 12500,
+          amount_refunded: overrides.amount_refunded,
+        },
+      },
+    });
+
+    it("flips to REFUNDED when fully refunded and emits payment.refunded", async () => {
+      const { service, paymentUpdate, domainEventCreate } = buildService({
+        refundLookupPayment: {
+          id: "pay-1",
+          salonId: SALON_ID,
+          appointmentId: APPOINTMENT_ID,
+          amountCents: 11000,
+          tipCents: 1500,
+          refundedCents: 0,
+        },
+      });
+
+      await service.process(refundEvent({ amount_refunded: 12500 }));
+
+      expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+        status: PaymentStatus.REFUNDED,
+        refundedCents: 12500,
+      });
+      expect(domainEventCreate.mock.calls[0]![0].data.eventType).toBe(
+        "payment.refunded",
+      );
+    });
+
+    it("flips to PARTIALLY_REFUNDED when only some money came back", async () => {
+      const { service, paymentUpdate } = buildService({
+        refundLookupPayment: {
+          id: "pay-1",
+          salonId: SALON_ID,
+          appointmentId: APPOINTMENT_ID,
+          amountCents: 11000,
+          tipCents: 0,
+          refundedCents: 0,
+        },
+      });
+
+      await service.process(refundEvent({ amount_refunded: 5000 }));
+
+      expect(paymentUpdate.mock.calls[0]![0].data).toMatchObject({
+        status: PaymentStatus.PARTIALLY_REFUNDED,
+        refundedCents: 5000,
+      });
+    });
+
+    it("no-ops when the refund total is already accounted for (race / re-delivery)", async () => {
+      const { service, paymentUpdate, domainEventCreate } = buildService({
+        refundLookupPayment: {
+          id: "pay-1",
+          salonId: SALON_ID,
+          appointmentId: APPOINTMENT_ID,
+          amountCents: 11000,
+          tipCents: 0,
+          refundedCents: 11000,
+        },
+      });
+
+      await service.process(refundEvent({ amount_refunded: 11000 }));
+
+      expect(paymentUpdate).not.toHaveBeenCalled();
+      expect(domainEventCreate).not.toHaveBeenCalled();
+    });
+
+    it("logs and skips when no Payment matches the payment_intent", async () => {
+      const { service, paymentUpdate } = buildService({
+        refundLookupPayment: null,
+      });
+
+      await service.process(refundEvent({ amount_refunded: 12500 }));
+
+      expect(paymentUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -143,12 +143,14 @@ export async function cancelAppointment(input: {
 
 /**
  * Server action wrapper for the checkout flow. Calls the API to create a
- * Stripe Checkout Session for an appointment, then routes the user to the
- * returned URL via Next's redirect() — which throws a special control-flow
- * exception, so this function "returns" only on the failure path.
+ * Stripe Checkout Session for an appointment (with optional tip), then
+ * routes the user to the returned URL via Next's redirect() — which
+ * throws a special control-flow exception, so this function "returns"
+ * only on the failure path.
  */
 export async function startCheckoutAction(
   appointmentId: string,
+  tipCents = 0,
 ): Promise<ActionResult> {
   let url: string;
   try {
@@ -156,7 +158,7 @@ export async function startCheckoutAction(
       "/payments/checkout",
       {
         method: "POST",
-        data: { appointmentId },
+        data: { appointmentId, tipCents: tipCents > 0 ? tipCents : undefined },
       },
     );
     url = res.url;
@@ -166,4 +168,19 @@ export async function startCheckoutAction(
   // redirect() throws — must be outside the try / catch so Next's
   // NEXT_REDIRECT control-flow exception isn't swallowed by `fail()`.
   redirect(url);
+}
+
+export async function refundPaymentAction(
+  paymentId: string,
+): Promise<ActionResult> {
+  try {
+    await apiFetch(`/payments/${paymentId}/refund`, {
+      method: "POST",
+      data: {},
+    });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
 }

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -12,6 +12,7 @@ import {
 import {
   cancelAppointment,
   completeAppointment,
+  refundPaymentAction,
   rescheduleAppointment,
   startCheckoutAction,
   transitionAppointment,
@@ -53,6 +54,8 @@ export interface ScheduleService {
 export interface ScheduleAppointmentService {
   serviceId: string;
   serviceNameSnapshot: string;
+  priceSnapshotCents: number;
+  currencySnapshot: string;
 }
 
 export interface ScheduleAppointment {
@@ -86,7 +89,13 @@ export interface SchedulePayment {
   id: string;
   appointmentId: string;
   status: SchedulePaymentStatus;
+  /** Subtotal in cents (services only). */
   amountCents: number;
+  /** Gratuity in cents. The total charged is amountCents + tipCents. */
+  tipCents: number;
+  /** Refunded so far. 0 when status is anything other than REFUNDED /
+   *  PARTIALLY_REFUNDED. */
+  refundedCents: number;
   currency: string;
   receiptUrl: string | null;
   capturedAt: string | null;
@@ -702,10 +711,7 @@ function DetailsPanel({
           <p>{appointment.internalNotes}</p>
         </div>
       )}
-      <PaymentSection
-        appointmentId={appointment.id}
-        payment={payment}
-      />
+      <PaymentSection appointment={appointment} payment={payment} />
       <div className="ss-detail-actions">
         {advanceTarget.map((t) => (
           <button
@@ -757,50 +763,109 @@ function DetailsPanel({
   );
 }
 
+// Tip presets shown when the user expands the "Pay now" UI. Custom is the
+// escape hatch — anything from $0 up to the API's $1000 cap.
+const TIP_PRESETS = [
+  { label: "No tip", percent: 0 },
+  { label: "15%", percent: 15 },
+  { label: "18%", percent: 18 },
+  { label: "20%", percent: 20 },
+  { label: "25%", percent: 25 },
+] as const;
+
 function PaymentSection({
-  appointmentId,
+  appointment,
   payment,
 }: {
-  appointmentId: string;
+  appointment: ScheduleAppointment;
   payment: SchedulePayment | null;
 }) {
-  // The startCheckoutAction server action redirects via redirect() — it
-  // throws NEXT_REDIRECT on success, so this state only flips back when
-  // the API rejects (already paid → 409, missing services → 400).
+  const subtotalCents = useMemo(
+    () =>
+      appointment.services.reduce((acc, s) => acc + s.priceSnapshotCents, 0),
+    [appointment.services],
+  );
+  const currency =
+    payment?.currency ??
+    appointment.services[0]?.currencySnapshot ??
+    "USD";
+
   const [submitting, setSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  // null when the tip picker is collapsed; a number (0 = "no tip") when
+  // the user has expanded it but not yet confirmed. Keeps "Pay now" as a
+  // single tap when the tip step is visible vs. surfacing it inline.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [tipPresetIndex, setTipPresetIndex] = useState<number>(2); // default 18%
+  const [customTipDollars, setCustomTipDollars] = useState<string>("");
+  const [customMode, setCustomMode] = useState(false);
 
-  async function pay() {
+  const tipCents = customMode
+    ? Math.max(0, Math.round(Number(customTipDollars || "0") * 100))
+    : Math.round(
+        (subtotalCents * (TIP_PRESETS[tipPresetIndex]?.percent ?? 0)) / 100,
+      );
+  const totalCents = subtotalCents + tipCents;
+
+  const succeeded = payment?.status === "SUCCEEDED";
+  const refunded =
+    payment?.status === "REFUNDED" ||
+    payment?.status === "PARTIALLY_REFUNDED";
+  const failed = payment?.status === "FAILED" || payment?.status === "CANCELLED";
+  const pending = payment?.status === "PENDING";
+  const canRefund = succeeded && payment !== null;
+
+  async function confirmAndPay() {
     setSubmitting(true);
     setErrorMsg(null);
-    const result = await startCheckoutAction(appointmentId);
-    // If we got here, the redirect didn't fire — that means the action
-    // failed (the success path throws and never returns).
+    const result = await startCheckoutAction(appointment.id, tipCents);
+    // If we got here, the redirect didn't fire — failure path.
     setSubmitting(false);
     setErrorMsg(result.message ?? "Couldn't start checkout");
   }
 
-  const succeeded = payment?.status === "SUCCEEDED";
-  const failed =
-    payment?.status === "FAILED" ||
-    payment?.status === "CANCELLED" ||
-    payment?.status === "REFUNDED" ||
-    payment?.status === "PARTIALLY_REFUNDED";
-  const pending = payment?.status === "PENDING";
+  async function refund() {
+    if (!payment) return;
+    if (!window.confirm(`Refund ${formatPrice(payment.amountCents + payment.tipCents - payment.refundedCents, payment.currency)} to the customer? This can't be undone from here.`)) {
+      return;
+    }
+    setSubmitting(true);
+    setErrorMsg(null);
+    const result = await refundPaymentAction(payment.id);
+    setSubmitting(false);
+    if (!result.ok) {
+      setErrorMsg(result.message ?? "Refund failed");
+    }
+  }
 
   return (
     <div className="ss-detail-section ss-detail-payment">
       <div className="ss-detail-label">Payment</div>
+
       {payment && (
         <div className="ss-detail-payment-row">
           <span className={`ss-tag is-pay-${payment.status.toLowerCase()}`}>
             {payment.status.replace("_", " ").toLowerCase()}
           </span>
           <span className="ss-detail-payment-amount">
-            {formatPrice(payment.amountCents, payment.currency)}
+            {formatPrice(
+              payment.amountCents + payment.tipCents,
+              payment.currency,
+            )}
           </span>
         </div>
       )}
+      {payment && payment.tipCents > 0 && (
+        <div className="ss-detail-payment-meta">
+          Includes {formatPrice(payment.tipCents, payment.currency)} tip
+        </div>
+      )}
+      {payment && payment.refundedCents > 0 && (
+        <div className="ss-detail-payment-meta">
+          {formatPrice(payment.refundedCents, payment.currency)} refunded
+        </div>
+      )}
+
       {succeeded && payment?.receiptUrl && (
         <a
           className="ss-link"
@@ -811,22 +876,115 @@ function PaymentSection({
           View Stripe receipt ↗
         </a>
       )}
-      {!succeeded && (
+
+      {!succeeded && !refunded && !pickerOpen && (
         <button
           type="button"
           className="ss-btn ss-btn-primary"
           disabled={submitting}
-          onClick={pay}
+          onClick={() => setPickerOpen(true)}
         >
-          {submitting
-            ? "Starting checkout…"
-            : pending
-              ? "Resume payment"
-              : failed
-                ? "Try again"
-                : "Pay now"}
+          {pending ? "Resume payment" : failed ? "Try again" : "Pay now"}
         </button>
       )}
+
+      {!succeeded && !refunded && pickerOpen && (
+        <div className="ss-tip-picker">
+          <div className="ss-tip-presets">
+            {TIP_PRESETS.map((p, i) => (
+              <button
+                key={p.label}
+                type="button"
+                className={`ss-tip-chip${
+                  !customMode && tipPresetIndex === i ? " is-on" : ""
+                }`}
+                onClick={() => {
+                  setCustomMode(false);
+                  setTipPresetIndex(i);
+                }}
+              >
+                <span className="ss-tip-chip-label">{p.label}</span>
+                {p.percent > 0 && (
+                  <span className="ss-tip-chip-amount">
+                    {formatPrice(
+                      Math.round((subtotalCents * p.percent) / 100),
+                      currency,
+                    )}
+                  </span>
+                )}
+              </button>
+            ))}
+            <button
+              type="button"
+              className={`ss-tip-chip${customMode ? " is-on" : ""}`}
+              onClick={() => setCustomMode(true)}
+            >
+              <span className="ss-tip-chip-label">Custom</span>
+            </button>
+          </div>
+          {customMode && (
+            <div className="ss-tip-custom">
+              <span>$</span>
+              <input
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.01"
+                placeholder="0.00"
+                value={customTipDollars}
+                onChange={(e) => setCustomTipDollars(e.target.value)}
+                autoFocus
+              />
+            </div>
+          )}
+          <div className="ss-tip-summary">
+            <span>Subtotal</span>
+            <span>{formatPrice(subtotalCents, currency)}</span>
+          </div>
+          {tipCents > 0 && (
+            <div className="ss-tip-summary">
+              <span>Tip</span>
+              <span>{formatPrice(tipCents, currency)}</span>
+            </div>
+          )}
+          <div className="ss-tip-summary is-total">
+            <span>Total</span>
+            <span>{formatPrice(totalCents, currency)}</span>
+          </div>
+          <div className="ss-tip-actions">
+            <button
+              type="button"
+              className="ss-btn ss-btn-ghost"
+              onClick={() => setPickerOpen(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="ss-btn ss-btn-primary"
+              onClick={confirmAndPay}
+              disabled={submitting}
+            >
+              {submitting
+                ? "Starting checkout…"
+                : `Pay ${formatPrice(totalCents, currency)}`}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {canRefund && (
+        <button
+          type="button"
+          className="ss-btn ss-btn-ghost"
+          disabled={submitting}
+          onClick={refund}
+        >
+          {submitting ? "Refunding…" : "Issue refund"}
+        </button>
+      )}
+
       {errorMsg && <div className="ss-form-error">{errorMsg}</div>}
     </div>
   );

--- a/apps/web/src/app/dev/checkout/page.tsx
+++ b/apps/web/src/app/dev/checkout/page.tsx
@@ -21,6 +21,8 @@ export default async function DevCheckoutPage({
   searchParams: Promise<{
     sid?: string;
     amount?: string;
+    subtotal?: string;
+    tip?: string;
     currency?: string;
     product?: string;
     success?: string;
@@ -33,6 +35,8 @@ export default async function DevCheckoutPage({
   const params = await searchParams;
   const sid = params.sid;
   const amountCents = Number(params.amount ?? 0);
+  const subtotalCents = Number(params.subtotal ?? params.amount ?? 0);
+  const tipCents = Number(params.tip ?? 0);
   const currency = (params.currency ?? "USD").toUpperCase();
   const product = params.product ?? "Appointment";
   const success = params.success ?? "";
@@ -42,10 +46,12 @@ export default async function DevCheckoutPage({
     notFound();
   }
 
-  const formattedAmount = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-  }).format(amountCents / 100);
+  const fmt = (cents: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(cents / 100);
+  const formattedAmount = fmt(amountCents);
 
   return (
     <main className="ss-dev-checkout">
@@ -53,6 +59,11 @@ export default async function DevCheckoutPage({
         <div className="ss-page-eyebrow">Dev payment simulator</div>
         <h1 className="ss-dev-checkout-title">{product}</h1>
         <div className="ss-dev-checkout-amount">{formattedAmount}</div>
+        {tipCents > 0 && (
+          <p className="ss-dev-checkout-meta">
+            Subtotal {fmt(subtotalCents)} · Tip {fmt(tipCents)}
+          </p>
+        )}
         <p className="ss-dev-checkout-meta">
           Session id <code>{sid}</code>
         </p>

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -801,6 +801,101 @@
   font-variant-numeric: tabular-nums;
 }
 .ss-detail-payment .ss-btn { align-self: flex-start; }
+.ss-detail-payment-meta {
+  font-size: 11.5px;
+  color: var(--ss-text-muted);
+  margin: 0;
+}
+
+/* Tip picker that expands inline before checkout. */
+.ss-tip-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.55);
+}
+.theme-twilight .ss-tip-picker { background: rgba(255, 255, 255, 0.04); }
+.ss-tip-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ss-tip-chip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--ss-panel-edge);
+  background: rgba(255, 255, 255, 0.7);
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+  cursor: pointer;
+  transition: border-color 100ms ease, background 100ms ease;
+}
+.theme-twilight .ss-tip-chip { background: rgba(255, 255, 255, 0.06); }
+.ss-tip-chip:hover { border-color: var(--ss-magenta); }
+.ss-tip-chip.is-on {
+  background: linear-gradient(180deg, rgba(30, 195, 217, 0.18), rgba(30, 195, 217, 0.06));
+  border-color: var(--ss-magenta);
+  box-shadow: 0 0 0 2px rgba(30, 195, 217, 0.18);
+}
+.ss-tip-chip-label { line-height: 1.1; }
+.ss-tip-chip-amount {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--ss-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.ss-tip-custom {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--ss-panel-edge);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ss-text-heading);
+}
+.theme-twilight .ss-tip-custom { background: rgba(255, 255, 255, 0.06); }
+.ss-tip-custom input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  color: inherit;
+  padding: 0;
+}
+.ss-tip-summary {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12.5px;
+  color: var(--ss-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.ss-tip-summary.is-total {
+  border-top: 1px solid var(--ss-panel-edge);
+  padding-top: 6px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ss-text-heading);
+}
+.ss-tip-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
 
 /* Payment status pills — colour-coded by health, not by tone. */
 .ss-tag.is-pay-succeeded {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -362,6 +362,10 @@ export type SalonSettingsUpdateInput = z.infer<
 
 export const checkoutCreateSchema = z.object({
   appointmentId: z.string().uuid(),
+  // Optional gratuity, in cents. Capped at $1000 so a typo or malicious
+  // client can't blow up the customer's card; tips above this go through
+  // a separate adjustment flow.
+  tipCents: z.number().int().nonnegative().max(100_000).optional(),
   // Optional overrides for the Stripe-hosted-checkout return URLs. When
   // unset, the API generates routes on WEB_ORIGIN that the frontend
   // handles. Validated as URLs to avoid passing junk to Stripe.
@@ -369,3 +373,11 @@ export const checkoutCreateSchema = z.object({
   cancelUrl: z.string().url().optional(),
 });
 export type CheckoutCreateInput = z.infer<typeof checkoutCreateSchema>;
+
+export const refundCreateSchema = z.object({
+  // Omit for full refund. Capped to a generous appointment ceiling
+  // ($10,000) so the validation can catch obvious typos before they hit
+  // Stripe. Partial-refund UI lands later — schema is forward-compatible.
+  amountCents: z.number().int().positive().max(1_000_000).optional(),
+});
+export type RefundCreateInput = z.infer<typeof refundCreateSchema>;


### PR DESCRIPTION
## Summary

Closes the Phase 5 trio (5a backend → 5b UI → 5c tips/refunds). The detail panel now exposes a tip picker before checkout and a refund button after, both backed by Stripe primitives with idempotent webhook reconciliation.

## Tips

- \`checkoutCreateSchema\` accepts an optional \`tipCents\` (capped at $1000).
- Stripe Checkout renders **Tip** as its own line item so the customer sees the breakdown on the page and on the receipt.
- \`Payment.amountCents\` holds the **services-only subtotal**; \`tipCents\` is the breakdown. Total charged = \`amountCents + tipCents\`.
- Inline tip picker on the detail panel — preset percent chips (15 / 18 / 20 / 25), No tip, custom dollar input. "Pay now" expands the picker; "Confirm" runs the existing \`startCheckoutAction\`.

## Refunds

- New \`refundPayment\` provider method; Stripe adapter calls \`stripe.refunds.create\` with our own scoped idempotency key so retries don't double-refund.
- \`POST /payments/:id/refund\` (UUID-validated) — empty body for full, \`{ amountCents }\` for partial.
- \`PaymentsService.refund\`:
  - 404 when not in salon, 409 when not SUCCEEDED, 400 when amount > remaining
  - On success, inline DB update (status → REFUNDED / PARTIALLY_REFUNDED, refundedCents += amount) so the UI flips immediately
  - Emits \`payment.refunded\`
- \`charge.refunded\` webhook handler does the same DB update from Stripe's side; short-circuits if the row is already at the reported total (handles race / re-delivery / inline-already-fired).

## UI

- Tip picker section described above.
- "Issue refund" button (with \`window.confirm\`) shown when status is SUCCEEDED. Routes through \`refundPaymentAction\` + \`revalidatePath\` so the panel updates without a manual refresh.
- Summary lines: "Includes $X tip", "$X refunded".

## Out of scope (intentional)

- **Disputes** (\`charge.dispute.*\`) — needs a \`DISPUTED\` status on \`PaymentStatus\` enum, tracked as a follow-up
- **Partial refund UI** — API supports it, the button is full-only for now (follow-up)

## Tests

67 / 67 passing (was 57, added 10):

- **Tips**: forwards tipCents to provider, persists subtotal + tip separately
- **Refunds (service)**: full success + event, partial → PARTIALLY_REFUNDED, 409 not-SUCCEEDED, 400 over-balance, 404 missing
- **\`charge.refunded\` webhook**: full → REFUNDED + event, partial → PARTIALLY_REFUNDED, no-op on already-accounted, log + skip on no-match

## Test plan

- [x] \`pnpm --filter @shearsimp/api typecheck\` / \`test\` (67/67)
- [x] \`pnpm --filter @shearsimp/web typecheck\` / \`db\` typecheck + enum-parity
- [ ] On \`/schedule\`, click an unpaid appointment → "Pay now" → expand picker, pick 18% → Confirm → \`/dev/checkout\` shows subtotal + tip + total → Confirm → return banner shows
- [ ] After webhook tick, panel shows status=succeeded, "Includes $X tip" line, "Issue refund" button
- [ ] Click "Issue refund" → confirm dialog → status flips to "refunded", amount line shows "$X refunded"
- [ ] Re-trigger webhook (e.g. simulate the same charge.refunded event) → no double processing, no second domain event