### PR TITLE
Issue #23: message history UI per client

### DIFF
--- a/apps/api/src/clients/clients.controller.ts
+++ b/apps/api/src/clients/clients.controller.ts
@@ -8,9 +8,14 @@ import {
   Post,
   Query,
 } from "@nestjs/common";
-import { clientCreateSchema, clientUpdateSchema } from "@shearsimp/shared";
+import {
+  clientCreateSchema,
+  clientMessagesQuerySchema,
+  clientUpdateSchema,
+} from "@shearsimp/shared";
 import type {
   ClientCreateInput,
+  ClientMessagesQuery,
   ClientUpdateInput,
 } from "@shearsimp/shared";
 import { CurrentSalon } from "../tenant/current-salon.decorator";
@@ -40,6 +45,16 @@ export class ClientsController {
     @Param("id", new ParseUUIDPipe()) id: string,
   ) {
     return this.clients.get(salon.salonId, id);
+  }
+
+  @Get(":id/messages")
+  listMessages(
+    @CurrentSalon() salon: ActiveSalon,
+    @Param("id", new ParseUUIDPipe()) id: string,
+    @Query(new ZodValidationPipe(clientMessagesQuerySchema))
+    query: ClientMessagesQuery,
+  ) {
+    return this.clients.listMessages(salon.salonId, id, query);
   }
 
   @Post()

--- a/apps/api/src/clients/clients.service.ts
+++ b/apps/api/src/clients/clients.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from "@nestjs/common";
-import { MessageDirection, Prisma } from "@prisma/client";
+import { MessageChannel, MessageDirection, Prisma } from "@prisma/client";
 import { EventType } from "@shearsimp/shared";
 import type {
   ClientCreateInput,
@@ -106,7 +106,15 @@ export class ClientsService {
 
     // Fetch one extra row to detect whether more pages exist without a
     // separate count query.
-    const where: Prisma.MessageWhereInput = { salonId, clientId };
+    //
+    // Scope to SMS — the kind heuristics (STOP/YES sniffing, OutboxEvent
+    // mapping) are SMS-shaped, and the UI labels this card as SMS history.
+    // VOICE / EMAIL Messages would render with the wrong pill kinds.
+    const where: Prisma.MessageWhereInput = {
+      salonId,
+      clientId,
+      channel: MessageChannel.SMS,
+    };
     if (decoded) {
       where.OR = [
         { createdAt: { lt: decoded.createdAt } },

--- a/apps/api/src/clients/clients.service.ts
+++ b/apps/api/src/clients/clients.service.ts
@@ -3,16 +3,29 @@ import {
   Injectable,
   NotFoundException,
 } from "@nestjs/common";
-import { Prisma } from "@prisma/client";
+import { MessageDirection, Prisma } from "@prisma/client";
 import { EventType } from "@shearsimp/shared";
 import type {
   ClientCreateInput,
+  ClientMessagesQuery,
   ClientUpdateInput,
 } from "@shearsimp/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import { appendDomainEvent } from "../common/domain-events";
 
 const APPOINTMENT_HISTORY_LIMIT = 50;
+const DEFAULT_MESSAGES_LIMIT = 50;
+const MAX_MESSAGES_LIMIT = 100;
+
+// Map outbound OutboxEvent.eventType → human-readable kind. Anything we
+// haven't tagged falls back to a generic "Message" so a future event type
+// renders sensibly until the matrix catches up.
+const OUTBOUND_KIND_BY_EVENT: Record<string, string> = {
+  [EventType.APPOINTMENT_CREATED]: "confirmation",
+  [EventType.APPOINTMENT_RESCHEDULED]: "reschedule",
+  [EventType.APPOINTMENT_CANCELLED]: "cancellation",
+  [EventType.APPOINTMENT_REMINDER_DUE]: "reminder",
+};
 
 @Injectable()
 export class ClientsService {
@@ -69,6 +82,93 @@ export class ClientsService {
     });
 
     return { ...client, appointments };
+  }
+
+  // Read-only message thread for the client profile. Newest first so the
+  // top of the page shows the latest exchange. Pagination uses (createdAt, id)
+  // as a cursor so ties at the same instant stay stable across pages.
+  async listMessages(
+    salonId: string,
+    clientId: string,
+    query: ClientMessagesQuery,
+  ) {
+    const exists = await this.prisma.client.findFirst({
+      where: { id: clientId, salonId },
+      select: { id: true },
+    });
+    if (!exists) throw new NotFoundException("Client not found");
+
+    const limit = Math.min(
+      query.limit ?? DEFAULT_MESSAGES_LIMIT,
+      MAX_MESSAGES_LIMIT,
+    );
+    const decoded = query.cursor ? decodeMessagesCursor(query.cursor) : null;
+
+    // Fetch one extra row to detect whether more pages exist without a
+    // separate count query.
+    const where: Prisma.MessageWhereInput = { salonId, clientId };
+    if (decoded) {
+      where.OR = [
+        { createdAt: { lt: decoded.createdAt } },
+        { createdAt: decoded.createdAt, id: { lt: decoded.id } },
+      ];
+    }
+
+    const rows = await this.prisma.message.findMany({
+      where,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: limit + 1,
+      select: {
+        id: true,
+        direction: true,
+        status: true,
+        body: true,
+        createdAt: true,
+        sentAt: true,
+        deliveredAt: true,
+        outboxEventId: true,
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+
+    // Resolve outbound kind from the related OutboxEvent.eventType — more
+    // robust than parsing the body, and keeps the formatter free to change.
+    const outboxIds = page
+      .map((m) => m.outboxEventId)
+      .filter((id): id is string => Boolean(id));
+    const outboxRows =
+      outboxIds.length === 0
+        ? []
+        : await this.prisma.outboxEvent.findMany({
+            where: { id: { in: outboxIds } },
+            select: { id: true, eventType: true },
+          });
+    const eventTypeById = new Map(outboxRows.map((e) => [e.id, e.eventType]));
+
+    const items = page.map((m) => ({
+      id: m.id,
+      direction: m.direction,
+      status: m.status,
+      body: m.body,
+      createdAt: m.createdAt,
+      sentAt: m.sentAt,
+      deliveredAt: m.deliveredAt,
+      kind: deriveMessageKind({
+        direction: m.direction,
+        outboxEventType: m.outboxEventId
+          ? eventTypeById.get(m.outboxEventId) ?? null
+          : null,
+        body: m.body,
+      }),
+    }));
+
+    const last = page[page.length - 1];
+    const nextCursor =
+      hasMore && last ? encodeMessagesCursor(last.createdAt, last.id) : null;
+
+    return { items, nextCursor };
   }
 
   async create(salonId: string, actorUserId: string, input: ClientCreateInput) {
@@ -137,6 +237,61 @@ export class ClientsService {
       throw mapKnownErrors(e, "Client");
     }
   }
+}
+
+function encodeMessagesCursor(createdAt: Date, id: string): string {
+  // Opaque from the caller's perspective. base64url so it survives URL
+  // encoding without needing extra escaping.
+  return Buffer.from(JSON.stringify({ c: createdAt.toISOString(), i: id })).toString(
+    "base64url",
+  );
+}
+
+function decodeMessagesCursor(
+  cursor: string,
+): { createdAt: Date; id: string } | null {
+  try {
+    const raw = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(raw) as { c?: unknown; i?: unknown };
+    if (typeof parsed.c !== "string" || typeof parsed.i !== "string") return null;
+    const createdAt = new Date(parsed.c);
+    if (Number.isNaN(createdAt.getTime())) return null;
+    return { createdAt, id: parsed.i };
+  } catch {
+    return null;
+  }
+}
+
+// Pill kind shown above the bubble. Inbound kind is detected by simple
+// keyword sniffing on the body — STOP/UNSUBSCRIBE per A2P 10DLC carrier
+// rules, plus a YES/Y heuristic that matches the confirmation prompt
+// vocabulary. Anything else stays a plain "reply".
+function deriveMessageKind(input: {
+  direction: MessageDirection;
+  outboxEventType: string | null;
+  body: string;
+}): string {
+  if (input.direction === MessageDirection.OUTBOUND) {
+    return (
+      (input.outboxEventType && OUTBOUND_KIND_BY_EVENT[input.outboxEventType]) ||
+      "outbound"
+    );
+  }
+  const trimmed = input.body.trim().toUpperCase();
+  if (
+    trimmed === "STOP" ||
+    trimmed === "UNSUBSCRIBE" ||
+    trimmed === "STOPALL" ||
+    trimmed === "CANCEL" ||
+    trimmed === "QUIT" ||
+    trimmed === "END"
+  ) {
+    return "opt_out";
+  }
+  if (trimmed === "Y" || trimmed === "YES" || trimmed === "CONFIRM") {
+    return "confirmed";
+  }
+  return "reply";
 }
 
 function clientSnapshot(c: {

--- a/apps/api/test/clients-list-messages.test.ts
+++ b/apps/api/test/clients-list-messages.test.ts
@@ -93,6 +93,18 @@ describe("ClientsService.listMessages", () => {
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
+  it("scopes the query to SMS so VOICE / EMAIL rows can't leak in", async () => {
+    const { service, prisma } = buildService({ messages: [] });
+    await service.listMessages(SALON_ID, CLIENT_ID, {});
+    const findManyArgs = (prisma.message.findMany as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { where: { channel?: string; salonId?: string; clientId?: string } };
+    expect(findManyArgs.where).toMatchObject({
+      salonId: SALON_ID,
+      clientId: CLIENT_ID,
+      channel: "SMS",
+    });
+  });
+
   it("returns messages newest-first with a kind derived from the related outbox event", async () => {
     const { service } = buildService({
       messages: [

--- a/apps/api/test/clients-list-messages.test.ts
+++ b/apps/api/test/clients-list-messages.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageDirection, MessageStatus } from "@prisma/client";
+import { NotFoundException } from "@nestjs/common";
+import { ClientsService } from "../src/clients/clients.service";
+
+const SALON_ID = "00000000-0000-0000-0000-000000000a01";
+const CLIENT_ID = "00000000-0000-0000-0000-000000000c01";
+
+interface MessageRow {
+  id: string;
+  direction: MessageDirection;
+  status: MessageStatus;
+  body: string;
+  createdAt: Date;
+  sentAt: Date | null;
+  deliveredAt: Date | null;
+  outboxEventId: string | null;
+}
+
+function buildService({
+  clientExists = true,
+  messages = [] as MessageRow[],
+  outboxEvents = [] as Array<{ id: string; eventType: string }>,
+}: {
+  clientExists?: boolean;
+  messages?: MessageRow[];
+  outboxEvents?: Array<{ id: string; eventType: string }>;
+}) {
+  const messageFindMany = vi.fn().mockImplementation(async (args: {
+    take: number;
+    where: { OR?: Array<{ createdAt: { lt: Date } | Date; id?: { lt: string } }> };
+  }) => {
+    // Apply the cursor predicate manually so this mock mirrors what Prisma
+    // would do — keeps the cursor encode/decode logic under test honest.
+    let filtered = messages;
+    if (args.where.OR) {
+      const [a, b] = args.where.OR;
+      const ltDate = (a!.createdAt as { lt: Date }).lt;
+      const eqDate = b!.createdAt as Date;
+      const ltId = (b!.id as { lt: string }).lt;
+      filtered = messages.filter(
+        (m) =>
+          m.createdAt.getTime() < ltDate.getTime() ||
+          (m.createdAt.getTime() === eqDate.getTime() && m.id < ltId),
+      );
+    }
+    const sorted = [...filtered].sort((a, b) => {
+      const t = b.createdAt.getTime() - a.createdAt.getTime();
+      return t !== 0 ? t : b.id.localeCompare(a.id);
+    });
+    return sorted.slice(0, args.take);
+  });
+
+  const prisma = {
+    client: {
+      findFirst: vi.fn().mockResolvedValue(clientExists ? { id: CLIENT_ID } : null),
+    },
+    message: { findMany: messageFindMany },
+    outboxEvent: {
+      findMany: vi.fn().mockImplementation(async (args: { where: { id: { in: string[] } } }) => {
+        const ids = new Set(args.where.id.in);
+        return outboxEvents.filter((e) => ids.has(e.id));
+      }),
+    },
+  };
+
+  const service = new ClientsService(prisma as never);
+  return { service, prisma };
+}
+
+function makeMessage(overrides: Partial<MessageRow> & { id: string }): MessageRow {
+  return {
+    direction: MessageDirection.OUTBOUND,
+    status: MessageStatus.SENT,
+    body: "hello",
+    createdAt: new Date("2026-04-29T12:00:00Z"),
+    sentAt: new Date("2026-04-29T12:00:01Z"),
+    deliveredAt: null,
+    outboxEventId: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ClientsService.listMessages", () => {
+  it("404s when the client doesn't belong to the salon", async () => {
+    const { service } = buildService({ clientExists: false });
+    await expect(
+      service.listMessages(SALON_ID, CLIENT_ID, {}),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("returns messages newest-first with a kind derived from the related outbox event", async () => {
+    const { service } = buildService({
+      messages: [
+        makeMessage({
+          id: "00000000-0000-0000-0000-000000000001",
+          createdAt: new Date("2026-04-29T08:00:00Z"),
+          outboxEventId: "00000000-0000-0000-0000-0000000000a1",
+          body: "Confirmation body",
+        }),
+        makeMessage({
+          id: "00000000-0000-0000-0000-000000000002",
+          createdAt: new Date("2026-04-29T10:00:00Z"),
+          outboxEventId: "00000000-0000-0000-0000-0000000000a2",
+          body: "Reminder body",
+        }),
+        makeMessage({
+          id: "00000000-0000-0000-0000-000000000003",
+          createdAt: new Date("2026-04-29T11:00:00Z"),
+          direction: MessageDirection.INBOUND,
+          status: MessageStatus.RECEIVED,
+          body: "Y",
+          outboxEventId: null,
+        }),
+      ],
+      outboxEvents: [
+        { id: "00000000-0000-0000-0000-0000000000a1", eventType: "appointment.created" },
+        { id: "00000000-0000-0000-0000-0000000000a2", eventType: "appointment.reminder_due" },
+      ],
+    });
+
+    const result = await service.listMessages(SALON_ID, CLIENT_ID, {});
+
+    expect(result.items.map((m) => m.id)).toEqual([
+      "00000000-0000-0000-0000-000000000003",
+      "00000000-0000-0000-0000-000000000002",
+      "00000000-0000-0000-0000-000000000001",
+    ]);
+    expect(result.items.map((m) => m.kind)).toEqual([
+      "confirmed",
+      "reminder",
+      "confirmation",
+    ]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("flags inbound STOP as opt_out", async () => {
+    const { service } = buildService({
+      messages: [
+        makeMessage({
+          id: "00000000-0000-0000-0000-000000000010",
+          direction: MessageDirection.INBOUND,
+          status: MessageStatus.RECEIVED,
+          body: "STOP",
+          outboxEventId: null,
+        }),
+      ],
+    });
+    const result = await service.listMessages(SALON_ID, CLIENT_ID, {});
+    expect(result.items[0]!.kind).toBe("opt_out");
+  });
+
+  it("returns a nextCursor when more rows are available and decodes it on the next call", async () => {
+    const messages: MessageRow[] = Array.from({ length: 5 }, (_, i) =>
+      makeMessage({
+        id: `00000000-0000-0000-0000-00000000010${i}`,
+        createdAt: new Date(2026, 3, 29, 10, i),
+        body: `body ${i}`,
+      }),
+    );
+    const { service } = buildService({ messages });
+
+    const page1 = await service.listMessages(SALON_ID, CLIENT_ID, { limit: 2 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.nextCursor).toBeTruthy();
+    expect(page1.items.map((m) => m.id)).toEqual([
+      "00000000-0000-0000-0000-000000000104",
+      "00000000-0000-0000-0000-000000000103",
+    ]);
+
+    const page2 = await service.listMessages(SALON_ID, CLIENT_ID, {
+      limit: 2,
+      cursor: page1.nextCursor!,
+    });
+    expect(page2.items.map((m) => m.id)).toEqual([
+      "00000000-0000-0000-0000-000000000102",
+      "00000000-0000-0000-0000-000000000101",
+    ]);
+    expect(page2.nextCursor).toBeTruthy();
+
+    const page3 = await service.listMessages(SALON_ID, CLIENT_ID, {
+      limit: 2,
+      cursor: page2.nextCursor!,
+    });
+    expect(page3.items.map((m) => m.id)).toEqual([
+      "00000000-0000-0000-0000-000000000100",
+    ]);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("treats an unparseable cursor as a fresh query rather than throwing", async () => {
+    const { service } = buildService({
+      messages: [
+        makeMessage({ id: "00000000-0000-0000-0000-0000000000ff" }),
+      ],
+    });
+    const result = await service.listMessages(SALON_ID, CLIENT_ID, {
+      cursor: "not-a-real-cursor",
+    });
+    expect(result.items).toHaveLength(1);
+  });
+});

--- a/apps/web/src/app/(app)/clients/[id]/page.tsx
+++ b/apps/web/src/app/(app)/clients/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/appointment-status";
 import { ClientForm } from "../_components/client-form";
 import { updateClientAction, type FormState } from "../_actions";
+import { MessageHistory, type MessageRow } from "../_components/message-history";
 
 interface AppointmentRow {
   id: string;
@@ -38,7 +39,12 @@ export default async function ClientDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const client = await apiFetch<ClientDetail>(`/clients/${id}`);
+  const [client, messagesPage] = await Promise.all([
+    apiFetch<ClientDetail>(`/clients/${id}`),
+    apiFetch<{ items: MessageRow[]; nextCursor: string | null }>(
+      `/clients/${id}/messages`,
+    ),
+  ]);
 
   const action = async (
     state: FormState,
@@ -163,6 +169,19 @@ export default async function ClientDetailPage({
                 notes: client.notes,
               }}
             />
+          </Card>
+
+          <Card
+            title="Messages"
+            meta={
+              messagesPage.items.length === 0
+                ? "No SMS yet"
+                : messagesPage.nextCursor
+                  ? `Latest ${messagesPage.items.length} · more available`
+                  : `${messagesPage.items.length} on record`
+            }
+          >
+            <MessageHistory messages={messagesPage.items} />
           </Card>
 
           <Card

--- a/apps/web/src/app/(app)/clients/_components/message-history.tsx
+++ b/apps/web/src/app/(app)/clients/_components/message-history.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // Read-only SMS thread on the client profile. Outbound bubbles render on
 // the right (us → them), inbound on the left, and a kind pill rides on
 // each outbound bubble so a receptionist can scan the column for what
@@ -6,6 +8,12 @@
 // Bubbles render newest-first to match the API; flip the array on render
 // so the timeline reads top-to-bottom oldest → newest, which is how chat
 // threads conventionally read.
+//
+// Client component on purpose: the Today/Yesterday divider and the bubble
+// timestamps are computed from `new Date()` and `toLocale*` calls, which
+// would otherwise resolve in the server's locale/timezone. Rendering in
+// the browser pins them to the receptionist's wall clock, which is what
+// they expect when triaging a thread near midnight.
 
 export type MessageDirection = "OUTBOUND" | "INBOUND";
 export type MessageStatus =

--- a/apps/web/src/app/(app)/clients/_components/message-history.tsx
+++ b/apps/web/src/app/(app)/clients/_components/message-history.tsx
@@ -1,0 +1,158 @@
+// Read-only SMS thread on the client profile. Outbound bubbles render on
+// the right (us → them), inbound on the left, and a kind pill rides on
+// each outbound bubble so a receptionist can scan the column for what
+// kind of automated message went out without reading the body.
+//
+// Bubbles render newest-first to match the API; flip the array on render
+// so the timeline reads top-to-bottom oldest → newest, which is how chat
+// threads conventionally read.
+
+export type MessageDirection = "OUTBOUND" | "INBOUND";
+export type MessageStatus =
+  | "QUEUED"
+  | "SENT"
+  | "DELIVERED"
+  | "FAILED"
+  | "RECEIVED";
+
+export interface MessageRow {
+  id: string;
+  direction: MessageDirection;
+  status: MessageStatus;
+  body: string;
+  createdAt: string;
+  sentAt: string | null;
+  deliveredAt: string | null;
+  // Server-derived label key. See clients.service.ts → deriveMessageKind.
+  kind:
+    | "confirmation"
+    | "reschedule"
+    | "cancellation"
+    | "reminder"
+    | "outbound"
+    | "confirmed"
+    | "opt_out"
+    | "reply";
+}
+
+interface KindStyle {
+  label: string;
+  cls: string;
+}
+
+const KIND_STYLES: Record<MessageRow["kind"], KindStyle> = {
+  confirmation: { label: "Confirmation sent", cls: "is-confirmed" },
+  reschedule: { label: "Reschedule sent", cls: "is-progress" },
+  cancellation: { label: "Cancellation sent", cls: "is-cancelled" },
+  reminder: { label: "Reminder sent", cls: "is-pending" },
+  outbound: { label: "Sent", cls: "is-pending" },
+  confirmed: { label: "Confirmed by client", cls: "is-confirmed" },
+  opt_out: { label: "Opted out", cls: "is-cancelled" },
+  reply: { label: "Reply received", cls: "is-checked" },
+};
+
+export function MessageHistory({ messages }: { messages: MessageRow[] }) {
+  if (messages.length === 0) {
+    return <p className="ss-empty">No SMS sent or received yet.</p>;
+  }
+
+  // The API returns newest-first; render oldest-first so the column reads
+  // chronologically. Day dividers separate runs of messages on the same
+  // calendar day — same convention as the design's Messages screen.
+  const ordered = [...messages].reverse();
+
+  const items: Array<
+    | { kind: "divider"; key: string; label: string }
+    | { kind: "bubble"; key: string; row: MessageRow }
+  > = [];
+  let lastDay: string | null = null;
+  for (const row of ordered) {
+    const day = dayKey(row.createdAt);
+    if (day !== lastDay) {
+      items.push({ kind: "divider", key: `d-${day}`, label: dayLabel(row.createdAt) });
+      lastDay = day;
+    }
+    items.push({ kind: "bubble", key: row.id, row });
+  }
+
+  return (
+    <div className="ss-thread-body" style={{ padding: 0 }}>
+      {items.map((item) => {
+        if (item.kind === "divider") {
+          return (
+            <div key={item.key} className="ss-day-divider">
+              {item.label}
+            </div>
+          );
+        }
+        return <Bubble key={item.key} row={item.row} />;
+      })}
+    </div>
+  );
+}
+
+function Bubble({ row }: { row: MessageRow }) {
+  const isOut = row.direction === "OUTBOUND";
+  const pill = KIND_STYLES[row.kind];
+  const failed = row.status === "FAILED";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: isOut ? "flex-end" : "flex-start",
+        gap: 4,
+      }}
+    >
+      <span
+        className={`ss-status-pill ${pill.cls}`}
+        style={{ fontSize: 9.5 }}
+      >
+        {failed ? "Send failed" : pill.label}
+      </span>
+      <div
+        className={isOut ? "ss-bubble ss-bubble-us" : "ss-bubble ss-bubble-them"}
+        style={failed ? { opacity: 0.6 } : undefined}
+      >
+        {row.body}
+      </div>
+      <div className="ss-bubble-time">{timeLabel(row.createdAt)}</div>
+    </div>
+  );
+}
+
+function dayKey(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function dayLabel(iso: string): string {
+  const d = new Date(iso);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  if (sameDay(d, today)) return "Today";
+  if (sameDay(d, yesterday)) return "Yesterday";
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() === today.getFullYear() ? undefined : "numeric",
+  });
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function timeLabel(iso: string): string {
+  return new Date(iso).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -221,6 +221,20 @@ export const clientUpdateSchema = z.object({
 export type ClientCreateInput = z.infer<typeof clientCreateSchema>;
 export type ClientUpdateInput = z.infer<typeof clientUpdateSchema>;
 
+// Cursor-paginated client message history. Cursor is opaque from the
+// caller's perspective — the server encodes (createdAt, id) so ties at
+// the same instant stay stable across pages.
+export const clientMessagesQuerySchema = z.object({
+  cursor: z.string().min(1).max(200).optional(),
+  limit: z
+    .preprocess(
+      (v) => (typeof v === "string" ? Number.parseInt(v, 10) : v),
+      z.number().int().min(1).max(100),
+    )
+    .optional(),
+});
+export type ClientMessagesQuery = z.infer<typeof clientMessagesQuerySchema>;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Appointments (Phase 3a)
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #23 — read-only SMS thread on the client profile page.

- **API:** `GET /clients/:id/messages` returns the message history for a client filtered by `(salonId, clientId)`, newest-first, with opaque cursor pagination on `(createdAt, id)`. Limit defaults to 50, capped at 100. The existing `(salonId, clientId, createdAt)` index already supports this.
- **Kind derivation:** outbound messages join `OutboxEvent.eventType` to derive the kind (`confirmation` / `reminder` / `reschedule` / `cancellation`) — more robust than parsing the rendered body, since the SMS formatter is free to change. Inbound kind sniffs the body for STOP/UNSUBSCRIBE → `opt_out` and YES/Y → `confirmed`.
- **UI:** new Messages card on the client profile renders bubbles using the existing `.ss-bubble` design tokens (right-aligned magenta for outbound, left-aligned panel for inbound), with day dividers and a kind pill above each message. FAILED messages dim and surface a "Send failed" pill.
- **No write surface** — composing is its own future feature, per the issue.

## Test plan

- [x] `pnpm --filter @shearsimp/api typecheck` passes
- [x] `pnpm --filter @shearsimp/web typecheck` passes
- [x] `pnpm --filter @shearsimp/api test` (79 pass, 5 new in `clients-list-messages.test.ts`):
  - 404 when the client is in another salon
  - returns messages newest-first with kind derived from related OutboxEvent
  - inbound STOP → `opt_out`
  - cursor round-trips a 5-row, 3-page walk
  - unparseable cursor falls back to a fresh query
- [ ] Manual: open `/clients/:id` for a client with confirmation + reminder + inbound replies; check the Messages card renders chronologically with the right pills.