### PR TITLE
Phase 20a: service ↔ stylist training matrix backend

### DIFF
--- a/apps/api/src/staff/staff.controller.ts
+++ b/apps/api/src/staff/staff.controller.ts
@@ -10,11 +10,13 @@ import {
 } from "@nestjs/common";
 import {
   staffCreateSchema,
+  staffServicesReplaceSchema,
   staffUpdateSchema,
   workingHoursReplaceSchema,
 } from "@shearsimp/shared";
 import type {
   StaffCreateInput,
+  StaffServicesReplaceInput,
   StaffUpdateInput,
   WorkingHoursReplaceInput,
 } from "@shearsimp/shared";
@@ -61,6 +63,17 @@ export class StaffController {
     @Body(new ZodValidationPipe(staffUpdateSchema)) input: StaffUpdateInput,
   ) {
     return this.staff.update(salon.salonId, user.userId, id, input);
+  }
+
+  @Put(":id/services")
+  replaceServices(
+    @CurrentSalon() salon: ActiveSalon,
+    @CurrentUser() user: AuthIdentity,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(staffServicesReplaceSchema))
+    input: StaffServicesReplaceInput,
+  ) {
+    return this.staff.replaceServices(salon.salonId, user.userId, id, input);
   }
 
   @Put(":id/working-hours")

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -7,6 +7,7 @@ import { Prisma } from "@prisma/client";
 import { EventType } from "@shearsimp/shared";
 import type {
   StaffCreateInput,
+  StaffServicesReplaceInput,
   StaffUpdateInput,
   WorkingHoursReplaceInput,
 } from "@shearsimp/shared";
@@ -34,10 +35,19 @@ export class StaffService {
             { startMinutesFromMidnight: "asc" },
           ],
         },
+        trainedServices: {
+          select: { serviceId: true },
+        },
       },
     });
     if (!staff) throw new NotFoundException("Staff member not found");
-    return staff;
+    // Flatten the junction rows into a plain id list — the UI doesn't need
+    // the row ids and the booking flow (20b) just wants the set membership.
+    const { trainedServices, ...rest } = staff;
+    return {
+      ...rest,
+      serviceIds: trainedServices.map((t) => t.serviceId),
+    };
   }
 
   async create(salonId: string, actorUserId: string, input: StaffCreateInput) {
@@ -110,6 +120,55 @@ export class StaffService {
     } catch (e) {
       throw mapKnownErrors(e, "Staff member");
     }
+  }
+
+  async replaceServices(
+    salonId: string,
+    actorUserId: string,
+    staffId: string,
+    input: StaffServicesReplaceInput,
+  ) {
+    await this.get(salonId, staffId);
+
+    // Validate every requested service belongs to this salon up front so a
+    // cross-tenant id surfaces as a 400 rather than a Prisma FK error.
+    if (input.serviceIds.length > 0) {
+      const found = await this.prisma.service.findMany({
+        where: { salonId, id: { in: input.serviceIds } },
+        select: { id: true },
+      });
+      if (found.length !== input.serviceIds.length) {
+        throw new NotFoundException("One or more services not found");
+      }
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      await tx.staffMemberService.deleteMany({
+        where: { salonId, staffMemberId: staffId },
+      });
+      if (input.serviceIds.length > 0) {
+        await tx.staffMemberService.createMany({
+          data: input.serviceIds.map((serviceId) => ({
+            salonId,
+            staffMemberId: staffId,
+            serviceId,
+          })),
+        });
+      }
+      await appendDomainEvent(tx, {
+        salonId,
+        aggregateType: "STAFF_MEMBER",
+        aggregateId: staffId,
+        eventType: EventType.STAFF_SERVICES_UPDATED,
+        payload: { serviceIds: input.serviceIds },
+        actorUserId,
+      });
+      const rows = await tx.staffMemberService.findMany({
+        where: { salonId, staffMemberId: staffId },
+        select: { serviceId: true },
+      });
+      return { serviceIds: rows.map((r) => r.serviceId) };
+    });
   }
 
   async replaceWorkingHours(

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -130,14 +130,20 @@ export class StaffService {
   ) {
     await this.get(salonId, staffId);
 
+    // Treat the payload as a set: dedupe up front so a client retry/merge
+    // that produces "[a, a, b]" doesn't trip either the existence check
+    // (`id IN (...)` returns each row once) or the (staffMemberId,
+    // serviceId) unique constraint on insert.
+    const uniqueServiceIds = [...new Set(input.serviceIds)];
+
     // Validate every requested service belongs to this salon up front so a
     // cross-tenant id surfaces as a 400 rather than a Prisma FK error.
-    if (input.serviceIds.length > 0) {
+    if (uniqueServiceIds.length > 0) {
       const found = await this.prisma.service.findMany({
-        where: { salonId, id: { in: input.serviceIds } },
+        where: { salonId, id: { in: uniqueServiceIds } },
         select: { id: true },
       });
-      if (found.length !== input.serviceIds.length) {
+      if (found.length !== uniqueServiceIds.length) {
         throw new NotFoundException("One or more services not found");
       }
     }
@@ -146,9 +152,9 @@ export class StaffService {
       await tx.staffMemberService.deleteMany({
         where: { salonId, staffMemberId: staffId },
       });
-      if (input.serviceIds.length > 0) {
+      if (uniqueServiceIds.length > 0) {
         await tx.staffMemberService.createMany({
-          data: input.serviceIds.map((serviceId) => ({
+          data: uniqueServiceIds.map((serviceId) => ({
             salonId,
             staffMemberId: staffId,
             serviceId,
@@ -160,7 +166,7 @@ export class StaffService {
         aggregateType: "STAFF_MEMBER",
         aggregateId: staffId,
         eventType: EventType.STAFF_SERVICES_UPDATED,
-        payload: { serviceIds: input.serviceIds },
+        payload: { serviceIds: uniqueServiceIds },
         actorUserId,
       });
       const rows = await tx.staffMemberService.findMany({

--- a/apps/web/src/app/(app)/staff/[id]/page.tsx
+++ b/apps/web/src/app/(app)/staff/[id]/page.tsx
@@ -4,6 +4,11 @@ import { Card, PageHeader } from "@/components/form";
 import { StaffForm } from "../_components/staff-form";
 import { WorkingHoursForm } from "../_components/working-hours-form";
 import {
+  StaffServicesForm,
+  type ServiceOption,
+} from "../_components/staff-services-form";
+import {
+  replaceStaffServicesAction,
   replaceWorkingHoursAction,
   updateStaffAction,
   type FormState,
@@ -23,6 +28,7 @@ interface StaffDetail {
   bio: string | null;
   isActive: boolean;
   workingHours: WorkingHoursRow[];
+  serviceIds: string[];
 }
 
 export default async function StaffDetailPage({
@@ -31,7 +37,10 @@ export default async function StaffDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const staff = await apiFetch<StaffDetail>(`/staff/${id}`);
+  const [staff, services] = await Promise.all([
+    apiFetch<StaffDetail>(`/staff/${id}`),
+    apiFetch<ServiceOption[]>("/services"),
+  ]);
 
   // Bind the staff id into the action so the client form doesn't need to
   // smuggle it via a hidden field.
@@ -48,6 +57,13 @@ export default async function StaffDetailPage({
   ): Promise<FormState> => {
     "use server";
     return replaceWorkingHoursAction(id, state, formData);
+  };
+  const servicesAction = async (
+    state: FormState,
+    formData: FormData,
+  ): Promise<FormState> => {
+    "use server";
+    return replaceStaffServicesAction(id, state, formData);
   };
 
   return (
@@ -74,6 +90,14 @@ export default async function StaffDetailPage({
             bio: staff.bio,
             isActive: staff.isActive,
           }}
+        />
+      </Card>
+
+      <Card title="Services" meta="What this stylist can perform">
+        <StaffServicesForm
+          action={servicesAction}
+          services={services}
+          initialIds={staff.serviceIds}
         />
       </Card>
 

--- a/apps/web/src/app/(app)/staff/_actions.ts
+++ b/apps/web/src/app/(app)/staff/_actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import {
   staffCreateSchema,
+  staffServicesReplaceSchema,
   staffUpdateSchema,
   workingHoursReplaceSchema,
 } from "@shearsimp/shared";
@@ -85,6 +86,37 @@ export async function updateStaffAction(
   revalidatePath("/staff");
   revalidatePath(`/staff/${id}`);
   return { message: "Saved." };
+}
+
+// Mirrors the working-hours pattern: form posts a JSON-encoded id list in a
+// single hidden input rather than fanning out FormData entries.
+export async function replaceStaffServicesAction(
+  id: string,
+  _prev: FormState,
+  formData: FormData,
+): Promise<FormState> {
+  let serviceIds: unknown;
+  try {
+    serviceIds = JSON.parse(String(formData.get("serviceIds") ?? "[]"));
+  } catch {
+    return { errors: { _: "Could not parse services" } };
+  }
+  const parsed = staffServicesReplaceSchema.safeParse({ serviceIds });
+  if (!parsed.success) return { errors: toFormErrors(parsed) };
+
+  try {
+    await apiFetch(`/staff/${id}/services`, {
+      method: "PUT",
+      data: parsed.data,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return { errors: e.fieldMessages() ?? {}, message: e.topMessage() };
+    }
+    throw e;
+  }
+  revalidatePath(`/staff/${id}`);
+  return { message: "Services saved." };
 }
 
 // Working-hours form posts a list of windows as JSON in a hidden input —

--- a/apps/web/src/app/(app)/staff/_components/staff-services-form.tsx
+++ b/apps/web/src/app/(app)/staff/_components/staff-services-form.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useActionState, useMemo, useState } from "react";
+import { Button, FormError } from "@/components/form";
+import type { FormState } from "../_actions";
+
+export interface ServiceOption {
+  id: string;
+  name: string;
+  isActive: boolean;
+  category: { id: string; name: string } | null;
+}
+
+export function StaffServicesForm({
+  action,
+  services,
+  initialIds,
+}: {
+  action: (state: FormState, formData: FormData) => Promise<FormState>;
+  services: ServiceOption[];
+  initialIds: string[];
+}) {
+  const [state, formAction, pending] = useActionState<FormState, FormData>(
+    action,
+    {},
+  );
+
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(initialIds),
+  );
+
+  const groups = useMemo(() => groupByCategory(services), [services]);
+  const ids = useMemo(() => Array.from(selected), [selected]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const allActiveIds = useMemo(
+    () => services.filter((s) => s.isActive).map((s) => s.id),
+    [services],
+  );
+  const selectAll = () => setSelected(new Set(allActiveIds));
+  const clearAll = () => setSelected(new Set());
+
+  return (
+    <form action={formAction} className="ss-form">
+      <FormError message={state?.errors?._ ?? state?.errors?.serviceIds} />
+      {state?.message && !state.errors && (
+        <div className="ss-form-success">{state.message}</div>
+      )}
+      <input type="hidden" name="serviceIds" value={JSON.stringify(ids)} />
+
+      <div className="ss-svc-checklist-actions">
+        <button
+          type="button"
+          onClick={selectAll}
+          className="ss-btn ss-btn-ghost ss-btn-tiny"
+        >
+          Select all active
+        </button>
+        <button
+          type="button"
+          onClick={clearAll}
+          className="ss-btn ss-btn-ghost ss-btn-tiny"
+        >
+          Clear
+        </button>
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="ss-empty">No services to assign yet.</p>
+      ) : (
+        groups.map((g) => (
+          <fieldset key={g.key} className="ss-svc-checklist">
+            <legend>{g.name}</legend>
+            <div className="ss-svc-checklist-grid">
+              {g.services.map((s) => {
+                const checked = selected.has(s.id);
+                return (
+                  <label key={s.id} className="ss-svc-checklist-item">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(s.id)}
+                      disabled={pending}
+                    />
+                    <span>
+                      {s.name}
+                      {!s.isActive && (
+                        <em className="ss-svc-inactive-tag"> (inactive)</em>
+                      )}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        ))
+      )}
+
+      <div className="ss-form-actions">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : "Save services"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function groupByCategory(services: ServiceOption[]): Array<{
+  key: string;
+  name: string;
+  services: ServiceOption[];
+}> {
+  const map = new Map<string, { name: string; services: ServiceOption[] }>();
+  const uncatKey = "__uncat__";
+  for (const s of services) {
+    const key = s.category?.id ?? uncatKey;
+    const name = s.category?.name ?? "Uncategorized";
+    const g = map.get(key) ?? { name, services: [] };
+    g.services.push(s);
+    map.set(key, g);
+  }
+  for (const g of map.values()) {
+    g.services.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return [...map.entries()]
+    .map(([key, value]) => ({ key, ...value }))
+    .sort((a, b) => {
+      // Uncategorized last.
+      if (a.key === uncatKey) return 1;
+      if (b.key === uncatKey) return -1;
+      return a.name.localeCompare(b.name);
+    });
+}

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1231,6 +1231,48 @@
 .ss-hours-sep { font-size: 12.5px; color: var(--ss-text-muted); }
 .ss-btn-tiny { padding: 6px 10px; font-size: 12px; }
 
+/* Stylist services checklist (issue #20). Reuses the panel-strong / line
+   tokens from working hours so the two cards read as siblings. */
+.ss-svc-checklist-actions {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+.ss-svc-checklist {
+  border: 1px solid var(--ss-line);
+  border-radius: 12px;
+  background: var(--ss-panel-strong);
+  padding: 14px 16px;
+  margin: 0;
+}
+.ss-svc-checklist + .ss-svc-checklist { margin-top: 8px; }
+.ss-svc-checklist legend {
+  padding: 0 6px;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ss-text-secondary);
+}
+.ss-svc-checklist-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px 16px;
+  margin-top: 6px;
+}
+.ss-svc-checklist-item {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 13.5px;
+  color: var(--ss-text-primary);
+  cursor: pointer;
+}
+.ss-svc-checklist-item input { cursor: pointer; }
+.ss-svc-inactive-tag {
+  font-style: normal;
+  font-size: 11px;
+  color: var(--ss-text-muted);
+  margin-left: 4px;
+}
+
 /* Card variant: flush table inside. */
 .ss-card.is-flush { padding: 0; }
 .ss-card.is-flush .ss-card-head {

--- a/packages/db/prisma/migrations/20260429230000_staff_member_services/migration.sql
+++ b/packages/db/prisma/migrations/20260429230000_staff_member_services/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "staff_member_services" (
+    "id" UUID NOT NULL,
+    "salonId" UUID NOT NULL,
+    "staffMemberId" UUID NOT NULL,
+    "serviceId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "staff_member_services_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "staff_member_services_salonId_staffMemberId_idx" ON "staff_member_services"("salonId", "staffMemberId");
+
+-- CreateIndex
+CREATE INDEX "staff_member_services_salonId_serviceId_idx" ON "staff_member_services"("salonId", "serviceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "staff_member_services_staffMemberId_serviceId_key" ON "staff_member_services"("staffMemberId", "serviceId");
+
+-- AddForeignKey
+ALTER TABLE "staff_member_services" ADD CONSTRAINT "staff_member_services_salonId_fkey" FOREIGN KEY ("salonId") REFERENCES "salons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_member_services" ADD CONSTRAINT "staff_member_services_staffMemberId_salonId_fkey" FOREIGN KEY ("staffMemberId", "salonId") REFERENCES "staff_members"("id", "salonId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "staff_member_services" ADD CONSTRAINT "staff_member_services_serviceId_salonId_fkey" FOREIGN KEY ("serviceId", "salonId") REFERENCES "services"("id", "salonId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: every existing stylist gets every active service in their salon.
+-- The booking flow in 20b will gate stylist tiles on this matrix; without
+-- this default, all existing bookings would suddenly fail validation.
+INSERT INTO "staff_member_services" ("id", "salonId", "staffMemberId", "serviceId")
+SELECT gen_random_uuid(), s."salonId", s."id", svc."id"
+FROM "staff_members" s
+JOIN "services" svc ON svc."salonId" = s."salonId" AND svc."isActive" = true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -158,6 +158,7 @@ model Salon {
   appointmentServices  AppointmentService[]
   appointmentSeries        AppointmentSeries[]
   appointmentSeriesServices AppointmentSeriesService[]
+  staffMemberServices  StaffMemberService[]
   payments             Payment[]
   messages             Message[]
   domainEvents         DomainEvent[]
@@ -218,11 +219,12 @@ model StaffMember {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  salon         Salon          @relation(fields: [salonId], references: [id], onDelete: Cascade)
-  user          User?          @relation(fields: [userId], references: [id], onDelete: SetNull)
+  salon         Salon                @relation(fields: [salonId], references: [id], onDelete: Cascade)
+  user          User?                @relation(fields: [userId], references: [id], onDelete: SetNull)
   appointments  Appointment[]
   appointmentSeries AppointmentSeries[]
   workingHours  WorkingHours[]
+  trainedServices StaffMemberService[]
 
   @@unique([salonId, userId])
   // Composite-FK target — referenced by Appointment/WorkingHours so cross-tenant
@@ -230,6 +232,26 @@ model StaffMember {
   @@unique([id, salonId], name: "staff_members_id_salonId_key")
   @@index([salonId, isActive])
   @@map("staff_members")
+}
+
+// Junction: which services a stylist is trained to perform. Junction (not a
+// `String[]` on StaffMember) so the composite FK enforces same-salon
+// integrity, matching AppointmentService / AppointmentSeriesService.
+model StaffMemberService {
+  id            String   @id @default(uuid()) @db.Uuid
+  salonId       String   @db.Uuid
+  staffMemberId String   @db.Uuid
+  serviceId     String   @db.Uuid
+  createdAt     DateTime @default(now())
+
+  salon       Salon       @relation(fields: [salonId], references: [id], onDelete: Cascade)
+  staffMember StaffMember @relation(fields: [staffMemberId, salonId], references: [id, salonId], onDelete: Cascade)
+  service     Service     @relation(fields: [serviceId, salonId], references: [id, salonId], onDelete: Cascade)
+
+  @@unique([staffMemberId, serviceId])
+  @@index([salonId, staffMemberId])
+  @@index([salonId, serviceId])
+  @@map("staff_member_services")
 }
 
 model WorkingHours {
@@ -317,6 +339,7 @@ model Service {
   category             ServiceCategory?     @relation(fields: [categoryId, salonId], references: [id, salonId], onDelete: Restrict)
   appointmentServices  AppointmentService[]
   appointmentSeriesServices AppointmentSeriesService[]
+  staffMemberServices  StaffMemberService[]
 
   @@unique([salonId, slug])
   // Composite-FK target — referenced by AppointmentService.

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -124,6 +124,7 @@ export const EventType = {
 
   STAFF_CREATED: "staff.created",
   STAFF_UPDATED: "staff.updated",
+  STAFF_SERVICES_UPDATED: "staff.services_updated",
   WORKING_HOURS_UPDATED: "staff.working_hours_updated",
 
   SERVICE_CATEGORY_CREATED: "service_category.created",

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -127,6 +127,17 @@ export type WorkingHoursReplaceInput = z.infer<
   typeof workingHoursReplaceSchema
 >;
 
+// Service ↔ stylist training matrix (issue #20). Replacement semantics so the
+// settings UI can post the full set; server diffs to handle inserts/deletes.
+// Empty array is allowed — a brand-new stylist with no services yet.
+export const staffServicesReplaceSchema = z.object({
+  serviceIds: z.array(uuidSchema).max(200),
+});
+
+export type StaffServicesReplaceInput = z.infer<
+  typeof staffServicesReplaceSchema
+>;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Salon membership (used by staff page when linking a stylist to a user)
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
First half of #20 — schema, backend, and the staff-profile checklist UI. Booking-flow integration (modal stylist-tile gating, calendar column dimming) lands as 20b.

## Summary

- **Schema** — new `StaffMemberService` junction with composite `(id, salonId)` FKs to both `StaffMember` and `Service`, matching the existing `AppointmentService` / `AppointmentSeriesService` pattern. Junction (not a `String[]` on `StaffMember`) so the same-salon constraint is enforced at the DB level.
- **Backfill** — the migration inserts every existing stylist × active service in their salon. Without this default, the 20b booking gate would suddenly disqualify all stylists across every existing tenant. Treats the matrix as a feature operators opt _out_ of.
- **Shared** — `staffServicesReplaceSchema` (replacement semantics, capped at 200 ids); new `EventType.STAFF_SERVICES_UPDATED`. EventType is a string-constant union so enum-parity isn't affected.
- **Backend** — `staff.service.get()` returns `serviceIds[]` flattened from the junction (UI doesn't need the row ids). `replaceServices()` validates every requested id belongs to this salon up front so a cross-tenant id surfaces as 404 rather than a Prisma FK error, then delete-then-recreate inside a transaction with a single `staff.services_updated` domain event. New `PUT /staff/:id/services` mirrors the existing `replaceWorkingHours` shape.
- **UI** — staff profile picks up a Services card with a category-grouped checklist plus _Select all active_ / _Clear_ helpers. Pure replacement post; same JSON-in-a-hidden-input pattern as the working-hours form.

## Tenant isolation

Every junction row carries denormalized `salonId`, and both FKs are composite `(id, salonId)` → so a row can never link a stylist and a service from different salons even at the database level. `replaceServices()` also rejects unknown service ids before the transaction starts.

## Backwards compatibility

The existing `GET /staff/:id` response gains `serviceIds: string[]`; the UI's `StaffDetail` interface was updated to match. No other call sites consume that shape today.

## Test plan

- [x] \`pnpm --filter @shearsimp/db prisma:validate\` — schema clean
- [x] \`pnpm --filter @shearsimp/db prisma:generate\` — client regenerated
- [x] \`prisma migrate deploy\` against local Postgres — migration + backfill applied cleanly
- [x] \`pnpm -r typecheck\` — clean across api / web / shared / db
- [x] \`pnpm --filter @shearsimp/db test\` — enum parity OK across 11 enums
- [x] \`pnpm --filter @shearsimp/api test\` — full Vitest suite 74/74
- [ ] Manual dogfood: open a staff profile, toggle a few services, confirm save persists and reload reflects the new set (do as part of review or alongside 20b)