### PR TITLE
Phase 20b: gate booking flow on the training matrix

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -343,8 +343,6 @@ greenfield product backlog that hasn't been touched at all.
 Cross-phase deferrals — see the `deferred` label on the repo:
 
 - [#18](https://github.com/jnoecker/ShearSimplicity/issues/18) — Migrate to Stripe Connect for per-salon money movement
-- [#19](https://github.com/jnoecker/ShearSimplicity/issues/19) — Recurring appointments / cadence support
-- [#20](https://github.com/jnoecker/ShearSimplicity/issues/20) — Service ↔ stylist training matrix
 - [#21](https://github.com/jnoecker/ShearSimplicity/issues/21) — Per-salon configurable reminder lead time
 - [#22](https://github.com/jnoecker/ShearSimplicity/issues/22) — Deep-link tokens for cancel/reschedule SMS
 - [#23](https://github.com/jnoecker/ShearSimplicity/issues/23) — Message history UI per client

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -18,11 +18,18 @@ import { appendDomainEvent } from "../common/domain-events";
 export class StaffService {
   constructor(private readonly prisma: PrismaService) {}
 
-  list(salonId: string) {
-    return this.prisma.staffMember.findMany({
+  async list(salonId: string) {
+    const rows = await this.prisma.staffMember.findMany({
       where: { salonId },
       orderBy: [{ isActive: "desc" }, { displayName: "asc" }],
+      include: {
+        trainedServices: { select: { serviceId: true } },
+      },
     });
+    return rows.map(({ trainedServices, ...rest }) => ({
+      ...rest,
+      serviceIds: trainedServices.map((t) => t.serviceId),
+    }));
   }
 
   async get(salonId: string, id: string) {

--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
@@ -27,6 +27,10 @@ export interface BookStaff {
   title: string | null;
   color: string | null;
   isActive: boolean;
+  /** Services this stylist is trained to perform (issue #20). Empty array
+   *  means none — the booking flow disables their tile entirely once any
+   *  service is picked. */
+  serviceIds: string[];
 }
 
 export interface BookService {
@@ -190,12 +194,20 @@ export function BookAppointmentModal({
     !isPending;
 
   function toggleService(id: string) {
-    setServiceIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+    const next = new Set(serviceIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setServiceIds(next);
+    // If the in-flight set now includes something the picked stylist can't
+    // do, clear the stylist so the booking can't sail through to an
+    // outright FK error on submit. The user re-picks from the now-gated
+    // tile row.
+    if (staffId) {
+      const picked = staff.find((s) => s.id === staffId);
+      if (picked && [...next].some((sid) => !picked.serviceIds.includes(sid))) {
+        setStaffId("");
+      }
+    }
   }
 
   function pickClient(id: string) {
@@ -308,6 +320,8 @@ export function BookAppointmentModal({
 
             <StaffField
               staff={staff}
+              services={services}
+              selectedServiceIds={serviceIds}
               selectedId={staffId}
               onSelect={setStaffId}
             />
@@ -326,6 +340,7 @@ export function BookAppointmentModal({
                 staff={staff}
                 selectedStaffId={staffId || null}
                 services={services}
+                selectedServiceIds={serviceIds}
                 selectedDurationMin={totalDuration}
                 onSelectDate={(iso) => {
                   setDate(iso);
@@ -828,27 +843,57 @@ function ServicesField({
 
 function StaffField({
   staff,
+  services,
+  selectedServiceIds,
   selectedId,
   onSelect,
 }: {
   staff: BookStaff[];
+  services: BookService[];
+  selectedServiceIds: Set<string>;
   selectedId: string;
   onSelect: (id: string) => void;
 }) {
+  const serviceNames = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of services) m.set(s.id, s.name);
+    return m;
+  }, [services]);
+
+  const pickedServiceIds = useMemo(
+    () => Array.from(selectedServiceIds),
+    [selectedServiceIds],
+  );
+
   return (
     <div className="bk-field">
       <label className="bk-label">Stylist</label>
       <div className="bk-staff-row">
         {staff.map((s, i) => {
           const isOn = s.id === selectedId;
+          const trained = new Set(s.serviceIds);
+          const untrainedFor = pickedServiceIds.filter((id) => !trained.has(id));
+          const disabled = untrainedFor.length > 0;
+          const tip = disabled
+            ? `${s.displayName.split(" ")[0]} isn't trained on ${untrainedFor
+                .map((id) => serviceNames.get(id) ?? "this service")
+                .join(", ")}`
+            : isOn
+              ? "Click to clear"
+              : undefined;
           return (
             <button
               key={s.id}
               type="button"
-              className={`bk-staff${isOn ? " is-on" : ""}`}
+              className={`bk-staff${isOn ? " is-on" : ""}${disabled ? " is-disabled" : ""}`}
               aria-pressed={isOn}
-              title={isOn ? "Click to clear" : undefined}
-              onClick={() => onSelect(isOn ? "" : s.id)}
+              aria-disabled={disabled || undefined}
+              disabled={disabled}
+              title={tip}
+              onClick={() => {
+                if (disabled) return;
+                onSelect(isOn ? "" : s.id);
+              }}
             >
               <span
                 className="bk-staff-avatar"

--- a/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-appointment-modal.tsx
@@ -888,7 +888,12 @@ function StaffField({
               className={`bk-staff${isOn ? " is-on" : ""}${disabled ? " is-disabled" : ""}`}
               aria-pressed={isOn}
               aria-disabled={disabled || undefined}
-              disabled={disabled}
+              // Don't set the native `disabled` attribute — Chromium and
+              // Safari swallow mouse events on disabled buttons, which
+              // suppresses the `title` tooltip that explains *why* the
+              // tile is faded. ARIA + onClick guard + cursor:not-allowed
+              // give us the same effective behaviour while preserving the
+              // hover hint operators rely on.
               title={tip}
               onClick={() => {
                 if (disabled) return;

--- a/apps/web/src/app/(app)/schedule/_components/book-calendar.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/book-calendar.tsx
@@ -72,6 +72,9 @@ interface Props {
   selectedStaffId: string | null;
   /** Service catalog so we can color-code by category. */
   services: BookService[];
+  /** Service ids the user has picked so far. Used to fade columns for
+   *  stylists who can't perform every selection (issue #20). */
+  selectedServiceIds: Set<string>;
   /** Sum of selected service durations — used to gate which slots are open. */
   selectedDurationMin: number;
   /** Set salon-local date (YYYY-MM-DD); transitions to day mode. */
@@ -95,6 +98,7 @@ export function BookCalendar({
   staff,
   selectedStaffId,
   services,
+  selectedServiceIds,
   selectedDurationMin,
   onSelectDate,
   onPickSlot,
@@ -207,6 +211,7 @@ export function BookCalendar({
             dateLabel={dateLabel}
             staff={staff}
             selectedStaffId={selectedStaffId}
+            selectedServiceIds={selectedServiceIds}
             appointments={selectedDayAppts}
             kindForServiceId={kindForServiceId}
             onPickSlot={(minutes, staffId) =>
@@ -496,6 +501,7 @@ function BookDayView({
   dateLabel,
   staff,
   selectedStaffId,
+  selectedServiceIds,
   appointments,
   kindForServiceId,
   onPickSlot,
@@ -508,6 +514,7 @@ function BookDayView({
   dateLabel: string;
   staff: BookStaff[];
   selectedStaffId: string | null;
+  selectedServiceIds: Set<string>;
   appointments: BookCalendarAppointment[];
   kindForServiceId: Map<string, CategoryKind>;
   onPickSlot: (minutes: number, staffId: string) => void;
@@ -516,6 +523,19 @@ function BookDayView({
   const visibleStaff = selectedStaffId
     ? staff.filter((s) => s.id === selectedStaffId)
     : staff;
+  // Stylists who can't perform every picked service get their column faded
+  // and their slots disabled, mirroring the gating on the stylist tiles
+  // above (issue #20). Indexed by visibleStaff position so render code can
+  // toggle a class without re-deriving the matrix per slot.
+  const untrained = useMemo(() => {
+    const picked = Array.from(selectedServiceIds);
+    if (picked.length === 0) return visibleStaff.map(() => false);
+    return visibleStaff.map((s) => {
+      const trained = new Set(s.serviceIds);
+      return picked.some((id) => !trained.has(id));
+    });
+  }, [visibleStaff, selectedServiceIds]);
+
   // Build a per-stylist occupancy map keyed by slot index. A slot is
   // "occupied" if it falls inside any active appointment for that stylist.
   // Computing once per render is cheap (4 staff × 40 slots).
@@ -564,33 +584,41 @@ function BookDayView({
         }}
       >
         <div className="bk-day-h-spacer" />
-        {visibleStaff.map((s, i) => (
-          <div
-            key={s.id}
-            className="bk-day-h"
-            style={
-              {
-                ["--bk-stylist-tint" as string]: s.color
-                  ? `linear-gradient(135deg, ${s.color}, ${s.color})`
-                  : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
-              } as React.CSSProperties
-            }
-          >
-            <span
-              className="bk-day-h-avatar"
-              style={{
-                background: s.color
-                  ? `linear-gradient(135deg, ${s.color}, ${s.color})`
-                  : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
-              }}
+        {visibleStaff.map((s, i) => {
+          const isUntrained = untrained[i];
+          return (
+            <div
+              key={s.id}
+              className={`bk-day-h${isUntrained ? " is-untrained" : ""}`}
+              title={
+                isUntrained
+                  ? `${s.displayName.split(" ")[0]} isn't trained on every picked service`
+                  : undefined
+              }
+              style={
+                {
+                  ["--bk-stylist-tint" as string]: s.color
+                    ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                    : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
+                } as React.CSSProperties
+              }
             >
-              {initialsOf(s.displayName)}
-            </span>
-            <span className="bk-day-h-name">
-              {s.displayName.split(" ")[0]}
-            </span>
-          </div>
-        ))}
+              <span
+                className="bk-day-h-avatar"
+                style={{
+                  background: s.color
+                    ? `linear-gradient(135deg, ${s.color}, ${s.color})`
+                    : STAFF_GRADIENTS[i % STAFF_GRADIENTS.length],
+                }}
+              >
+                {initialsOf(s.displayName)}
+              </span>
+              <span className="bk-day-h-name">
+                {s.displayName.split(" ")[0]}
+              </span>
+            </div>
+          );
+        })}
 
         <div
           className="bk-day-times"
@@ -614,10 +642,11 @@ function BookDayView({
 
         {visibleStaff.map((s, ci) => {
           const occ = occupancy[ci] ?? [];
+          const isUntrained = untrained[ci];
           return (
             <div
               key={s.id}
-              className="bk-day-col"
+              className={`bk-day-col${isUntrained ? " is-untrained" : ""}`}
               style={{
                 gridRow: `2 / span ${TOTAL_SLOTS}`,
                 height: SLOT_HEIGHT * TOTAL_SLOTS,
@@ -651,36 +680,37 @@ function BookDayView({
                   service — clicks were dispatched to whichever button
                   happened to be last in DOM order at that y-coord, so
                   picking "1:00" often booked 1:15 / 1:30 / etc. */}
-              {Array.from({ length: TOTAL_SLOTS }).map((_, slot) => {
-                if (occ[slot]) return null;
-                let fits = true;
-                for (let k = 0; k < requiredSlots; k++) {
-                  if (slot + k >= TOTAL_SLOTS || occ[slot + k]) {
-                    fits = false;
-                    break;
+              {!isUntrained &&
+                Array.from({ length: TOTAL_SLOTS }).map((_, slot) => {
+                  if (occ[slot]) return null;
+                  let fits = true;
+                  for (let k = 0; k < requiredSlots; k++) {
+                    if (slot + k >= TOTAL_SLOTS || occ[slot + k]) {
+                      fits = false;
+                      break;
+                    }
                   }
-                }
-                if (!fits) return null;
-                const minutes = SLOT_START_MIN + slot * SLOT_MIN;
-                return (
-                  <button
-                    key={`o${slot}`}
-                    type="button"
-                    className="bk-day-open"
-                    style={{
-                      top: slot * SLOT_HEIGHT,
-                      height: SLOT_HEIGHT,
-                    }}
-                    aria-label={`Book ${minutesLabel(minutes)} with ${s.displayName}`}
-                    onClick={() => {
-                      onPickSlot(minutes, s.id);
-                      if (!selectedStaffId && onSelectStaff) {
-                        onSelectStaff(s.id);
-                      }
-                    }}
-                  />
-                );
-              })}
+                  if (!fits) return null;
+                  const minutes = SLOT_START_MIN + slot * SLOT_MIN;
+                  return (
+                    <button
+                      key={`o${slot}`}
+                      type="button"
+                      className="bk-day-open"
+                      style={{
+                        top: slot * SLOT_HEIGHT,
+                        height: SLOT_HEIGHT,
+                      }}
+                      aria-label={`Book ${minutesLabel(minutes)} with ${s.displayName}`}
+                      onClick={() => {
+                        onPickSlot(minutes, s.id);
+                        if (!selectedStaffId && onSelectStaff) {
+                          onSelectStaff(s.id);
+                        }
+                      }}
+                    />
+                  );
+                })}
 
               {/* Picked-slot preview — non-interactive overlay that shows
                   the appointment's full duration in this column. We paint

--- a/apps/web/src/styles/styles-extra.css
+++ b/apps/web/src/styles/styles-extra.css
@@ -1951,6 +1951,13 @@
   background: linear-gradient(180deg, rgba(30, 195, 217, 0.14), rgba(30, 195, 217, 0.04));
   box-shadow: 0 0 0 3px rgba(30, 195, 217, 0.18);
 }
+.bk-staff.is-disabled,
+.bk-staff[disabled] {
+  opacity: 0.42;
+  cursor: not-allowed;
+  filter: grayscale(0.6);
+}
+.bk-staff.is-disabled:hover { border-color: var(--ss-panel-edge); }
 .bk-staff-avatar {
   width: 36px;
   height: 36px;
@@ -2376,6 +2383,15 @@
 .bk-day-col {
   position: relative;
   border-left: 1px solid var(--ss-panel-edge);
+}
+/* Untrained-stylist column (issue #20): mute the header + body so the
+   operator can see the stylist's load context but knows they can't take
+   the picked services. Slots are simply not rendered for these columns,
+   so no further interaction-blocking is needed. */
+.bk-day-h.is-untrained,
+.bk-day-col.is-untrained {
+  opacity: 0.42;
+  filter: grayscale(0.6);
 }
 .bk-day-hour-line {
   position: absolute;


### PR DESCRIPTION
Wires the service ↔ stylist training matrix (#34) into the booking modal + day view. Closes #20.

## Summary

- **Staff list endpoint** — `GET /staff` now includes \`serviceIds[]\` alongside the existing fields so the booking flow doesn't need a second round trip per stylist.
- **Stylist tiles** — each tile computes the picked-but-untrained service list. If non-empty, the tile is `disabled` + faded with a \"Felix isn't trained on Balayage, Color\" tooltip listing the offending services. Toggling on a service the currently-picked stylist can't do clears the stylist selection so a booking can't sail through and 4xx on submit.
- **Day view (booking calendar)** — columns for stylists who can't perform every picked service get the same fade + grayscale on the header and the column body, and their open-slot buttons aren't rendered at all. Existing appointment blocks still render (read-only context — operators can still see who's booked when).
- **Empty-state** — when no services are picked yet, nothing is gated; the matrix only kicks in once the first service is on.
- **Roadmap** — drops #19 + #20 from the deferred list now that both have shipped.

## Tenant isolation

No new persistence — this is pure read-side wiring on top of 20a's junction. The serviceIds the UI receives are scoped by the existing TenantGuard on `GET /staff`.

## Backwards compatibility

`BookStaff` gained a required `serviceIds: string[]` field. The schedule page already consumes the new shape via `apiFetch<BookStaff[]>(\"/staff\")`, and TypeScript caught the one call site that needed updating. The `ScheduleStaff` type also receives the field at runtime but doesn't declare it (structural — fine).

## Test plan

- [x] \`pnpm -r typecheck\` clean across api / web / shared / db
- [x] \`pnpm --filter @shearsimp/db test\` — enum parity OK across 11 enums
- [x] \`pnpm --filter @shearsimp/api test\` — full Vitest suite 74/74
- [ ] Manual dogfood (do as part of review): on a staff profile, untick one service for a stylist; open the booking modal, pick that service, confirm the stylist's tile is faded with the tooltip and their day-view column is grayed out with no open-slot buttons; pick a different stylist who's trained, then add the unticked service back through the picker — confirm the picked stylist clears.