### PR TITLE
Phase 19b: recurring appointments UI

### DIFF
--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -56,6 +56,19 @@ const APPOINTMENT_INCLUDE = {
       sortOrder: true,
     },
   },
+  // Surface enough series state for the schedule UI to render the recurring
+  // glyph on the calendar block, the "every N weeks · ongoing" line on the
+  // detail panel, and the ending-soon banner — without a separate fetch
+  // per appointment. Nullable: only joins when seriesId is set.
+  series: {
+    select: {
+      id: true,
+      everyNWeeks: true,
+      stopAfterVisits: true,
+      status: true,
+      anchorIndex: true,
+    },
+  },
 } satisfies Prisma.AppointmentInclude;
 
 type AppointmentWithRelations = Prisma.AppointmentGetPayload<{

--- a/apps/api/src/appointments/series.controller.ts
+++ b/apps/api/src/appointments/series.controller.ts
@@ -68,4 +68,15 @@ export class AppointmentSeriesController {
   ) {
     return this.series.extend(salon.salonId, user.userId, id, input);
   }
+
+  // No body — the action is unambiguous. Idempotent: if the series is
+  // already indefinite the service returns the current state.
+  @Post(":id/convert-to-indefinite")
+  convertToIndefinite(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+  ) {
+    return this.series.convertToIndefinite(salon.salonId, user.userId, id);
+  }
 }

--- a/apps/api/src/appointments/series.service.ts
+++ b/apps/api/src/appointments/series.service.ts
@@ -401,6 +401,62 @@ export class AppointmentSeriesService {
     });
   }
 
+  // Flip a finite series to indefinite (stopAfterVisits = null) so it stops
+  // running out and the operator never has to remember to extend it again.
+  // The complement of extend(): both keep an at-risk-of-ending series alive,
+  // but converting drops the cap entirely so the rolling top-off keeps it
+  // running until the user cancels.
+  async convertToIndefinite(
+    salonId: string,
+    actorUserId: string,
+    seriesId: string,
+  ) {
+    const series = await this.get(salonId, seriesId);
+    if (series.status === AppointmentSeriesStatusEnum.CANCELLED) {
+      throw new ConflictException("Cannot convert a cancelled series");
+    }
+    if (series.stopAfterVisits === null) {
+      // Already indefinite. Treat as a no-op so the UI can call this
+      // optimistically without checking first.
+      return series;
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.appointmentSeries.update({
+        where: { id: seriesId },
+        data: {
+          stopAfterVisits: null,
+          status: AppointmentSeriesStatusEnum.ACTIVE,
+        },
+        include: SERIES_INCLUDE,
+      });
+      // Make sure a top-off is queued — a series that hit COMPLETED before
+      // this call will have suppressed its top-off chain, and indefinite
+      // mode needs that chain back.
+      await tx.outboxEvent.create({
+        data: {
+          salonId,
+          eventType: EventType.APPOINTMENT_SERIES_TOP_OFF_DUE,
+          payload: { seriesId, salonId } as Prisma.InputJsonValue,
+          status: OutboxStatus.PENDING,
+          nextAttemptAt: new Date(),
+        },
+      });
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "APPOINTMENT_SERIES",
+        aggregateId: seriesId,
+        eventType: EventType.APPOINTMENT_SERIES_EXTENDED,
+        payload: {
+          previousStopAfterVisits: series.stopAfterVisits,
+          newStopAfterVisits: null,
+        } as Prisma.InputJsonValue,
+        actorUserId,
+      });
+      return updated;
+    });
+  }
+
   // Extend a finite series by N more visits. Indefinite series have no cap
   // to extend — calling this is a 400. Bumps stopAfterVisits, flips
   // COMPLETED back to ACTIVE if relevant, and ensures a top-off is queued.

--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -78,6 +78,10 @@ export async function rescheduleAppointment(input: {
   id: string;
   startAtIso: string;
   staffMemberId?: string;
+  /** "one" (default) reschedules just this occurrence. "following" cascades
+   *  the same delta to every future occurrence in the series and resets the
+   *  series anchor. Ignored on appointments without a seriesId. */
+  scope?: "one" | "following";
 }): Promise<ActionResult> {
   try {
     await apiFetch(`/appointments/${input.id}/reschedule`, {
@@ -85,6 +89,7 @@ export async function rescheduleAppointment(input: {
       data: {
         startAt: input.startAtIso,
         ...(input.staffMemberId ? { staffMemberId: input.staffMemberId } : {}),
+        ...(input.scope ? { scope: input.scope } : {}),
       },
     });
     revalidatePath("/schedule");
@@ -128,12 +133,87 @@ export async function completeAppointment(
 export async function cancelAppointment(input: {
   id: string;
   reason?: string;
+  /** "one" (default) cancels just this visit. "following" cancels this
+   *  occurrence + all future occurrences and ends the series. Ignored on
+   *  appointments without a seriesId. */
+  scope?: "one" | "following";
 }): Promise<ActionResult> {
   try {
     await apiFetch(`/appointments/${input.id}/cancel`, {
       method: "POST",
-      data: { reason: input.reason ?? "" },
+      data: {
+        reason: input.reason ?? "",
+        ...(input.scope ? { scope: input.scope } : {}),
+      },
     });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// ---------- Recurring appointments (series) ----------
+
+export async function createSeriesAction(input: {
+  clientId: string;
+  staffMemberId: string;
+  serviceIds: string[];
+  startAtIso: string;
+  everyNWeeks: number;
+  /** null = indefinite (the regular long-term-client case). */
+  stopAfterVisits: number | null;
+  notes?: string;
+  internalNotes?: string;
+}): Promise<ActionResult> {
+  try {
+    const created = await apiFetch<{ id: string }>("/appointment-series", {
+      method: "POST",
+      data: {
+        clientId: input.clientId,
+        staffMemberId: input.staffMemberId,
+        serviceIds: input.serviceIds,
+        startAt: input.startAtIso,
+        everyNWeeks: input.everyNWeeks,
+        stopAfterVisits: input.stopAfterVisits,
+        notes: input.notes && input.notes.length > 0 ? input.notes : undefined,
+        internalNotes:
+          input.internalNotes && input.internalNotes.length > 0
+            ? input.internalNotes
+            : undefined,
+      },
+    });
+    revalidatePath("/schedule");
+    return { ok: true, appointmentId: created.id };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function extendSeriesAction(input: {
+  seriesId: string;
+  additionalVisits: number;
+}): Promise<ActionResult> {
+  try {
+    await apiFetch(`/appointment-series/${input.seriesId}/extend`, {
+      method: "POST",
+      data: { additionalVisits: input.additionalVisits },
+    });
+    revalidatePath("/schedule");
+    return { ok: true };
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function convertSeriesToIndefiniteAction(input: {
+  seriesId: string;
+}): Promise<ActionResult> {
+  try {
+    await apiFetch(
+      `/appointment-series/${input.seriesId}/convert-to-indefinite`,
+      { method: "POST", data: {} },
+    );
     revalidatePath("/schedule");
     return { ok: true };
   } catch (e) {

--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
@@ -13,6 +13,7 @@ import { categoryKind, type CategoryKind } from "@/lib/service-categories";
 import { instantAtMinutes } from "@/lib/salon-time";
 import {
   createAppointmentAction,
+  createSeriesAction,
   searchClientsAction,
 } from "../_actions";
 import {
@@ -110,6 +111,14 @@ export function BookAppointmentModal({
   const [notes, setNotes] = useState("");
   const [internalNotes, setInternalNotes] = useState("");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  // Recurrence section. Off by default — most bookings are one-offs.
+  // When on: cadence + cap. `noEndDate` defaults checked because
+  // "indefinite" is the safe answer that prevents Darlene-style series
+  // from quietly running out 20 years from now (issue #19).
+  const [recurOn, setRecurOn] = useState(false);
+  const [everyNWeeks, setEveryNWeeks] = useState(4);
+  const [noEndDate, setNoEndDate] = useState(true);
+  const [stopAfterVisits, setStopAfterVisits] = useState(6);
 
   // Lock body scroll while the modal is open, restore on unmount.
   useEffect(() => {
@@ -200,17 +209,27 @@ export function BookAppointmentModal({
     if (!canSubmit || minutes === null) return;
     setErrorMsg(null);
     const startAtIso = instantAtMinutes(minutes, date, timezone).toISOString();
+    const baseInput = {
+      clientId,
+      staffMemberId: staffId,
+      serviceIds: Array.from(serviceIds),
+      startAtIso,
+      notes: notes.trim() || undefined,
+      internalNotes: internalNotes.trim() || undefined,
+    };
     startTransition(async () => {
-      const result = await createAppointmentAction({
-        clientId,
-        staffMemberId: staffId,
-        serviceIds: Array.from(serviceIds),
-        startAtIso,
-        notes: notes.trim() || undefined,
-        internalNotes: internalNotes.trim() || undefined,
-      });
+      const result = recurOn
+        ? await createSeriesAction({
+            ...baseInput,
+            everyNWeeks,
+            stopAfterVisits: noEndDate ? null : stopAfterVisits,
+          })
+        : await createAppointmentAction(baseInput);
       if (!result.ok) {
-        setErrorMsg(result.message ?? "Could not book appointment");
+        setErrorMsg(
+          result.message ??
+            (recurOn ? "Could not create series" : "Could not book appointment"),
+        );
         return;
       }
       router.push(`/schedule?date=${date}`);
@@ -334,6 +353,75 @@ export function BookAppointmentModal({
               )}
             </div>
 
+            <div className="bk-field bk-field-recur">
+              <div className="ss-toggle-row">
+                <div className="ss-toggle-meta">
+                  <span className="ss-toggle-title">Repeat this booking</span>
+                  <span className="ss-toggle-sub">
+                    Set a cadence so the series materializes future visits
+                    automatically.
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className={`ss-toggle${recurOn ? " is-on" : ""}`}
+                  role="switch"
+                  aria-checked={recurOn}
+                  aria-label="Repeat this booking"
+                  onClick={() => setRecurOn((v) => !v)}
+                />
+              </div>
+              {recurOn && (
+                <div className="bk-recur-fields">
+                  <div className="bk-recur-row">
+                    <label htmlFor="bk-every">Every</label>
+                    <input
+                      id="bk-every"
+                      type="number"
+                      min={1}
+                      max={52}
+                      value={everyNWeeks}
+                      onChange={(e) =>
+                        setEveryNWeeks(
+                          clampInt(Number(e.target.value), 1, 52, 4),
+                        )
+                      }
+                    />
+                    <span>{everyNWeeks === 1 ? "week" : "weeks"}</span>
+                  </div>
+                  <div className="bk-recur-row">
+                    <label htmlFor="bk-no-end" className="bk-recur-checkbox">
+                      <input
+                        id="bk-no-end"
+                        type="checkbox"
+                        checked={noEndDate}
+                        onChange={(e) => setNoEndDate(e.target.checked)}
+                      />
+                      <span>No end date (recommended for regulars)</span>
+                    </label>
+                  </div>
+                  {!noEndDate && (
+                    <div className="bk-recur-row">
+                      <label htmlFor="bk-stop">Stop after</label>
+                      <input
+                        id="bk-stop"
+                        type="number"
+                        min={2}
+                        max={52}
+                        value={stopAfterVisits}
+                        onChange={(e) =>
+                          setStopAfterVisits(
+                            clampInt(Number(e.target.value), 2, 52, 6),
+                          )
+                        }
+                      />
+                      <span>visits</span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             <div className="bk-field">
               <label className="bk-label" htmlFor="bk-notes">
                 Notes (visible to client)
@@ -387,7 +475,13 @@ export function BookAppointmentModal({
               className="ss-btn ss-btn-primary"
               disabled={!canSubmit}
             >
-              {isPending ? "Booking…" : "Book appointment"}
+              {isPending
+                ? recurOn
+                  ? "Creating series…"
+                  : "Booking…"
+                : recurOn
+                  ? "Create recurring booking"
+                  : "Book appointment"}
             </button>
           </div>
         </div>
@@ -804,6 +898,14 @@ function formatPrice(cents: number, currency: string): string {
     currency,
     maximumFractionDigits: 0,
   }).format(cents / 100);
+}
+
+function clampInt(n: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(n)) return fallback;
+  const i = Math.round(n);
+  if (i < min) return min;
+  if (i > max) return max;
+  return i;
 }
 
 function formatDateLabel(iso: string): string {

--- a/apps/web/src/app/(app)/schedule/_components/cancel-appointment-modal.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/cancel-appointment-modal.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Cancel-confirmation modal. Replaces the old `window.prompt()` because we
+// now need a scope choice ("just this visit" vs "end the whole series")
+// for series occurrences, and a native prompt can't render a radio.
+export function CancelAppointmentModal({
+  clientName,
+  isSeries,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  clientName: string;
+  /** When true, surface the "End the whole series" radio. */
+  isSeries: boolean;
+  isPending: boolean;
+  onConfirm: (input: { reason: string; scope: "one" | "following" }) => void;
+  onClose: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [scope, setScope] = useState<"one" | "following">("one");
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <div className="bk-backdrop" onClick={onClose} aria-hidden />
+      <div
+        className="bk-modal bk-modal-classic ss-cancel-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ss-cancel-title"
+      >
+        <div className="bk-head">
+          <div>
+            <div className="bk-kicker">Cancel appointment</div>
+            <h2 className="bk-title" id="ss-cancel-title">
+              {clientName}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="bk-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+              <path
+                d="M2 2 L12 12 M12 2 L2 12"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="bk-modal-body">
+          {isSeries && (
+            <fieldset className="ss-scope-radio">
+              <legend className="bk-label">Cancel</legend>
+              <label className={`ss-scope-row${scope === "one" ? " is-on" : ""}`}>
+                <input
+                  type="radio"
+                  name="cancel-scope"
+                  value="one"
+                  checked={scope === "one"}
+                  onChange={() => setScope("one")}
+                />
+                <span>
+                  <strong>Just this visit</strong>
+                  <span className="ss-scope-sub">
+                    The series keeps running on its normal cadence.
+                  </span>
+                </span>
+              </label>
+              <label
+                className={`ss-scope-row${scope === "following" ? " is-on" : ""}`}
+              >
+                <input
+                  type="radio"
+                  name="cancel-scope"
+                  value="following"
+                  checked={scope === "following"}
+                  onChange={() => setScope("following")}
+                />
+                <span>
+                  <strong>End the whole series</strong>
+                  <span className="ss-scope-sub">
+                    Cancels every future occurrence and stops top-offs.
+                  </span>
+                </span>
+              </label>
+            </fieldset>
+          )}
+          <div className="bk-field">
+            <label className="bk-label" htmlFor="ss-cancel-reason">
+              Reason (optional)
+            </label>
+            <textarea
+              id="ss-cancel-reason"
+              className="bk-textarea"
+              rows={2}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              maxLength={500}
+              placeholder="Why is this being cancelled?"
+            />
+          </div>
+        </div>
+        <div className="bk-footer">
+          <span className="bk-footer-meta" />
+          <div className="bk-footer-actions">
+            <button
+              type="button"
+              className="ss-btn ss-btn-ghost"
+              onClick={onClose}
+              disabled={isPending}
+            >
+              Keep it
+            </button>
+            <button
+              type="button"
+              className="ss-btn ss-btn-primary"
+              onClick={() => onConfirm({ reason: reason.trim(), scope })}
+              disabled={isPending}
+            >
+              {isPending
+                ? "Cancelling…"
+                : scope === "following"
+                  ? "End series"
+                  : "Cancel appointment"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/schedule/_components/cascade-prompt-modal.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/cascade-prompt-modal.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Two-button confirm: "just this one" or "this and all future". Shown after
+// a drag-to-reschedule on a series occurrence so the operator's intent is
+// explicit — the alternative is a silent default that's wrong half the
+// time. Generic over reschedule + cancel so the wording can be tuned.
+export interface CascadePromptCopy {
+  title: string;
+  body: string;
+  oneLabel: string;
+  followingLabel: string;
+}
+
+export function CascadePromptModal({
+  copy,
+  onPick,
+  onCancel,
+  isPending,
+}: {
+  copy: CascadePromptCopy;
+  onPick: (scope: "one" | "following") => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  // Esc cancels. Same pattern as the booking modal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <>
+      <div className="bk-backdrop" onClick={onCancel} aria-hidden />
+      <div
+        className="bk-modal bk-modal-classic ss-cascade-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ss-cascade-title"
+      >
+        <div className="bk-head">
+          <div>
+            <div className="bk-kicker">Recurring appointment</div>
+            <h2 className="bk-title" id="ss-cascade-title">
+              {copy.title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="bk-close"
+            onClick={onCancel}
+            aria-label="Close"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+              <path
+                d="M2 2 L12 12 M12 2 L2 12"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="bk-modal-body">
+          <p className="ss-cascade-body">{copy.body}</p>
+          <div className="ss-cascade-actions">
+            <button
+              type="button"
+              className="ss-btn ss-btn-ghost"
+              onClick={() => onPick("one")}
+              disabled={isPending}
+            >
+              {copy.oneLabel}
+            </button>
+            <button
+              type="button"
+              className="ss-btn ss-btn-primary"
+              onClick={() => onPick("following")}
+              disabled={isPending}
+            >
+              {copy.followingLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -12,11 +12,15 @@ import {
 import {
   cancelAppointment,
   completeAppointment,
+  convertSeriesToIndefiniteAction,
+  extendSeriesAction,
   refundPaymentAction,
   rescheduleAppointment,
   startCheckoutAction,
   transitionAppointment,
 } from "../_actions";
+import { CascadePromptModal } from "./cascade-prompt-modal";
+import { CancelAppointmentModal } from "./cancel-appointment-modal";
 
 // Minutes-since-day-start grid. The calendar opens at SLOT_START minutes (9 AM
 // default) and runs until SLOT_END (7 PM). 15-minute granularity at 14px/slot
@@ -58,6 +62,15 @@ export interface ScheduleAppointmentService {
   currencySnapshot: string;
 }
 
+export interface ScheduleSeriesSummary {
+  id: string;
+  everyNWeeks: number;
+  /** null = indefinite (no cap to extend; runs forever until cancelled). */
+  stopAfterVisits: number | null;
+  status: "ACTIVE" | "CANCELLED" | "COMPLETED";
+  anchorIndex: number;
+}
+
 export interface ScheduleAppointment {
   id: string;
   startAt: string;
@@ -75,6 +88,14 @@ export interface ScheduleAppointment {
   client: { id: string; displayName: string; phone: string | null };
   staffMember: { id: string; displayName: string };
   services: ScheduleAppointmentService[];
+  /** When set, this appointment is part of a recurring series. seriesIndex
+   *  is the 1-based occurrence number within the series. */
+  seriesId: string | null;
+  seriesIndex: number | null;
+  /** Series summary, included by the API when seriesId is set. Drives the
+   *  recurring glyph, the detail-panel "every N weeks" line, and the
+   *  ending-soon banner. */
+  series: ScheduleSeriesSummary | null;
 }
 
 export type SchedulePaymentStatus =
@@ -179,6 +200,20 @@ export function ScheduleView({
     slot: number;
   } | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  // Stash the reschedule params from a drag-drop on a series occurrence
+  // until the cascade prompt resolves. null = no prompt active.
+  const [pendingReschedule, setPendingReschedule] = useState<{
+    appointmentId: string;
+    clientName: string;
+    startAtIso: string;
+    staffMemberId?: string;
+  } | null>(null);
+  // null = closed; { id } = open with that appointment.
+  const [cancelTarget, setCancelTarget] = useState<{
+    id: string;
+    clientName: string;
+    isSeries: boolean;
+  } | null>(null);
 
   // Lookup table from serviceId to its category kind (for color coding).
   // Keyed by snapshot service id rather than name so it's stable across
@@ -287,13 +322,46 @@ export function ScheduleView({
       timezone,
     ).toISOString();
 
+    const staffMemberId =
+      block.staffIndex === staffIndex ? undefined : targetStaff.id;
+
+    // Series occurrence: ask which scope before firing. Resolving the
+    // prompt calls runReschedule() with the chosen scope. Non-series
+    // appointments skip the prompt entirely.
+    if (
+      block.appointment.seriesId &&
+      block.appointment.series?.status === "ACTIVE"
+    ) {
+      setPendingReschedule({
+        appointmentId,
+        clientName: block.appointment.client.displayName,
+        startAtIso: newStartIso,
+        staffMemberId,
+      });
+      return;
+    }
+
+    runReschedule({
+      appointmentId,
+      startAtIso: newStartIso,
+      staffMemberId,
+      scope: "one",
+    });
+  }
+
+  function runReschedule(args: {
+    appointmentId: string;
+    startAtIso: string;
+    staffMemberId?: string;
+    scope: "one" | "following";
+  }) {
     setErrorMsg(null);
     startTransition(async () => {
       const result = await rescheduleAppointment({
-        id: appointmentId,
-        startAtIso: newStartIso,
-        staffMemberId:
-          block.staffIndex === staffIndex ? undefined : targetStaff.id,
+        id: args.appointmentId,
+        startAtIso: args.startAtIso,
+        staffMemberId: args.staffMemberId,
+        scope: args.scope,
       });
       if (!result.ok) {
         setErrorMsg(result.message ?? "Reschedule failed");
@@ -489,6 +557,63 @@ export function ScheduleView({
               router.refresh();
             });
           }}
+          onRequestCancel={() =>
+            setCancelTarget({
+              id: selected.id,
+              clientName: selected.client.displayName,
+              isSeries: !!selected.seriesId && selected.series?.status === "ACTIVE",
+            })
+          }
+        />
+      )}
+
+      {pendingReschedule && (
+        <CascadePromptModal
+          copy={{
+            title: `Move ${pendingReschedule.clientName}'s appointment`,
+            body: "This visit is part of a recurring series. Apply the new time to just this one, or this and every future occurrence?",
+            oneLabel: "Just this one",
+            followingLabel: "This and all future",
+          }}
+          isPending={isPending}
+          onCancel={() => setPendingReschedule(null)}
+          onPick={(scope) => {
+            const args = pendingReschedule;
+            setPendingReschedule(null);
+            runReschedule({
+              appointmentId: args.appointmentId,
+              startAtIso: args.startAtIso,
+              staffMemberId: args.staffMemberId,
+              scope,
+            });
+          }}
+        />
+      )}
+
+      {cancelTarget && (
+        <CancelAppointmentModal
+          clientName={cancelTarget.clientName}
+          isSeries={cancelTarget.isSeries}
+          isPending={isPending}
+          onClose={() => setCancelTarget(null)}
+          onConfirm={({ reason, scope }) => {
+            const target = cancelTarget;
+            setCancelTarget(null);
+            setErrorMsg(null);
+            startTransition(async () => {
+              const r = await cancelAppointment({
+                id: target.id,
+                reason,
+                scope,
+              });
+              if (!r.ok) {
+                setErrorMsg(r.message ?? "Cancel failed");
+                return;
+              }
+              setSelectedId(null);
+              router.refresh();
+            });
+          }}
         />
       )}
     </>
@@ -608,6 +733,15 @@ function AppointmentBlock({
     >
       <div className="ss-cal-block-name">
         {appointment.client.displayName}
+        {appointment.seriesId && (
+          <span
+            className="ss-cal-block-recur"
+            title="Part of a recurring series"
+            aria-label="Recurring"
+          >
+            ↻
+          </span>
+        )}
         {paymentBadgeKind && (
           <span
             className={`ss-cal-block-pay is-${paymentBadgeKind}`}
@@ -638,6 +772,7 @@ function DetailsPanel({
   isPending,
   onClose,
   onAction,
+  onRequestCancel,
 }: {
   appointment: ScheduleAppointment;
   payment: SchedulePayment | null;
@@ -647,6 +782,7 @@ function DetailsPanel({
   onAction: (
     run: () => Promise<{ ok: boolean; message?: string }>,
   ) => void;
+  onRequestCancel: () => void;
 }) {
   const start = formatTimeInTimezone(new Date(appointment.startAt), timezone);
   const end = formatTimeInTimezone(new Date(appointment.endAt), timezone);
@@ -696,6 +832,12 @@ function DetailsPanel({
         {start} – {end} · with {appointment.staffMember.displayName}
       </p>
       <p className="ss-detail-services">{services}</p>
+      {appointment.series && appointment.seriesIndex !== null && (
+        <p className="ss-detail-recur">
+          <span className="ss-detail-recur-glyph" aria-hidden>↻</span>
+          {seriesSummaryLine(appointment.series, appointment.seriesIndex)}
+        </p>
+      )}
       {appointment.client.phone && (
         <p className="ss-detail-meta">{appointment.client.phone}</p>
       )}
@@ -712,6 +854,17 @@ function DetailsPanel({
         </div>
       )}
       <PaymentSection appointment={appointment} payment={payment} />
+      {appointment.series &&
+        appointment.seriesIndex !== null &&
+        shouldShowEndingBanner(appointment.series, appointment.seriesIndex) && (
+          <SeriesEndingSoonBanner
+            seriesId={appointment.series.id}
+            seriesIndex={appointment.seriesIndex}
+            stopAfterVisits={appointment.series.stopAfterVisits!}
+            isPending={isPending}
+            onAction={onAction}
+          />
+        )}
       <div className="ss-detail-actions">
         {advanceTarget.map((t) => (
           <button
@@ -748,12 +901,7 @@ function DetailsPanel({
             type="button"
             className="ss-btn ss-btn-ghost"
             disabled={isPending}
-            onClick={() => {
-              const reason = window.prompt("Cancellation reason (optional)") ?? "";
-              onAction(() =>
-                cancelAppointment({ id: appointment.id, reason }),
-              );
-            }}
+            onClick={onRequestCancel}
           >
             Cancel
           </button>
@@ -1052,5 +1200,96 @@ function slotForBlock(block: RenderBlock): number {
   return Math.max(
     0,
     Math.round((block.startMin - SLOT_START_MIN) / SLOT_MIN),
+  );
+}
+
+// "Recurring · every 4 weeks · 5 of 6" / "ongoing" / "completed".
+function seriesSummaryLine(
+  series: ScheduleSeriesSummary,
+  seriesIndex: number,
+): string {
+  const cadence = `every ${cadenceLabel(series.everyNWeeks)}`;
+  const progress =
+    series.status === "CANCELLED"
+      ? "ended"
+      : series.stopAfterVisits === null
+        ? "ongoing"
+        : `${seriesIndex} of ${series.stopAfterVisits}`;
+  return `Recurring · ${cadence} · ${progress}`;
+}
+
+function cadenceLabel(everyNWeeks: number): string {
+  if (everyNWeeks === 1) return "week";
+  return `${everyNWeeks} weeks`;
+}
+
+// Show the ending-soon banner on the last 1-2 occurrences of a finite,
+// active series. Not on already-cancelled / already-completed series — at
+// that point the operator can't extend without recreating.
+function shouldShowEndingBanner(
+  series: ScheduleSeriesSummary,
+  seriesIndex: number,
+): boolean {
+  if (series.status !== "ACTIVE") return false;
+  if (series.stopAfterVisits === null) return false;
+  return seriesIndex >= series.stopAfterVisits - 1;
+}
+
+function SeriesEndingSoonBanner({
+  seriesId,
+  seriesIndex,
+  stopAfterVisits,
+  isPending,
+  onAction,
+}: {
+  seriesId: string;
+  seriesIndex: number;
+  stopAfterVisits: number;
+  isPending: boolean;
+  onAction: (
+    run: () => Promise<{ ok: boolean; message?: string }>,
+  ) => void;
+}) {
+  const isLast = seriesIndex === stopAfterVisits;
+  const headline = isLast
+    ? "Last visit in this series."
+    : `Second-to-last visit (${seriesIndex} of ${stopAfterVisits}).`;
+  return (
+    <div className="ss-detail-section ss-series-end-banner" role="status">
+      <div className="ss-series-end-banner-head">
+        <span className="ss-detail-recur-glyph" aria-hidden>↻</span>
+        <strong>{headline}</strong>
+      </div>
+      <p className="ss-series-end-banner-body">
+        Don&apos;t lose this regular. Add more visits or switch to indefinite
+        so it never runs out.
+      </p>
+      <div className="ss-series-end-banner-actions">
+        <button
+          type="button"
+          className="ss-btn ss-btn-ghost"
+          disabled={isPending}
+          onClick={() =>
+            onAction(() =>
+              extendSeriesAction({ seriesId, additionalVisits: 6 }),
+            )
+          }
+        >
+          Extend by 6 more
+        </button>
+        <button
+          type="button"
+          className="ss-btn ss-btn-primary"
+          disabled={isPending}
+          onClick={() =>
+            onAction(() =>
+              convertSeriesToIndefiniteAction({ seriesId }),
+            )
+          }
+        >
+          Switch to indefinite
+        </button>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -327,10 +327,13 @@ export function ScheduleView({
 
     // Series occurrence: ask which scope before firing. Resolving the
     // prompt calls runReschedule() with the chosen scope. Non-series
-    // appointments skip the prompt entirely.
+    // appointments skip the prompt entirely. Both ACTIVE and COMPLETED
+    // series can still have future occurrences worth cascading — only
+    // CANCELLED skips the prompt (its future occurrences were already
+    // cancelled when the series ended).
     if (
       block.appointment.seriesId &&
-      block.appointment.series?.status === "ACTIVE"
+      block.appointment.series?.status !== "CANCELLED"
     ) {
       setPendingReschedule({
         appointmentId,
@@ -561,7 +564,12 @@ export function ScheduleView({
             setCancelTarget({
               id: selected.id,
               clientName: selected.client.displayName,
-              isSeries: !!selected.seriesId && selected.series?.status === "ACTIVE",
+              // ACTIVE *and* COMPLETED series can still have future
+              // occurrences (a finite series flips to COMPLETED as soon as
+              // the cap is materialized). Only CANCELLED has nothing left
+              // to cascade.
+              isSeries:
+                !!selected.seriesId && selected.series?.status !== "CANCELLED",
             })
           }
         />
@@ -1223,14 +1231,17 @@ function cadenceLabel(everyNWeeks: number): string {
   return `${everyNWeeks} weeks`;
 }
 
-// Show the ending-soon banner on the last 1-2 occurrences of a finite,
-// active series. Not on already-cancelled / already-completed series — at
-// that point the operator can't extend without recreating.
+// Show the ending-soon banner on the last 1-2 occurrences of a finite
+// series. Includes COMPLETED — a finite series flips to COMPLETED as soon
+// as its cap is fully materialized, but the occurrences themselves are
+// still in the future and the banner is the only in-UI recovery path
+// (extend / convert to indefinite). Only CANCELLED is excluded; once a
+// series is cancelled there's nothing to extend.
 function shouldShowEndingBanner(
   series: ScheduleSeriesSummary,
   seriesIndex: number,
 ): boolean {
-  if (series.status !== "ACTIVE") return false;
+  if (series.status === "CANCELLED") return false;
   if (series.stopAfterVisits === null) return false;
   return seriesIndex >= series.stopAfterVisits - 1;
 }

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -2464,3 +2464,183 @@
   text-overflow: ellipsis;
 }
 
+/* ============= RECURRING APPOINTMENTS (issue #19) ============= */
+
+/* Tiny ↻ glyph in the calendar block header alongside the payment badge.
+   Matches the .ss-cal-block-pay sibling sizing so both badges align. */
+.ss-cal-block-recur {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  margin-left: auto;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ss-text-heading);
+  box-shadow: 0 1px 2px rgba(15, 30, 50, 0.12);
+}
+.ss-cal-block-name .ss-cal-block-recur + .ss-cal-block-pay { margin-left: 4px; }
+
+/* "Recurring · every N weeks · X of Y" line in the appointment detail panel. */
+.ss-detail-recur {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--ss-card-tint);
+  border: 1px solid var(--ss-line);
+  font-size: 12px;
+  color: var(--ss-text-muted);
+  width: fit-content;
+}
+.ss-detail-recur-glyph {
+  font-size: 13px;
+  color: var(--ss-cyan);
+  font-weight: 600;
+}
+
+/* Ending-soon banner inside the detail panel — uses .ss-detail-section as
+   the host for spacing and adds its own border+padding for emphasis. */
+.ss-series-end-banner {
+  border: 1px solid var(--ss-line-strong);
+  border-left: 3px solid var(--ss-magenta);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: var(--ss-card-tint);
+}
+.ss-series-end-banner-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ss-text-heading);
+}
+.ss-series-end-banner-body {
+  margin: 6px 0 10px;
+  font-size: 12.5px;
+  color: var(--ss-text-muted);
+}
+.ss-series-end-banner-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.ss-series-end-banner-actions .ss-btn {
+  font-size: 12.5px;
+  padding: 6px 12px;
+}
+
+/* Booking-modal recurrence section. The .ss-toggle-row used inside the
+   field gives us the slide-switch + meta layout for free; bk-recur-fields
+   is the disclosure for cadence inputs once the toggle is on. */
+.bk-field-recur .ss-toggle-row {
+  border-bottom: 0;
+  padding: 8px 0 0;
+}
+.bk-recur-fields {
+  margin-top: 8px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: var(--ss-card-tint);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.bk-recur-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ss-text-primary);
+}
+.bk-recur-row label {
+  color: var(--ss-text-muted);
+  font-size: 12.5px;
+}
+.bk-recur-row input[type="number"] {
+  width: 60px;
+  padding: 4px 8px;
+  border: 1px solid var(--ss-line);
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--ss-card-bg);
+  color: var(--ss-text-primary);
+}
+.bk-recur-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.bk-recur-checkbox input { accent-color: var(--ss-cyan); }
+
+/* Cascade prompt and cancel modals reuse the .bk-modal-classic shell. */
+.ss-cascade-modal,
+.ss-cancel-modal {
+  width: min(440px, calc(100vw - 32px));
+}
+.ss-cascade-body {
+  margin: 0 0 16px;
+  padding: 0 24px;
+  font-size: 13.5px;
+  color: var(--ss-text-primary);
+  line-height: 1.5;
+}
+.ss-cascade-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding: 0 24px 20px;
+}
+
+/* Scope radio in the cancel modal. Two big rows so the choice reads
+   clearly even when scanning. */
+.ss-scope-radio {
+  border: 0;
+  margin: 0 0 16px;
+  padding: 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ss-scope-radio legend { padding: 0 0 6px; }
+.ss-scope-row {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  align-items: start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--ss-line);
+  border-radius: 8px;
+  background: var(--ss-card-bg);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.ss-scope-row.is-on {
+  border-color: var(--ss-cyan);
+  background: var(--ss-card-tint);
+}
+.ss-scope-row input[type="radio"] {
+  margin-top: 2px;
+  accent-color: var(--ss-cyan);
+}
+.ss-scope-row strong {
+  display: block;
+  font-size: 13.5px;
+  color: var(--ss-text-heading);
+  margin-bottom: 2px;
+}
+.ss-scope-sub {
+  display: block;
+  font-size: 12px;
+  color: var(--ss-text-muted);
+  line-height: 1.4;
+}
+


### PR DESCRIPTION
Wires the recurring-appointments backend (#32) into the schedule UI. Closes #19.

## Summary

- **Booking modal** — new "Repeat this booking" toggle below the date/time picker. When on, an everyNWeeks input + a "No end date (recommended for regulars)" checkbox (defaulted on) + an optional stopAfterVisits field. Submit routes to a new \`createSeriesAction\` instead of \`createAppointmentAction\`.
- **Calendar block** — tiny ↻ glyph in the corner when \`seriesId\` is set so the operator can spot recurring bookings at a glance. Lives next to the \$ payment badge.
- **Appointment detail panel** — adds a "Recurring · every N weeks · X of Y / ongoing" pill when the appointment is part of a series. For finite series at the last 1–2 occurrences, a series-ending banner appears with one-click "Extend by 6 more" and "Switch to indefinite" actions.
- **Drag-to-reschedule cascade** — when a series occurrence gets dragged, a small confirm modal asks "Just this one / This and all future" before firing. Non-series appointments skip the prompt entirely (no behavior change).
- **Cancel modal** — replaces the old \`window.prompt()\` with a real modal that takes a reason and, for active-series occurrences, offers a "Just this visit / End the whole series" radio.

## Backend changes (small)

- \`APPOINTMENT_INCLUDE\` on \`appointments.service.ts\` now joins the series summary so the schedule UI gets \`seriesId\` / \`seriesIndex\` + cadence state in the same call as the calendar render — no per-appointment fetch waterfall.
- New \`POST /appointment-series/:id/convert-to-indefinite\` endpoint backs the "Switch to indefinite" button on the ending-soon banner. Idempotent: returns the current state if already indefinite.

## Verified

- [x] \`tsc --noEmit\` clean across \`apps/api\`, \`apps/web\`, \`packages/shared\`, \`packages/db\`
- [x] \`prisma validate\` clean
- [x] Full Vitest suite passes (74/74)
- [x] \`prisma migrate deploy\` applied the 19a migration cleanly to a real local Postgres
- [x] API boots with all four \`/appointment-series\` routes mapped (including the new \`convert-to-indefinite\`)

## Not verified by me

I can't drive a real browser from here. **Worth a hands-on dogfood pass** before merge:
- Create a series ("every 4 weeks, no end date") and confirm the first 12 appointments materialize on the calendar with the ↻ glyph.
- Drag one of the future occurrences and confirm the cascade-prompt modal shows up; pick "this and all future" and confirm subsequent occurrences shift to the new pattern.
- Cancel a series occurrence and confirm the modal's "End the whole series" radio cascades correctly.
- Create a finite series (e.g. 3 visits), then on the last occurrence's detail panel confirm the ending-soon banner renders with both buttons working.