### PR TITLE
Phase 19a: recurring appointments backend

### DIFF
--- a/apps/api/src/appointments/appointments.module.ts
+++ b/apps/api/src/appointments/appointments.module.ts
@@ -1,9 +1,12 @@
 import { Module } from "@nestjs/common";
 import { AppointmentsController } from "./appointments.controller";
 import { AppointmentsService } from "./appointments.service";
+import { AppointmentSeriesController } from "./series.controller";
+import { AppointmentSeriesService } from "./series.service";
 
 @Module({
-  controllers: [AppointmentsController],
-  providers: [AppointmentsService],
+  controllers: [AppointmentsController, AppointmentSeriesController],
+  providers: [AppointmentsService, AppointmentSeriesService],
+  exports: [AppointmentSeriesService],
 })
 export class AppointmentsModule {}

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -285,10 +285,16 @@ export class AppointmentsService {
             salonId,
             seriesId: existing.seriesId!,
             seriesIndex: { gte: existing.seriesIndex! },
+            // Match canReschedule(): the same statuses that are allowed for
+            // a single reschedule. Omitting CHECKED_IN here would skip the
+            // clicked occurrence itself when the user cascades from a
+            // CHECKED_IN row, leaving it at its old time while the future
+            // ones (and the series anchor) move.
             status: {
               in: [
                 AppointmentStatusEnum.SCHEDULED,
                 AppointmentStatusEnum.CONFIRMED,
+                AppointmentStatusEnum.CHECKED_IN,
               ],
             },
           },
@@ -313,15 +319,20 @@ export class AppointmentsService {
     }));
 
     // Conflict-check the moved row(s). For a single reschedule, that's just
-    // this appointment in its new slot. For a cascade, every shifted row.
+    // this appointment in its new slot. For a cascade, every shifted row —
+    // and we must exclude *every* sibling cascade row from each check, not
+    // just the one being checked. Otherwise shifting by exactly one cadence
+    // interval makes row N's new time collide with row N+1's still-current
+    // time and produces a false 409.
     if (isSeriesCascade) {
+      const cascadeIds = cascadeUpdates.map((u) => u.id);
       for (const u of cascadeUpdates) {
         await this.assertNoStylistConflict({
           salonId,
           staffMemberId: targetStaffId,
           startAt: u.newStartAt,
           endAt: u.newEndAt,
-          excludeAppointmentId: u.id,
+          excludeAppointmentIds: cascadeIds,
         });
       }
     } else {
@@ -330,7 +341,7 @@ export class AppointmentsService {
         staffMemberId: targetStaffId,
         startAt: newStart,
         endAt: newEnd,
-        excludeAppointmentId: id,
+        excludeAppointmentIds: [id],
       });
     }
 
@@ -794,7 +805,11 @@ export class AppointmentsService {
     staffMemberId: string;
     startAt: Date;
     endAt: Date;
-    excludeAppointmentId?: string;
+    // Single id (one-off reschedule) or list (cascade reschedule, where all
+    // sibling rows are about to move together and so must be excluded from
+    // each row's conflict check — otherwise a one-cadence shift produces a
+    // false 409 against a sibling still at its old time).
+    excludeAppointmentIds?: string[];
   }) {
     if (args.endAt <= args.startAt) {
       throw new BadRequestException("Appointment endAt must be after startAt");
@@ -806,8 +821,8 @@ export class AppointmentsService {
         status: { in: BLOCKING_STATUSES as AppointmentStatusEnum[] },
         startAt: { lt: args.endAt },
         endAt: { gt: args.startAt },
-        ...(args.excludeAppointmentId
-          ? { NOT: { id: args.excludeAppointmentId } }
+        ...(args.excludeAppointmentIds && args.excludeAppointmentIds.length > 0
+          ? { id: { notIn: args.excludeAppointmentIds } }
           : {}),
       },
       select: { id: true, startAt: true, endAt: true },

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import {
+  AppointmentSeriesStatus as AppointmentSeriesStatusEnum,
   AppointmentSource as AppointmentSourceEnum,
   AppointmentStatus as AppointmentStatusEnum,
   OutboxStatus,
@@ -261,87 +262,253 @@ export class AppointmentsService {
     const newStart = input.startAt;
     const newEnd = new Date(newStart.getTime() + durationMs);
 
-    await this.assertNoStylistConflict({
-      salonId,
-      staffMemberId: targetStaffId,
-      startAt: newStart,
-      endAt: newEnd,
-      excludeAppointmentId: id,
-    });
+    // Cascade reschedule onto every future occurrence in the same series.
+    // The delta we apply is in raw milliseconds — wall-clock-preserving math
+    // here would be wrong: the user dragged the block to a specific instant,
+    // so future occurrences shift by the same instant-delta. The series
+    // anchor's wall-clock time is updated below so subsequent top-offs use
+    // the new pattern.
+    const isSeriesCascade =
+      input.scope === "following" && existing.seriesId !== null;
+    if (isSeriesCascade && existing.seriesIndex === null) {
+      // Defensive: a row with seriesId must have seriesIndex too. If the
+      // invariant is broken, fall back to a single-occurrence reschedule
+      // rather than silently shifting nothing.
+      throw new ConflictException(
+        "Cannot cascade-reschedule: appointment is missing seriesIndex",
+      );
+    }
+
+    const cascadeRows = isSeriesCascade
+      ? await this.prisma.appointment.findMany({
+          where: {
+            salonId,
+            seriesId: existing.seriesId!,
+            seriesIndex: { gte: existing.seriesIndex! },
+            status: {
+              in: [
+                AppointmentStatusEnum.SCHEDULED,
+                AppointmentStatusEnum.CONFIRMED,
+              ],
+            },
+          },
+          select: {
+            id: true,
+            seriesIndex: true,
+            startAt: true,
+            endAt: true,
+            staffMemberId: true,
+          },
+          orderBy: [{ seriesIndex: "asc" }],
+        })
+      : [];
+
+    const deltaMs = newStart.getTime() - existing.startAt.getTime();
+    const cascadeUpdates = cascadeRows.map((row) => ({
+      id: row.id,
+      seriesIndex: row.seriesIndex!,
+      previousStartAt: row.startAt,
+      newStartAt: new Date(row.startAt.getTime() + deltaMs),
+      newEndAt: new Date(row.endAt.getTime() + deltaMs),
+    }));
+
+    // Conflict-check the moved row(s). For a single reschedule, that's just
+    // this appointment in its new slot. For a cascade, every shifted row.
+    if (isSeriesCascade) {
+      for (const u of cascadeUpdates) {
+        await this.assertNoStylistConflict({
+          salonId,
+          staffMemberId: targetStaffId,
+          startAt: u.newStartAt,
+          endAt: u.newEndAt,
+          excludeAppointmentId: u.id,
+        });
+      }
+    } else {
+      await this.assertNoStylistConflict({
+        salonId,
+        staffMemberId: targetStaffId,
+        startAt: newStart,
+        endAt: newEnd,
+        excludeAppointmentId: id,
+      });
+    }
 
     return this.prisma.$transaction(async (tx) => {
-      const updated = await tx.appointment.update({
-        where: { id },
-        data: {
-          startAt: newStart,
-          endAt: newEnd,
-          ...(input.staffMemberId && input.staffMemberId !== existing.staffMemberId
-            ? {
-                staffMember: {
-                  connect: {
-                    staff_members_id_salonId_key: {
-                      id: input.staffMemberId,
-                      salonId,
-                    },
+      const staffConnect =
+        input.staffMemberId && input.staffMemberId !== existing.staffMemberId
+          ? {
+              staffMember: {
+                connect: {
+                  staff_members_id_salonId_key: {
+                    id: input.staffMemberId,
+                    salonId,
                   },
                 },
-              }
-            : {}),
-        },
-        include: APPOINTMENT_INCLUDE,
-      });
-      await appendDomainEvent(tx, {
-        salonId,
-        aggregateType: "APPOINTMENT",
-        aggregateId: id,
-        eventType: EventType.APPOINTMENT_RESCHEDULED,
-        payload: {
-          before: {
-            startAt: existing.startAt,
-            endAt: existing.endAt,
-            staffMemberId: existing.staffMemberId,
+              },
+            }
+          : {};
+
+      let updated;
+      if (isSeriesCascade && cascadeUpdates.length > 0) {
+        // Apply the same delta to every shifted occurrence and emit per-row
+        // events so each customer's SMS still fires with their correct old
+        // and new times.
+        for (const u of cascadeUpdates) {
+          const before = await tx.appointment.findUniqueOrThrow({
+            where: { id: u.id },
+            select: { startAt: true, endAt: true, staffMemberId: true },
+          });
+          await tx.appointment.update({
+            where: { id: u.id },
+            data: {
+              startAt: u.newStartAt,
+              endAt: u.newEndAt,
+              ...staffConnect,
+            },
+          });
+          await appendDomainEvent(tx, {
+            salonId,
+            aggregateType: "APPOINTMENT",
+            aggregateId: u.id,
+            eventType: EventType.APPOINTMENT_RESCHEDULED,
+            payload: {
+              before: {
+                startAt: before.startAt,
+                endAt: before.endAt,
+                staffMemberId: before.staffMemberId,
+              },
+              after: {
+                startAt: u.newStartAt,
+                endAt: u.newEndAt,
+                staffMemberId: targetStaffId,
+              },
+              cascadedFromSeriesIndex: existing.seriesIndex,
+            } as Prisma.InputJsonValue,
+            actorUserId,
+          });
+          await tx.outboxEvent.create({
+            data: {
+              salonId,
+              eventType: EventType.APPOINTMENT_RESCHEDULED,
+              payload: {
+                id: u.id,
+                salonId,
+                previousStartAt: u.previousStartAt.toISOString(),
+              } as Prisma.InputJsonValue,
+              status: OutboxStatus.PENDING,
+            },
+          });
+          await tx.outboxEvent.updateMany({
+            where: {
+              eventType: EventType.APPOINTMENT_REMINDER_DUE,
+              status: OutboxStatus.PENDING,
+              salonId,
+              payload: { path: ["id"], equals: u.id },
+            },
+            data: {
+              nextAttemptAt: new Date(
+                u.newStartAt.getTime() - REMINDER_LEAD_MS,
+              ),
+            },
+          });
+        }
+
+        // Reset the series anchor so future top-offs continue at the new
+        // pattern. anchorIndex tracks which occurrence the new anchor maps
+        // to; the cadence helper computes occurrence M as
+        // anchor + (M - anchorIndex) * everyNWeeks weeks.
+        await tx.appointmentSeries.update({
+          where: { id: existing.seriesId! },
+          data: {
+            anchorStartAt: newStart,
+            anchorIndex: existing.seriesIndex!,
+            ...(input.staffMemberId &&
+            input.staffMemberId !== existing.staffMemberId
+              ? { staffMemberId: input.staffMemberId }
+              : {}),
           },
-          after: {
-            startAt: updated.startAt,
-            endAt: updated.endAt,
-            staffMemberId: updated.staffMemberId,
-          },
-        },
-        actorUserId,
-      });
-      // Outbox row drives the reschedule SMS in 4b-1. Minimal payload: id +
-      // salonId + previousStartAt. The handler looks up the appointment for
-      // current state (new startAt, services, staff) and uses
-      // previousStartAt only for the "moved from X to Y" wording.
-      await tx.outboxEvent.create({
-        data: {
+        });
+        await appendDomainEvent(tx, {
           salonId,
+          aggregateType: "APPOINTMENT_SERIES",
+          aggregateId: existing.seriesId!,
+          eventType: EventType.APPOINTMENT_SERIES_RESCHEDULED,
+          payload: {
+            fromSeriesIndex: existing.seriesIndex,
+            deltaMs,
+            shiftedOccurrences: cascadeUpdates.length,
+            newStaffMemberId: input.staffMemberId ?? null,
+          } as Prisma.InputJsonValue,
+          actorUserId,
+        });
+        updated = await tx.appointment.findUniqueOrThrow({
+          where: { id },
+          include: APPOINTMENT_INCLUDE,
+        });
+      } else {
+        updated = await tx.appointment.update({
+          where: { id },
+          data: {
+            startAt: newStart,
+            endAt: newEnd,
+            ...staffConnect,
+          },
+          include: APPOINTMENT_INCLUDE,
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "APPOINTMENT",
+          aggregateId: id,
           eventType: EventType.APPOINTMENT_RESCHEDULED,
           payload: {
-            id,
+            before: {
+              startAt: existing.startAt,
+              endAt: existing.endAt,
+              staffMemberId: existing.staffMemberId,
+            },
+            after: {
+              startAt: updated.startAt,
+              endAt: updated.endAt,
+              staffMemberId: updated.staffMemberId,
+            },
+          },
+          actorUserId,
+        });
+        // Outbox row drives the reschedule SMS in 4b-1. Minimal payload: id +
+        // salonId + previousStartAt. The handler looks up the appointment for
+        // current state (new startAt, services, staff) and uses
+        // previousStartAt only for the "moved from X to Y" wording.
+        await tx.outboxEvent.create({
+          data: {
             salonId,
-            previousStartAt: existing.startAt.toISOString(),
-          } as Prisma.InputJsonValue,
-          status: OutboxStatus.PENDING,
-        },
-      });
-      // Move the still-pending reminder forward (or back) to match the new
-      // startAt. updateMany skips rows that have already fired (status !=
-      // PENDING), which is the correct behaviour — once a reminder went
-      // out for the old time, we can't unsend it.
-      await tx.outboxEvent.updateMany({
-        where: {
-          eventType: EventType.APPOINTMENT_REMINDER_DUE,
-          status: OutboxStatus.PENDING,
-          salonId,
-          payload: { path: ["id"], equals: id },
-        },
-        data: {
-          nextAttemptAt: new Date(
-            updated.startAt.getTime() - REMINDER_LEAD_MS,
-          ),
-        },
-      });
+            eventType: EventType.APPOINTMENT_RESCHEDULED,
+            payload: {
+              id,
+              salonId,
+              previousStartAt: existing.startAt.toISOString(),
+            } as Prisma.InputJsonValue,
+            status: OutboxStatus.PENDING,
+          },
+        });
+        // Move the still-pending reminder forward (or back) to match the new
+        // startAt. updateMany skips rows that have already fired (status !=
+        // PENDING), which is the correct behaviour — once a reminder went
+        // out for the old time, we can't unsend it.
+        await tx.outboxEvent.updateMany({
+          where: {
+            eventType: EventType.APPOINTMENT_REMINDER_DUE,
+            status: OutboxStatus.PENDING,
+            salonId,
+            payload: { path: ["id"], equals: id },
+          },
+          data: {
+            nextAttemptAt: new Date(
+              updated.startAt.getTime() - REMINDER_LEAD_MS,
+            ),
+          },
+        });
+      }
       return updated;
     });
   }
@@ -357,6 +524,114 @@ export class AppointmentsService {
       throw new ConflictException(
         `Cannot cancel an appointment in status ${existing.status}`,
       );
+    }
+
+    // Cascade: cancel this occurrence + all future + end the series. We
+    // bundle it inline (rather than delegating to AppointmentSeriesService)
+    // because we need the same transactional guarantees the single-cancel
+    // path provides, and the SeriesService method only walks future
+    // occurrences with startAt > now — it would skip the row the user
+    // actually clicked on if it was already in progress (which canCancel
+    // already disallowed) or in the past few seconds.
+    if (input.scope === "following" && existing.seriesId !== null) {
+      return this.prisma.$transaction(async (tx) => {
+        const now = new Date();
+        const future = await tx.appointment.findMany({
+          where: {
+            salonId,
+            seriesId: existing.seriesId!,
+            seriesIndex: { gte: existing.seriesIndex ?? 0 },
+            status: {
+              in: [
+                AppointmentStatusEnum.SCHEDULED,
+                AppointmentStatusEnum.CONFIRMED,
+                AppointmentStatusEnum.CHECKED_IN,
+                AppointmentStatusEnum.IN_PROGRESS,
+              ],
+            },
+          },
+          select: { id: true, status: true },
+        });
+        for (const appt of future) {
+          if (!canCancel(appt.status)) continue;
+          await tx.appointment.update({
+            where: { id: appt.id },
+            data: {
+              status: AppointmentStatusEnum.CANCELLED,
+              cancelledAt: now,
+              cancellationReason: input.reason ?? "Series ended",
+            },
+          });
+          await appendDomainEvent(tx, {
+            salonId,
+            aggregateType: "APPOINTMENT",
+            aggregateId: appt.id,
+            eventType: EventType.APPOINTMENT_CANCELLED,
+            payload: {
+              previousStatus: appt.status,
+              reason: input.reason ?? "Series ended",
+              cascadedFromSeries: existing.seriesId,
+            } as Prisma.InputJsonValue,
+            actorUserId,
+          });
+          await tx.outboxEvent.create({
+            data: {
+              salonId,
+              eventType: EventType.APPOINTMENT_CANCELLED,
+              payload: { id: appt.id, salonId } as Prisma.InputJsonValue,
+              status: OutboxStatus.PENDING,
+            },
+          });
+          await tx.outboxEvent.updateMany({
+            where: {
+              eventType: EventType.APPOINTMENT_REMINDER_DUE,
+              status: OutboxStatus.PENDING,
+              salonId,
+              payload: { path: ["id"], equals: appt.id },
+            },
+            data: {
+              status: OutboxStatus.COMPLETED,
+              processedAt: now,
+            },
+          });
+        }
+        // Suppress the next top-off and flip the series to CANCELLED.
+        await tx.outboxEvent.updateMany({
+          where: {
+            eventType: EventType.APPOINTMENT_SERIES_TOP_OFF_DUE,
+            status: OutboxStatus.PENDING,
+            salonId,
+            payload: { path: ["seriesId"], equals: existing.seriesId! },
+          },
+          data: {
+            status: OutboxStatus.COMPLETED,
+            processedAt: now,
+          },
+        });
+        await tx.appointmentSeries.update({
+          where: { id: existing.seriesId! },
+          data: {
+            status: AppointmentSeriesStatusEnum.CANCELLED,
+            cancelledAt: now,
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "APPOINTMENT_SERIES",
+          aggregateId: existing.seriesId!,
+          eventType: EventType.APPOINTMENT_SERIES_CANCELLED,
+          payload: {
+            reason: input.reason ?? null,
+            cancelledOccurrences: future.length,
+            cascadedFromAppointment: id,
+          } as Prisma.InputJsonValue,
+          actorUserId,
+        });
+        return tx.appointment.findUniqueOrThrow({
+          where: { id },
+          include: APPOINTMENT_INCLUDE,
+        });
+      });
     }
 
     return this.prisma.$transaction(async (tx) => {

--- a/apps/api/src/appointments/cadence.ts
+++ b/apps/api/src/appointments/cadence.ts
@@ -1,0 +1,127 @@
+// Wall-clock-preserving cadence math for AppointmentSeries.
+//
+// "Every 4 weeks at 4:45pm Thursday" must mean 4:45pm wall-clock — not
+// "exactly 28 * 24h after the previous occurrence", which would drift by
+// an hour twice a year as the salon's timezone enters and exits DST.
+//
+// Pattern: pull the local components of the anchor in salon.timezone, add
+// (n * everyNWeeks * 7) calendar days, then convert that local datetime
+// back to UTC at the target date's offset. The offset lookup uses
+// Intl.DateTimeFormat which knows the IANA tz database — no extra deps.
+
+interface LocalParts {
+  year: number;
+  month: number; // 1-12
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const LOCAL_PARTS_FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
+
+function formatterFor(timeZone: string): Intl.DateTimeFormat {
+  let f = LOCAL_PARTS_FORMATTER_CACHE.get(timeZone);
+  if (!f) {
+    f = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    LOCAL_PARTS_FORMATTER_CACHE.set(timeZone, f);
+  }
+  return f;
+}
+
+function localPartsAt(instant: Date, timeZone: string): LocalParts {
+  const parts = formatterFor(timeZone).formatToParts(instant);
+  const m: Record<string, string> = {};
+  for (const p of parts) m[p.type] = p.value;
+  return {
+    year: Number(m.year),
+    month: Number(m.month),
+    day: Number(m.day),
+    // Intl reports 24 for midnight in some locales; normalise to 0.
+    hour: Number(m.hour) === 24 ? 0 : Number(m.hour),
+    minute: Number(m.minute),
+    second: Number(m.second),
+  };
+}
+
+// Convert a wall-clock datetime in `timeZone` to the corresponding UTC
+// instant. Uses one fixed-point refinement: a first guess based on UTC
+// arithmetic, then we ask "what does that instant look like in tz?",
+// extract the offset, and shift. One refinement is enough because the
+// offset only depends on the date once you're within an hour of the target.
+function utcFromLocal(parts: LocalParts, timeZone: string): Date {
+  const guessUtcMs = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  const guessLocal = localPartsAt(new Date(guessUtcMs), timeZone);
+  const guessLocalAsUtcMs = Date.UTC(
+    guessLocal.year,
+    guessLocal.month - 1,
+    guessLocal.day,
+    guessLocal.hour,
+    guessLocal.minute,
+    guessLocal.second,
+  );
+  const offsetMs = guessLocalAsUtcMs - guessUtcMs;
+  return new Date(guessUtcMs - offsetMs);
+}
+
+// Compute the start time of occurrence #seriesIndex given the series anchor.
+// anchorIndex is the seriesIndex assigned to anchorStartAt — usually 1, but
+// shifted forward when the user reschedules "this and following".
+export function occurrenceStartAt(args: {
+  anchorStartAt: Date;
+  anchorIndex: number;
+  everyNWeeks: number;
+  seriesIndex: number;
+  timeZone: string;
+}): Date {
+  const offsetWeeks = (args.seriesIndex - args.anchorIndex) * args.everyNWeeks;
+  if (offsetWeeks === 0) return args.anchorStartAt;
+  const local = localPartsAt(args.anchorStartAt, args.timeZone);
+  // 7 calendar days × week-count, applied to the day field. Date.UTC
+  // handles month / year overflow cleanly.
+  const shifted: LocalParts = { ...local, day: local.day + offsetWeeks * 7 };
+  return utcFromLocal(shifted, args.timeZone);
+}
+
+// Convenience for the materializer: list the (seriesIndex, startAt) pairs
+// for `count` consecutive occurrences starting at startIndex.
+export function occurrenceRange(args: {
+  anchorStartAt: Date;
+  anchorIndex: number;
+  everyNWeeks: number;
+  startIndex: number;
+  count: number;
+  timeZone: string;
+}): { seriesIndex: number; startAt: Date }[] {
+  const out: { seriesIndex: number; startAt: Date }[] = [];
+  for (let i = 0; i < args.count; i++) {
+    const seriesIndex = args.startIndex + i;
+    out.push({
+      seriesIndex,
+      startAt: occurrenceStartAt({
+        anchorStartAt: args.anchorStartAt,
+        anchorIndex: args.anchorIndex,
+        everyNWeeks: args.everyNWeeks,
+        seriesIndex,
+        timeZone: args.timeZone,
+      }),
+    });
+  }
+  return out;
+}

--- a/apps/api/src/appointments/series.controller.ts
+++ b/apps/api/src/appointments/series.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from "@nestjs/common";
+import {
+  appointmentSeriesCancelSchema,
+  appointmentSeriesCreateSchema,
+  appointmentSeriesExtendSchema,
+} from "@shearsimp/shared";
+import type {
+  AppointmentSeriesCancelInput,
+  AppointmentSeriesCreateInput,
+  AppointmentSeriesExtendInput,
+} from "@shearsimp/shared";
+import { CurrentSalon } from "../tenant/current-salon.decorator";
+import { CurrentUser } from "../auth/current-user.decorator";
+import type {
+  ActiveSalon,
+  AuthIdentity,
+} from "../context/request-context";
+import { ZodValidationPipe } from "../common/zod-validation.pipe";
+import { AppointmentSeriesService } from "./series.service";
+
+@Controller("appointment-series")
+export class AppointmentSeriesController {
+  constructor(private readonly series: AppointmentSeriesService) {}
+
+  @Get(":id")
+  get(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+  ) {
+    return this.series.get(salon.salonId, id);
+  }
+
+  @Post()
+  create(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Body(new ZodValidationPipe(appointmentSeriesCreateSchema))
+    input: AppointmentSeriesCreateInput,
+  ) {
+    return this.series.create(salon.salonId, user.userId, input);
+  }
+
+  @Post(":id/cancel")
+  cancel(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentSeriesCancelSchema))
+    input: AppointmentSeriesCancelInput,
+  ) {
+    return this.series.cancelSeries(salon.salonId, user.userId, id, input);
+  }
+
+  @Post(":id/extend")
+  extend(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(appointmentSeriesExtendSchema))
+    input: AppointmentSeriesExtendInput,
+  ) {
+    return this.series.extend(salon.salonId, user.userId, id, input);
+  }
+}

--- a/apps/api/src/appointments/series.service.ts
+++ b/apps/api/src/appointments/series.service.ts
@@ -316,7 +316,7 @@ export class AppointmentSeriesService {
           },
           startAt: { gt: now },
         },
-        select: { id: true },
+        select: { id: true, status: true },
       });
 
       for (const appt of future) {
@@ -334,7 +334,7 @@ export class AppointmentSeriesService {
           aggregateId: appt.id,
           eventType: EventType.APPOINTMENT_CANCELLED,
           payload: {
-            previousStatus: AppointmentStatusEnum.SCHEDULED,
+            previousStatus: appt.status,
             reason: input.reason ?? "Series ended",
             cascadedFromSeries: seriesId,
           } as Prisma.InputJsonValue,

--- a/apps/api/src/appointments/series.service.ts
+++ b/apps/api/src/appointments/series.service.ts
@@ -1,0 +1,676 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import {
+  AppointmentSeriesStatus as AppointmentSeriesStatusEnum,
+  AppointmentSource as AppointmentSourceEnum,
+  AppointmentStatus as AppointmentStatusEnum,
+  OutboxStatus,
+  Prisma,
+  type OutboxEvent,
+} from "@prisma/client";
+import { EventType } from "@shearsimp/shared";
+import type {
+  AppointmentSeriesCancelInput,
+  AppointmentSeriesCreateInput,
+  AppointmentSeriesExtendInput,
+} from "@shearsimp/shared";
+import { PrismaService } from "../prisma/prisma.service";
+import { appendDomainEvent } from "../common/domain-events";
+import { occurrenceRange } from "./cadence";
+
+// How many future occurrences we keep materialized at any time. 12 weeks of
+// buffer means the top-off worker can be down for days without the calendar
+// running dry, and 12 rows per series is trivial write amplification.
+const MATERIALIZE_AHEAD = 12;
+// Trigger another top-off when fewer than this many future occurrences remain.
+const TOP_OFF_THRESHOLD = 4;
+// How long to wait between top-off attempts for an active series. A weekly
+// cadence is ample given the buffer above and keeps the outbox light.
+const TOP_OFF_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+// Same lead time the appointments service uses for one-off bookings.
+const REMINDER_LEAD_MS = 24 * 60 * 60 * 1000;
+
+const SERIES_INCLUDE = {
+  client: { select: { id: true, displayName: true, phone: true, email: true } },
+  staffMember: { select: { id: true, displayName: true, color: true } },
+  services: {
+    orderBy: [{ sortOrder: "asc" as const }],
+    select: { id: true, serviceId: true, sortOrder: true },
+  },
+} satisfies Prisma.AppointmentSeriesInclude;
+
+@Injectable()
+export class AppointmentSeriesService {
+  private readonly logger = new Logger(AppointmentSeriesService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async get(salonId: string, id: string) {
+    const series = await this.prisma.appointmentSeries.findFirst({
+      where: { id, salonId },
+      include: SERIES_INCLUDE,
+    });
+    if (!series) throw new NotFoundException("Series not found");
+    return series;
+  }
+
+  // Create a new series + materialize the initial batch of occurrences in
+  // one transaction. First-occurrence conflicts surface as 409 like normal
+  // bookings; subsequent materialized rows skip conflict checks (they're
+  // weeks out, the operator can resolve overlaps in the calendar UI).
+  async create(
+    salonId: string,
+    actorUserId: string,
+    input: AppointmentSeriesCreateInput,
+  ) {
+    const [client, staff, services, salon] = await Promise.all([
+      this.prisma.client.findFirst({
+        where: { id: input.clientId, salonId },
+        select: { id: true },
+      }),
+      this.prisma.staffMember.findFirst({
+        where: { id: input.staffMemberId, salonId, isActive: true },
+        select: { id: true },
+      }),
+      this.prisma.service.findMany({
+        where: { id: { in: input.serviceIds }, salonId },
+        select: {
+          id: true,
+          name: true,
+          defaultDurationMinutes: true,
+          defaultPriceCents: true,
+          currency: true,
+          isActive: true,
+        },
+      }),
+      this.prisma.salon.findUnique({
+        where: { id: salonId },
+        select: { timezone: true },
+      }),
+    ]);
+
+    if (!client) throw new NotFoundException("Client not found");
+    if (!staff) throw new NotFoundException("Staff member not found or inactive");
+    if (services.length !== input.serviceIds.length) {
+      throw new NotFoundException("One or more services not found in this salon");
+    }
+    if (services.some((s) => !s.isActive)) {
+      throw new BadRequestException("Cannot book inactive services");
+    }
+    if (!salon) {
+      throw new NotFoundException("Salon not found");
+    }
+
+    const orderedServices = input.serviceIds
+      .map((id) => services.find((s) => s.id === id))
+      .filter((s): s is (typeof services)[number] => Boolean(s));
+    const durationMinutes = orderedServices.reduce(
+      (acc, s) => acc + s.defaultDurationMinutes,
+      0,
+    );
+
+    const initialCount = Math.min(
+      MATERIALIZE_AHEAD,
+      input.stopAfterVisits ?? MATERIALIZE_AHEAD,
+    );
+    const occurrences = occurrenceRange({
+      anchorStartAt: input.startAt,
+      anchorIndex: 1,
+      everyNWeeks: input.everyNWeeks,
+      startIndex: 1,
+      count: initialCount,
+      timeZone: salon.timezone,
+    });
+
+    // First occurrence is the user-driven booking — fail hard if the stylist
+    // is double-booked there. The customer is sitting in front of you; pick
+    // a different start time.
+    const firstStart = occurrences[0].startAt;
+    const firstEnd = new Date(firstStart.getTime() + durationMinutes * 60_000);
+    const firstConflict = await this.prisma.appointment.findFirst({
+      where: {
+        salonId,
+        staffMemberId: input.staffMemberId,
+        status: {
+          in: [
+            AppointmentStatusEnum.SCHEDULED,
+            AppointmentStatusEnum.CONFIRMED,
+            AppointmentStatusEnum.CHECKED_IN,
+            AppointmentStatusEnum.IN_PROGRESS,
+            AppointmentStatusEnum.COMPLETED,
+          ],
+        },
+        startAt: { lt: firstEnd },
+        endAt: { gt: firstStart },
+      },
+      select: { id: true, startAt: true, endAt: true },
+    });
+    if (firstConflict) {
+      throw new ConflictException(
+        `Stylist already booked from ${firstConflict.startAt.toISOString()} to ${firstConflict.endAt.toISOString()}`,
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const series = await tx.appointmentSeries.create({
+        data: {
+          salonId,
+          clientId: input.clientId,
+          staffMemberId: input.staffMemberId,
+          anchorStartAt: input.startAt,
+          anchorIndex: 1,
+          durationMinutes,
+          everyNWeeks: input.everyNWeeks,
+          stopAfterVisits: input.stopAfterVisits,
+          status: AppointmentSeriesStatusEnum.ACTIVE,
+          notes: input.notes ?? null,
+          internalNotes: input.internalNotes ?? null,
+          createdById: actorUserId,
+          services: {
+            create: orderedServices.map((s, i) => ({
+              salonId,
+              serviceId: s.id,
+              sortOrder: i,
+            })),
+          },
+        },
+      });
+
+      for (const occ of occurrences) {
+        const startAt = occ.startAt;
+        const endAt = new Date(startAt.getTime() + durationMinutes * 60_000);
+        const appointment = await tx.appointment.create({
+          data: {
+            salonId,
+            clientId: input.clientId,
+            staffMemberId: input.staffMemberId,
+            startAt,
+            endAt,
+            status: AppointmentStatusEnum.SCHEDULED,
+            source: input.source ?? AppointmentSourceEnum.STAFF,
+            notes: input.notes ?? null,
+            internalNotes: input.internalNotes ?? null,
+            createdById: actorUserId,
+            seriesId: series.id,
+            seriesIndex: occ.seriesIndex,
+            services: {
+              create: orderedServices.map((s, i) => ({
+                serviceId: s.id,
+                serviceNameSnapshot: s.name,
+                priceSnapshotCents: s.defaultPriceCents,
+                durationSnapshotMinutes: s.defaultDurationMinutes,
+                currencySnapshot: s.currency,
+                sortOrder: i,
+              })),
+            },
+          },
+        });
+        // Mirror the one-off booking outbox events: confirmation SMS for the
+        // first occurrence (the rest are not surprising — the customer just
+        // signed up for the recurrence), reminder for every occurrence.
+        if (occ.seriesIndex === 1) {
+          await tx.outboxEvent.create({
+            data: {
+              salonId,
+              eventType: EventType.APPOINTMENT_CREATED,
+              payload: {
+                id: appointment.id,
+                salonId,
+              } as Prisma.InputJsonValue,
+              status: OutboxStatus.PENDING,
+            },
+          });
+        }
+        await tx.outboxEvent.create({
+          data: {
+            salonId,
+            eventType: EventType.APPOINTMENT_REMINDER_DUE,
+            payload: {
+              id: appointment.id,
+              salonId,
+            } as Prisma.InputJsonValue,
+            status: OutboxStatus.PENDING,
+            nextAttemptAt: new Date(startAt.getTime() - REMINDER_LEAD_MS),
+          },
+        });
+      }
+
+      // For finite series whose initial materialization covers all visits we
+      // skip top-off scheduling — there's nothing left to add.
+      const exhausted =
+        input.stopAfterVisits !== null &&
+        initialCount >= (input.stopAfterVisits ?? Number.POSITIVE_INFINITY);
+      if (!exhausted) {
+        await tx.outboxEvent.create({
+          data: {
+            salonId,
+            eventType: EventType.APPOINTMENT_SERIES_TOP_OFF_DUE,
+            payload: {
+              seriesId: series.id,
+              salonId,
+            } as Prisma.InputJsonValue,
+            status: OutboxStatus.PENDING,
+            nextAttemptAt: new Date(Date.now() + TOP_OFF_INTERVAL_MS),
+          },
+        });
+      }
+
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT_SERIES",
+        aggregateId: series.id,
+        eventType: EventType.APPOINTMENT_SERIES_CREATED,
+        payload: {
+          everyNWeeks: input.everyNWeeks,
+          stopAfterVisits: input.stopAfterVisits,
+          firstStartAt: input.startAt.toISOString(),
+          initialOccurrences: initialCount,
+        } as Prisma.InputJsonValue,
+        actorUserId,
+      });
+
+      return tx.appointmentSeries.findFirstOrThrow({
+        where: { id: series.id, salonId },
+        include: SERIES_INCLUDE,
+      });
+    });
+  }
+
+  // Cancel the entire series: flips status, cancels every future
+  // non-terminal occurrence, suppresses their pending reminders, and
+  // suppresses the next top-off. Past appointments (already completed,
+  // checked-in, etc.) are left alone — those happened.
+  async cancelSeries(
+    salonId: string,
+    actorUserId: string,
+    seriesId: string,
+    input: AppointmentSeriesCancelInput,
+  ) {
+    const series = await this.get(salonId, seriesId);
+    if (series.status !== AppointmentSeriesStatusEnum.ACTIVE) {
+      throw new ConflictException(
+        `Cannot cancel a series in status ${series.status}`,
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const now = new Date();
+
+      // Find future cancellable occurrences. We list them first so we can
+      // emit per-appointment SMS and domain events; updateMany would be
+      // faster but skip the per-row notifications.
+      const future = await tx.appointment.findMany({
+        where: {
+          salonId,
+          seriesId,
+          status: {
+            in: [
+              AppointmentStatusEnum.SCHEDULED,
+              AppointmentStatusEnum.CONFIRMED,
+            ],
+          },
+          startAt: { gt: now },
+        },
+        select: { id: true },
+      });
+
+      for (const appt of future) {
+        await tx.appointment.update({
+          where: { id: appt.id },
+          data: {
+            status: AppointmentStatusEnum.CANCELLED,
+            cancelledAt: now,
+            cancellationReason: input.reason ?? "Series ended",
+          },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "APPOINTMENT",
+          aggregateId: appt.id,
+          eventType: EventType.APPOINTMENT_CANCELLED,
+          payload: {
+            previousStatus: AppointmentStatusEnum.SCHEDULED,
+            reason: input.reason ?? "Series ended",
+            cascadedFromSeries: seriesId,
+          } as Prisma.InputJsonValue,
+          actorUserId,
+        });
+        await tx.outboxEvent.create({
+          data: {
+            salonId,
+            eventType: EventType.APPOINTMENT_CANCELLED,
+            payload: { id: appt.id, salonId } as Prisma.InputJsonValue,
+            status: OutboxStatus.PENDING,
+          },
+        });
+        // Suppress the still-pending reminder.
+        await tx.outboxEvent.updateMany({
+          where: {
+            eventType: EventType.APPOINTMENT_REMINDER_DUE,
+            status: OutboxStatus.PENDING,
+            salonId,
+            payload: { path: ["id"], equals: appt.id },
+          },
+          data: {
+            status: OutboxStatus.COMPLETED,
+            processedAt: now,
+          },
+        });
+      }
+
+      // Suppress the next top-off so the worker doesn't re-materialize a
+      // cancelled series.
+      await tx.outboxEvent.updateMany({
+        where: {
+          eventType: EventType.APPOINTMENT_SERIES_TOP_OFF_DUE,
+          status: OutboxStatus.PENDING,
+          salonId,
+          payload: { path: ["seriesId"], equals: seriesId },
+        },
+        data: {
+          status: OutboxStatus.COMPLETED,
+          processedAt: now,
+        },
+      });
+
+      const updated = await tx.appointmentSeries.update({
+        where: { id: seriesId },
+        data: {
+          status: AppointmentSeriesStatusEnum.CANCELLED,
+          cancelledAt: now,
+        },
+        include: SERIES_INCLUDE,
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT_SERIES",
+        aggregateId: seriesId,
+        eventType: EventType.APPOINTMENT_SERIES_CANCELLED,
+        payload: {
+          reason: input.reason ?? null,
+          cancelledOccurrences: future.length,
+        } as Prisma.InputJsonValue,
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
+  // Extend a finite series by N more visits. Indefinite series have no cap
+  // to extend — calling this is a 400. Bumps stopAfterVisits, flips
+  // COMPLETED back to ACTIVE if relevant, and ensures a top-off is queued.
+  async extend(
+    salonId: string,
+    actorUserId: string,
+    seriesId: string,
+    input: AppointmentSeriesExtendInput,
+  ) {
+    const series = await this.get(salonId, seriesId);
+    if (series.status === AppointmentSeriesStatusEnum.CANCELLED) {
+      throw new ConflictException("Cannot extend a cancelled series");
+    }
+    if (series.stopAfterVisits === null) {
+      throw new BadRequestException(
+        "Indefinite series have no cap to extend — they continue until cancelled",
+      );
+    }
+    const newCap = series.stopAfterVisits + input.additionalVisits;
+    if (newCap > 52) {
+      throw new BadRequestException(
+        "stopAfterVisits cannot exceed 52 — convert to indefinite instead",
+      );
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.appointmentSeries.update({
+        where: { id: seriesId },
+        data: {
+          stopAfterVisits: newCap,
+          status: AppointmentSeriesStatusEnum.ACTIVE,
+        },
+        include: SERIES_INCLUDE,
+      });
+      // Make sure a top-off is queued so the additional occurrences get
+      // materialized. If one's already pending the dedup is fine — the
+      // handler is idempotent.
+      await tx.outboxEvent.create({
+        data: {
+          salonId,
+          eventType: EventType.APPOINTMENT_SERIES_TOP_OFF_DUE,
+          payload: {
+            seriesId,
+            salonId,
+          } as Prisma.InputJsonValue,
+          status: OutboxStatus.PENDING,
+          // Run on the next tick — the operator just clicked extend and is
+          // looking at the calendar.
+          nextAttemptAt: new Date(),
+        },
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT_SERIES",
+        aggregateId: seriesId,
+        eventType: EventType.APPOINTMENT_SERIES_EXTENDED,
+        payload: {
+          additionalVisits: input.additionalVisits,
+          newStopAfterVisits: newCap,
+        } as Prisma.InputJsonValue,
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
+  // Outbox handler: top up the series' future-occurrence buffer. Skip
+  // conflict checks here — these are calendar entries weeks out; if a
+  // walk-in lands in the same slot, the calendar UI shows the overlap and
+  // the operator resolves manually. Re-enqueues itself for the next
+  // interval if the series remains active.
+  async handleTopOffDue(event: OutboxEvent): Promise<void> {
+    const payload = (event.payload ?? {}) as { seriesId?: string; salonId?: string };
+    const seriesId = payload.seriesId;
+    const salonId = payload.salonId;
+    if (!seriesId || !salonId) {
+      this.logger.warn(
+        `${event.eventType} event ${event.id} missing seriesId/salonId — skipping`,
+      );
+      return;
+    }
+
+    const series = await this.prisma.appointmentSeries.findFirst({
+      where: { id: seriesId, salonId },
+      include: {
+        services: {
+          orderBy: [{ sortOrder: "asc" as const }],
+          select: { serviceId: true, sortOrder: true },
+        },
+      },
+    });
+    if (!series) {
+      this.logger.warn(`top-off skipped: series ${seriesId} not found`);
+      return;
+    }
+    if (series.status !== AppointmentSeriesStatusEnum.ACTIVE) {
+      // Cancelled / completed series don't get re-materialized or re-queued.
+      // The outbox row completes and that's the end of the chain.
+      return;
+    }
+
+    const salon = await this.prisma.salon.findUnique({
+      where: { id: salonId },
+      select: { timezone: true },
+    });
+    if (!salon) {
+      this.logger.warn(`top-off skipped: salon ${salonId} not found`);
+      return;
+    }
+
+    // Look up materialized occurrences to figure out what's already there,
+    // what the highest seriesIndex is, and how many future SCHEDULED
+    // occurrences remain.
+    const allOccurrences = await this.prisma.appointment.findMany({
+      where: { salonId, seriesId },
+      select: {
+        id: true,
+        seriesIndex: true,
+        status: true,
+        startAt: true,
+      },
+      orderBy: [{ seriesIndex: "asc" }],
+    });
+    const now = new Date();
+    const highestIndex = allOccurrences.reduce(
+      (acc, o) => Math.max(acc, o.seriesIndex ?? 0),
+      0,
+    );
+    const futureCount = allOccurrences.filter(
+      (o) =>
+        (o.status === AppointmentStatusEnum.SCHEDULED ||
+          o.status === AppointmentStatusEnum.CONFIRMED) &&
+        o.startAt > now,
+    ).length;
+
+    let materializedCount = 0;
+    if (futureCount < TOP_OFF_THRESHOLD) {
+      // How many more do we add? Bring the future buffer back to
+      // MATERIALIZE_AHEAD, but never exceed stopAfterVisits if finite.
+      const toAdd = MATERIALIZE_AHEAD - futureCount;
+      const cap =
+        series.stopAfterVisits === null
+          ? Number.POSITIVE_INFINITY
+          : series.stopAfterVisits - highestIndex;
+      const count = Math.max(0, Math.min(toAdd, cap));
+      if (count > 0) {
+        // Re-fetch services with the snapshot fields needed to materialize
+        // an Appointment row (price, duration, etc.).
+        const serviceIds = series.services.map((s) => s.serviceId);
+        const services = await this.prisma.service.findMany({
+          where: { id: { in: serviceIds }, salonId },
+          select: {
+            id: true,
+            name: true,
+            defaultDurationMinutes: true,
+            defaultPriceCents: true,
+            currency: true,
+            isActive: true,
+          },
+        });
+        if (services.length !== serviceIds.length) {
+          this.logger.warn(
+            `top-off skipped: series ${seriesId} references services that no longer exist; flipping series to CANCELLED`,
+          );
+          await this.prisma.appointmentSeries.update({
+            where: { id: seriesId },
+            data: {
+              status: AppointmentSeriesStatusEnum.CANCELLED,
+              cancelledAt: now,
+            },
+          });
+          return;
+        }
+        const orderedServices = series.services
+          .map((s) => services.find((svc) => svc.id === s.serviceId))
+          .filter((s): s is (typeof services)[number] => Boolean(s));
+        const occurrences = occurrenceRange({
+          anchorStartAt: series.anchorStartAt,
+          anchorIndex: series.anchorIndex,
+          everyNWeeks: series.everyNWeeks,
+          startIndex: highestIndex + 1,
+          count,
+          timeZone: salon.timezone,
+        });
+        await this.prisma.$transaction(async (tx) => {
+          for (const occ of occurrences) {
+            const startAt = occ.startAt;
+            const endAt = new Date(
+              startAt.getTime() + series.durationMinutes * 60_000,
+            );
+            const appointment = await tx.appointment.create({
+              data: {
+                salonId,
+                clientId: series.clientId,
+                staffMemberId: series.staffMemberId,
+                startAt,
+                endAt,
+                status: AppointmentStatusEnum.SCHEDULED,
+                source: AppointmentSourceEnum.STAFF,
+                notes: series.notes,
+                internalNotes: series.internalNotes,
+                createdById: series.createdById,
+                seriesId: series.id,
+                seriesIndex: occ.seriesIndex,
+                services: {
+                  create: orderedServices.map((s, i) => ({
+                    serviceId: s.id,
+                    serviceNameSnapshot: s.name,
+                    priceSnapshotCents: s.defaultPriceCents,
+                    durationSnapshotMinutes: s.defaultDurationMinutes,
+                    currencySnapshot: s.currency,
+                    sortOrder: i,
+                  })),
+                },
+              },
+            });
+            await tx.outboxEvent.create({
+              data: {
+                salonId,
+                eventType: EventType.APPOINTMENT_REMINDER_DUE,
+                payload: {
+                  id: appointment.id,
+                  salonId,
+                } as Prisma.InputJsonValue,
+                status: OutboxStatus.PENDING,
+                nextAttemptAt: new Date(startAt.getTime() - REMINDER_LEAD_MS),
+              },
+            });
+          }
+        });
+        materializedCount = occurrences.length;
+      }
+    }
+
+    // Did we just hit the finite cap? Flip to COMPLETED so subsequent top-offs
+    // exit early. The outbox row itself completes via the worker; we don't
+    // re-enqueue a top-off in this case.
+    const newHighestIndex = highestIndex + materializedCount;
+    const willHitCap =
+      series.stopAfterVisits !== null &&
+      newHighestIndex >= series.stopAfterVisits;
+    if (willHitCap) {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.appointmentSeries.update({
+          where: { id: seriesId },
+          data: { status: AppointmentSeriesStatusEnum.COMPLETED },
+        });
+        await appendDomainEvent(tx, {
+          salonId,
+          aggregateType: "APPOINTMENT_SERIES",
+          aggregateId: seriesId,
+          eventType: EventType.APPOINTMENT_SERIES_COMPLETED,
+          payload: {
+            totalOccurrences: newHighestIndex,
+          } as Prisma.InputJsonValue,
+        });
+      });
+      return;
+    }
+
+    // Still active — re-queue the next top-off. This is the chain that keeps
+    // an indefinite series running forever: each top-off enqueues the next.
+    await this.prisma.outboxEvent.create({
+      data: {
+        salonId,
+        eventType: EventType.APPOINTMENT_SERIES_TOP_OFF_DUE,
+        payload: { seriesId, salonId } as Prisma.InputJsonValue,
+        status: OutboxStatus.PENDING,
+        nextAttemptAt: new Date(Date.now() + TOP_OFF_INTERVAL_MS),
+      },
+    });
+  }
+}

--- a/apps/api/src/outbox/outbox.module.ts
+++ b/apps/api/src/outbox/outbox.module.ts
@@ -1,7 +1,12 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
+import { AppointmentsModule } from "../appointments/appointments.module";
 import { OutboxWorker } from "./outbox.worker";
 
+// forwardRef defends against a future cycle: today AppointmentsModule
+// doesn't import OutboxModule, but exporting AppointmentSeriesService for
+// the worker's dispatch is the kind of boundary that quietly grows into one.
 @Module({
+  imports: [forwardRef(() => AppointmentsModule)],
   providers: [OutboxWorker],
   exports: [OutboxWorker],
 })

--- a/apps/api/src/outbox/outbox.worker.ts
+++ b/apps/api/src/outbox/outbox.worker.ts
@@ -9,6 +9,7 @@ import { EventType } from "@shearsimp/shared";
 import { env } from "../env";
 import { PrismaService } from "../prisma/prisma.service";
 import { SmsHandlersService } from "../messaging/sms-handlers.service";
+import { AppointmentSeriesService } from "../appointments/series.service";
 
 const POLL_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 25;
@@ -28,6 +29,7 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
   constructor(
     private readonly prisma: PrismaService,
     private readonly smsHandlers: SmsHandlersService,
+    private readonly seriesService: AppointmentSeriesService,
   ) {}
 
   onModuleInit() {
@@ -159,6 +161,9 @@ export class OutboxWorker implements OnModuleInit, OnModuleDestroy {
         return;
       case EventType.APPOINTMENT_REMINDER_DUE:
         await this.smsHandlers.handleAppointmentReminderDue(event);
+        return;
+      case EventType.APPOINTMENT_SERIES_TOP_OFF_DUE:
+        await this.seriesService.handleTopOffDue(event);
         return;
       default:
         // Unknown event types are silently completed so a bad row can't wedge

--- a/apps/api/test/cadence.test.ts
+++ b/apps/api/test/cadence.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { occurrenceRange, occurrenceStartAt } from "../src/appointments/cadence";
+
+describe("cadence", () => {
+  it("produces equal-spaced occurrences within a single DST window", () => {
+    // Anchor: 2026-04-15 4:45pm America/New_York (EDT, UTC-4 → 20:45Z).
+    // EDT runs from March until November, so the next 5 monthly visits
+    // never cross a DST boundary; arithmetic should be a clean +28 days.
+    const anchorStartAt = new Date("2026-04-15T20:45:00.000Z");
+    const occurrences = occurrenceRange({
+      anchorStartAt,
+      anchorIndex: 1,
+      everyNWeeks: 4,
+      startIndex: 1,
+      count: 5,
+      timeZone: "America/New_York",
+    });
+    expect(occurrences.map((o) => o.seriesIndex)).toEqual([1, 2, 3, 4, 5]);
+    expect(occurrences[0].startAt.toISOString()).toBe("2026-04-15T20:45:00.000Z");
+    expect(occurrences[1].startAt.toISOString()).toBe("2026-05-13T20:45:00.000Z");
+    expect(occurrences[2].startAt.toISOString()).toBe("2026-06-10T20:45:00.000Z");
+    expect(occurrences[3].startAt.toISOString()).toBe("2026-07-08T20:45:00.000Z");
+    expect(occurrences[4].startAt.toISOString()).toBe("2026-08-05T20:45:00.000Z");
+  });
+
+  it("preserves wall-clock time across the spring DST boundary", () => {
+    // Anchor: 2026-02-12 4:45pm America/New_York (EST, UTC-5 → 21:45Z).
+    // 4 weeks later is 2026-03-12 — which is past the 2026-03-08 DST
+    // jump in the US, so the offset becomes UTC-4. The wall-clock time
+    // should still be 4:45pm, meaning UTC shifts from 21:45Z to 20:45Z.
+    const anchorStartAt = new Date("2026-02-12T21:45:00.000Z");
+    const next = occurrenceStartAt({
+      anchorStartAt,
+      anchorIndex: 1,
+      everyNWeeks: 4,
+      seriesIndex: 2,
+      timeZone: "America/New_York",
+    });
+    expect(next.toISOString()).toBe("2026-03-12T20:45:00.000Z");
+  });
+
+  it("preserves wall-clock time across the fall DST boundary", () => {
+    // Anchor: 2026-10-15 4:45pm EDT (UTC-4 → 20:45Z). 4 weeks later is
+    // 2026-11-12 — past the 2026-11-01 fallback to EST (UTC-5). The
+    // wall-clock 4:45pm should map back to 21:45Z.
+    const anchorStartAt = new Date("2026-10-15T20:45:00.000Z");
+    const next = occurrenceStartAt({
+      anchorStartAt,
+      anchorIndex: 1,
+      everyNWeeks: 4,
+      seriesIndex: 2,
+      timeZone: "America/New_York",
+    });
+    expect(next.toISOString()).toBe("2026-11-12T21:45:00.000Z");
+  });
+
+  it("anchorIndex shifts the formula's origin without changing cadence", () => {
+    // After a "this and following" reschedule from occurrence #3, the
+    // series anchor becomes the new time at index 3. Index 4 is one
+    // cadence forward, index 5 is two.
+    const anchorStartAt = new Date("2026-06-04T18:00:00.000Z");
+    const week3 = occurrenceStartAt({
+      anchorStartAt,
+      anchorIndex: 3,
+      everyNWeeks: 2,
+      seriesIndex: 3,
+      timeZone: "America/New_York",
+    });
+    const week4 = occurrenceStartAt({
+      anchorStartAt,
+      anchorIndex: 3,
+      everyNWeeks: 2,
+      seriesIndex: 4,
+      timeZone: "America/New_York",
+    });
+    const week5 = occurrenceStartAt({
+      anchorStartAt,
+      anchorIndex: 3,
+      everyNWeeks: 2,
+      seriesIndex: 5,
+      timeZone: "America/New_York",
+    });
+    expect(week3.toISOString()).toBe("2026-06-04T18:00:00.000Z");
+    expect(week4.toISOString()).toBe("2026-06-18T18:00:00.000Z");
+    expect(week5.toISOString()).toBe("2026-07-02T18:00:00.000Z");
+  });
+
+  it("supports a UTC-fixed timezone with no DST", () => {
+    // Iceland is UTC year-round, so the cadence math is the trivial case.
+    const anchorStartAt = new Date("2026-01-15T15:00:00.000Z");
+    const next = occurrenceStartAt({
+      anchorStartAt,
+      anchorIndex: 1,
+      everyNWeeks: 1,
+      seriesIndex: 10,
+      timeZone: "Atlantic/Reykjavik",
+    });
+    expect(next.toISOString()).toBe("2026-03-19T15:00:00.000Z");
+  });
+});

--- a/packages/db/prisma/migrations/20260429220000_appointment_series/migration.sql
+++ b/packages/db/prisma/migrations/20260429220000_appointment_series/migration.sql
@@ -1,0 +1,88 @@
+-- CreateEnum
+CREATE TYPE "AppointmentSeriesStatus" AS ENUM ('ACTIVE', 'CANCELLED', 'COMPLETED');
+
+-- AlterEnum
+ALTER TYPE "AggregateType" ADD VALUE 'APPOINTMENT_SERIES';
+
+-- AlterTable
+ALTER TABLE "appointments" ADD COLUMN     "seriesId" UUID,
+ADD COLUMN     "seriesIndex" INTEGER;
+
+-- CreateTable
+CREATE TABLE "appointment_series" (
+    "id" UUID NOT NULL,
+    "salonId" UUID NOT NULL,
+    "clientId" UUID NOT NULL,
+    "staffMemberId" UUID NOT NULL,
+    "anchorStartAt" TIMESTAMP(3) NOT NULL,
+    "anchorIndex" INTEGER NOT NULL DEFAULT 1,
+    "durationMinutes" INTEGER NOT NULL,
+    "everyNWeeks" INTEGER NOT NULL,
+    "stopAfterVisits" INTEGER,
+    "status" "AppointmentSeriesStatus" NOT NULL DEFAULT 'ACTIVE',
+    "notes" TEXT,
+    "internalNotes" TEXT,
+    "createdById" UUID,
+    "cancelledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "appointment_series_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "appointment_series_services" (
+    "id" UUID NOT NULL,
+    "salonId" UUID NOT NULL,
+    "seriesId" UUID NOT NULL,
+    "serviceId" UUID NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "appointment_series_services_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "appointments_salonId_seriesId_seriesIndex_idx" ON "appointments"("salonId", "seriesId", "seriesIndex");
+
+-- CreateIndex
+CREATE INDEX "appointment_series_salonId_status_idx" ON "appointment_series"("salonId", "status");
+
+-- CreateIndex
+CREATE INDEX "appointment_series_salonId_clientId_idx" ON "appointment_series"("salonId", "clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "appointment_series_id_salonId_key" ON "appointment_series"("id", "salonId");
+
+-- CreateIndex
+CREATE INDEX "appointment_series_services_salonId_seriesId_idx" ON "appointment_series_services"("salonId", "seriesId");
+
+-- CreateIndex
+CREATE INDEX "appointment_series_services_salonId_serviceId_idx" ON "appointment_series_services"("salonId", "serviceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "appointment_series_services_seriesId_serviceId_key" ON "appointment_series_services"("seriesId", "serviceId");
+
+-- AddForeignKey
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_seriesId_salonId_fkey" FOREIGN KEY ("seriesId", "salonId") REFERENCES "appointment_series"("id", "salonId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series" ADD CONSTRAINT "appointment_series_salonId_fkey" FOREIGN KEY ("salonId") REFERENCES "salons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series" ADD CONSTRAINT "appointment_series_clientId_salonId_fkey" FOREIGN KEY ("clientId", "salonId") REFERENCES "clients"("id", "salonId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series" ADD CONSTRAINT "appointment_series_staffMemberId_salonId_fkey" FOREIGN KEY ("staffMemberId", "salonId") REFERENCES "staff_members"("id", "salonId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series" ADD CONSTRAINT "appointment_series_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series_services" ADD CONSTRAINT "appointment_series_services_salonId_fkey" FOREIGN KEY ("salonId") REFERENCES "salons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series_services" ADD CONSTRAINT "appointment_series_services_seriesId_salonId_fkey" FOREIGN KEY ("seriesId", "salonId") REFERENCES "appointment_series"("id", "salonId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_series_services" ADD CONSTRAINT "appointment_series_services_serviceId_salonId_fkey" FOREIGN KEY ("serviceId", "salonId") REFERENCES "services"("id", "salonId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -56,6 +56,12 @@ enum AppointmentSource {
   IMPORT
 }
 
+enum AppointmentSeriesStatus {
+  ACTIVE
+  CANCELLED
+  COMPLETED
+}
+
 enum PaymentStatus {
   PENDING
   SUCCEEDED
@@ -109,6 +115,7 @@ enum ActorType {
 
 enum AggregateType {
   APPOINTMENT
+  APPOINTMENT_SERIES
   CLIENT
   PAYMENT
   MESSAGE
@@ -149,6 +156,8 @@ model Salon {
   services             Service[]
   appointments         Appointment[]
   appointmentServices  AppointmentService[]
+  appointmentSeries        AppointmentSeries[]
+  appointmentSeriesServices AppointmentSeriesService[]
   payments             Payment[]
   messages             Message[]
   domainEvents         DomainEvent[]
@@ -170,6 +179,7 @@ model User {
   memberships  SalonMembership[]
   staffLinks   StaffMember[]
   appointmentsCreated Appointment[] @relation("AppointmentCreatedBy")
+  appointmentSeriesCreated AppointmentSeries[] @relation("AppointmentSeriesCreatedBy")
 
   @@map("users")
 }
@@ -211,6 +221,7 @@ model StaffMember {
   salon         Salon          @relation(fields: [salonId], references: [id], onDelete: Cascade)
   user          User?          @relation(fields: [userId], references: [id], onDelete: SetNull)
   appointments  Appointment[]
+  appointmentSeries AppointmentSeries[]
   workingHours  WorkingHours[]
 
   @@unique([salonId, userId])
@@ -255,6 +266,7 @@ model Client {
 
   salon        Salon         @relation(fields: [salonId], references: [id], onDelete: Cascade)
   appointments Appointment[]
+  appointmentSeries AppointmentSeries[]
   payments     Payment[]
   messages     Message[]
 
@@ -304,6 +316,7 @@ model Service {
   // the required salonId — Postgres SET NULL would NULL all FK columns.
   category             ServiceCategory?     @relation(fields: [categoryId, salonId], references: [id, salonId], onDelete: Restrict)
   appointmentServices  AppointmentService[]
+  appointmentSeriesServices AppointmentSeriesService[]
 
   @@unique([salonId, slug])
   // Composite-FK target — referenced by AppointmentService.
@@ -328,6 +341,12 @@ model Appointment {
   notes                 String?
   internalNotes         String?
   createdById           String?            @db.Uuid
+  // Recurring-appointments membership. Null for one-off bookings. seriesIndex
+  // is 1-based and stable: seriesIndex=N is "the Nth scheduled visit in the
+  // series" even if some get cancelled. For finite series, the last visit has
+  // seriesIndex == series.stopAfterVisits.
+  seriesId              String?            @db.Uuid
+  seriesIndex           Int?
   // Set on completion. Used to learn duration prediction quality.
   actualStartAt         DateTime?
   actualEndAt           DateTime?
@@ -344,6 +363,11 @@ model Appointment {
   client        Client               @relation(fields: [clientId, salonId], references: [id, salonId], onDelete: Restrict)
   staffMember   StaffMember          @relation(fields: [staffMemberId, salonId], references: [id, salonId], onDelete: Restrict)
   createdBy     User?                @relation("AppointmentCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  // Composite FK (optional): when seriesId is set it must point to an
+  // AppointmentSeries in the same salon. SetNull on series delete would
+  // null only seriesId and leave the composite incomplete; we use Restrict
+  // so the operator must explicitly cascade-cancel before deleting a series.
+  series        AppointmentSeries?   @relation(fields: [seriesId, salonId], references: [id, salonId], onDelete: Restrict)
   services      AppointmentService[]
   payments      Payment[]
   predictions   DurationPrediction[]
@@ -352,6 +376,7 @@ model Appointment {
   @@index([salonId, status])
   @@index([salonId, staffMemberId, startAt])
   @@index([salonId, clientId, startAt])
+  @@index([salonId, seriesId, seriesIndex])
   // Composite-FK target — referenced by AppointmentService/Payment/DurationPrediction.
   @@unique([id, salonId], name: "appointments_id_salonId_key")
   @@map("appointments")
@@ -384,6 +409,74 @@ model AppointmentService {
   @@index([salonId, appointmentId])
   @@index([salonId, serviceId])
   @@map("appointment_services")
+}
+
+// Recurring appointments. The series row is the template — it owns the
+// cadence, the client/staff defaults, and the service list. Occurrences are
+// real Appointment rows with `seriesId` set, materialized eagerly up to a
+// rolling window so calendar conflict detection sees them as ordinary rows.
+//
+// Cadence: the first occurrence's startAt becomes `anchorStartAt`. Future
+// occurrences are anchorStartAt + N * everyNWeeks weeks at the same
+// wall-clock time in the salon's timezone (so DST shifts don't drift the
+// appointment). When the user "reschedules this and following", anchor
+// resets to the new time and `anchorIndex` records which occurrence the
+// new anchor maps to (default 1; bumped on each cascade reschedule).
+model AppointmentSeries {
+  id              String                  @id @default(uuid()) @db.Uuid
+  salonId         String                  @db.Uuid
+  clientId        String                  @db.Uuid
+  staffMemberId   String                  @db.Uuid
+  anchorStartAt   DateTime
+  anchorIndex     Int                     @default(1)
+  durationMinutes Int
+  everyNWeeks     Int
+  // Null = indefinite (the "regular" case — Darlene every 4 weeks forever).
+  // When set, no more than this many total occurrences materialize across
+  // the lifetime of the series, including any that have been cancelled.
+  stopAfterVisits Int?
+  status          AppointmentSeriesStatus @default(ACTIVE)
+  notes           String?
+  internalNotes   String?
+  createdById     String?                 @db.Uuid
+  cancelledAt     DateTime?
+  createdAt       DateTime                @default(now())
+  updatedAt       DateTime                @updatedAt
+
+  salon        Salon                       @relation(fields: [salonId], references: [id], onDelete: Cascade)
+  client       Client                      @relation(fields: [clientId, salonId], references: [id, salonId], onDelete: Restrict)
+  staffMember  StaffMember                 @relation(fields: [staffMemberId, salonId], references: [id, salonId], onDelete: Restrict)
+  createdBy    User?                       @relation("AppointmentSeriesCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  services     AppointmentSeriesService[]
+  appointments Appointment[]
+
+  @@index([salonId, status])
+  @@index([salonId, clientId])
+  // Composite-FK target — referenced by Appointment.seriesId.
+  @@unique([id, salonId], name: "appointment_series_id_salonId_key")
+  @@map("appointment_series")
+}
+
+// Junction: which services this recurring series books each time. We use a
+// junction (not a `String[]`) so the composite FK enforces same-salon
+// integrity for every service id in the template, matching the rest of the
+// schema's tenant-isolation pattern.
+model AppointmentSeriesService {
+  id        String   @id @default(uuid()) @db.Uuid
+  salonId   String   @db.Uuid
+  seriesId  String   @db.Uuid
+  serviceId String   @db.Uuid
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+
+  salon   Salon             @relation(fields: [salonId], references: [id], onDelete: Cascade)
+  series  AppointmentSeries @relation(fields: [seriesId, salonId], references: [id, salonId], onDelete: Cascade)
+  service Service           @relation(fields: [serviceId, salonId], references: [id, salonId], onDelete: Restrict)
+
+  @@unique([seriesId, serviceId])
+  @@index([salonId, seriesId])
+  @@index([salonId, serviceId])
+  @@map("appointment_series_services")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/db/test/enum-parity.test.ts
+++ b/packages/db/test/enum-parity.test.ts
@@ -9,6 +9,7 @@ import {
   Role,
   AppointmentStatus,
   AppointmentSource,
+  AppointmentSeriesStatus,
   PaymentStatus,
   MessageDirection,
   MessageStatus,
@@ -35,6 +36,11 @@ const cases: ParityCase[] = [
     name: "AppointmentSource",
     shared: AppointmentSource,
     prisma: Prisma.AppointmentSource,
+  },
+  {
+    name: "AppointmentSeriesStatus",
+    shared: AppointmentSeriesStatus,
+    prisma: Prisma.AppointmentSeriesStatus,
   },
   { name: "PaymentStatus", shared: PaymentStatus, prisma: Prisma.PaymentStatus },
   {

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -29,6 +29,14 @@ export const AppointmentSource = {
 export type AppointmentSource =
   (typeof AppointmentSource)[keyof typeof AppointmentSource];
 
+export const AppointmentSeriesStatus = {
+  ACTIVE: "ACTIVE",
+  CANCELLED: "CANCELLED",
+  COMPLETED: "COMPLETED",
+} as const;
+export type AppointmentSeriesStatus =
+  (typeof AppointmentSeriesStatus)[keyof typeof AppointmentSeriesStatus];
+
 export const PaymentStatus = {
   PENDING: "PENDING",
   SUCCEEDED: "SUCCEEDED",
@@ -75,6 +83,7 @@ export type ActorType = (typeof ActorType)[keyof typeof ActorType];
 
 export const AggregateType = {
   APPOINTMENT: "APPOINTMENT",
+  APPOINTMENT_SERIES: "APPOINTMENT_SERIES",
   CLIENT: "CLIENT",
   PAYMENT: "PAYMENT",
   MESSAGE: "MESSAGE",
@@ -99,6 +108,13 @@ export const EventType = {
   PAYMENT_REFUNDED: "payment.refunded",
 
   APPOINTMENT_REMINDER_DUE: "appointment.reminder_due",
+
+  APPOINTMENT_SERIES_CREATED: "appointment_series.created",
+  APPOINTMENT_SERIES_RESCHEDULED: "appointment_series.rescheduled",
+  APPOINTMENT_SERIES_CANCELLED: "appointment_series.cancelled",
+  APPOINTMENT_SERIES_EXTENDED: "appointment_series.extended",
+  APPOINTMENT_SERIES_COMPLETED: "appointment_series.completed",
+  APPOINTMENT_SERIES_TOP_OFF_DUE: "appointment_series.top_off_due",
 
   MESSAGE_SMS_SENT: "message.sms_sent",
   MESSAGE_SMS_RECEIVED: "message.sms_received",

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -239,15 +239,23 @@ export const appointmentCreateSchema = z.object({
   source: appointmentSourceSchema.default(AppointmentSource.STAFF),
 });
 
+// Reschedule cascade scope. "one" only moves this occurrence (default,
+// matching the pre-recurrence behaviour). "following" shifts every future
+// occurrence by the same delta and resets the series anchor so subsequent
+// top-offs use the new pattern. Ignored on appointments without a seriesId.
+export const appointmentScopeSchema = z.enum(["one", "following"]);
+
 export const appointmentRescheduleSchema = z.object({
   startAt: isoDateTime,
   // Allow moving to a different stylist as part of a reschedule. When omitted,
   // the existing stylist is kept.
   staffMemberId: uuidSchema.optional(),
+  scope: appointmentScopeSchema.default("one"),
 });
 
 export const appointmentCancelSchema = z.object({
   reason: optionalTrimmed(500),
+  scope: appointmentScopeSchema.default("one"),
 });
 
 export const appointmentNotesUpdateSchema = z
@@ -322,6 +330,53 @@ export type AppointmentCompleteInput = z.infer<
 >;
 export type AppointmentListQueryInput = z.infer<
   typeof appointmentListQuerySchema
+>;
+export type AppointmentScope = z.infer<typeof appointmentScopeSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recurring appointments (issue #19)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Cadence bounds. 1–52 weeks covers everything from "weekly highlights" to
+// "yearly check-in"; the upper bound also caps the wall-clock arithmetic
+// for the materializer. stopAfterVisits null is the indefinite mode (the
+// regular long-term client). When set, 2–52 — a one-visit "series" makes
+// no sense, and 52 is more than a year of weekly visits.
+export const appointmentSeriesCreateSchema = z.object({
+  clientId: uuidSchema,
+  staffMemberId: uuidSchema,
+  serviceIds: z.array(uuidSchema).min(1).max(20),
+  // First occurrence's wall-clock start. The materializer treats this as
+  // the series anchor: subsequent occurrences are at the same wall-clock
+  // time, N weeks later, in the salon's timezone.
+  startAt: isoDateTime,
+  everyNWeeks: z.number().int().min(1).max(52),
+  stopAfterVisits: z.number().int().min(2).max(52).nullable(),
+  notes: optionalNotes,
+  internalNotes: optionalNotes,
+  source: appointmentSourceSchema.default(AppointmentSource.STAFF),
+});
+
+export const appointmentSeriesExtendSchema = z.object({
+  // Add this many additional visits to a finite series. Server enforces
+  // the resulting total stays within stopAfterVisits' max (52). For
+  // indefinite series this endpoint is a no-op — they don't have a cap
+  // to extend.
+  additionalVisits: z.number().int().min(1).max(52),
+});
+
+export const appointmentSeriesCancelSchema = z.object({
+  reason: optionalTrimmed(500),
+});
+
+export type AppointmentSeriesCreateInput = z.infer<
+  typeof appointmentSeriesCreateSchema
+>;
+export type AppointmentSeriesExtendInput = z.infer<
+  typeof appointmentSeriesExtendSchema
+>;
+export type AppointmentSeriesCancelInput = z.infer<
+  typeof appointmentSeriesCancelSchema
 >;
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
First half of #19 — the backend for recurring appointments. UI lands as 19b.

## Summary

- **Schema** — `AppointmentSeries` + `AppointmentSeriesService` (composite `(id, salonId)` FKs); `Appointment` gains nullable `seriesId` + `seriesIndex`. New `AppointmentSeriesStatus` enum (`ACTIVE` / `CANCELLED` / `COMPLETED`).
- **Cadence is wall-clock-preserving in the salon's timezone** via `Intl.DateTimeFormat` (no new deps). "4:45pm Thursday every 4 weeks" stays at 4:45pm through both DST boundaries — see `apps/api/test/cadence.test.ts`.
- **Eager materialization with rolling top-off**: 12 future occurrences kept buffered; an `appointment_series.top_off_due` outbox event re-enqueues itself weekly while the series is `ACTIVE`. Indefinite series (no `stopAfterVisits`) are the regular-long-term-client path — Darlene's 20 years of every-4-week 4:45pm Thursdays is just `stopAfterVisits = null`. Finite series flip to `COMPLETED` once the cap's reached.
- **Reschedule + cancel take a `scope` (`"one" | "following"`, default `"one"`)**. Cascade reschedule shifts every future occurrence by the same delta and resets `series.anchorStartAt` / `anchorIndex` so subsequent top-offs use the new pattern. Cascade cancel ends the series (cancels all future occurrences, suppresses pending reminders + the next top-off).
- **New endpoints**: `POST /appointment-series`, `POST /appointment-series/:id/cancel`, `POST /appointment-series/:id/extend`, `GET /appointment-series/:id`.

## Tenant isolation

Every new tenant-scoped row has the composite `(id, salonId)` FK pattern the rest of the schema uses. `AppointmentSeriesService` is the junction (rather than a `String[]` of service ids) precisely so the same-salon constraint is enforced at the DB level.

## Backwards compatibility

`appointmentRescheduleSchema` and `appointmentCancelSchema` gained `scope` with a `.default("one")`, so existing web callers (which don't pass it) keep their pre-recurrence semantics. Verified by typechecking `apps/web`.

## Known limitation

Cascade reschedules apply a raw-millisecond delta to already-materialized rows (correct user intent — they dragged the block to a specific instant). If the cascade crosses a DST boundary, those rows could be off by an hour relative to the series' new wall-clock anchor. Future top-offs use the correct wall-clock pattern. Not blocking; can flag as a follow-up.

## Test plan

- [x] `pnpm typecheck` passes (`apps/api`, `apps/web`, `packages/shared`, `packages/db`)
- [x] `prisma validate` passes
- [x] Enum parity test passes (11/11 enums)
- [x] Full api Vitest suite passes (74/74)
- [x] New `cadence.test.ts` covers spring + fall DST transitions, anchor-index shifting, and a UTC-fixed timezone (5/5)
- [ ] `pnpm db:migrate` against a real Postgres (run as part of the PR review or merge)
- [ ] Manually create a series, verify 12 occurrences materialize, and confirm reschedule-following + extend + cancel-series end-to-end (done as part of 19b once the UI exists)