### PR TITLE
Issue #31: partial refund UI on appointment detail panel

### DIFF
--- a/apps/web/src/app/(app)/schedule/_actions.ts
+++ b/apps/web/src/app/(app)/schedule/_actions.ts
@@ -252,11 +252,12 @@ export async function startCheckoutAction(
 
 export async function refundPaymentAction(
   paymentId: string,
+  amountCents?: number,
 ): Promise<ActionResult> {
   try {
     await apiFetch(`/payments/${paymentId}/refund`, {
       method: "POST",
-      data: {},
+      data: amountCents !== undefined ? { amountCents } : {},
     });
     revalidatePath("/schedule");
     return { ok: true };

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -987,6 +987,22 @@ function PaymentSection({
   const [refundCustomMode, setRefundCustomMode] = useState(false);
   const [refundCustomDollars, setRefundCustomDollars] = useState<string>("");
 
+  // Always re-enter the picker on the documented default (100% remaining).
+  // Without this, a cancelled-then-reopened picker would silently reuse the
+  // operator's prior selection, making it easy to submit a stale partial.
+  function openRefundPicker() {
+    setRefundPreset("full");
+    setRefundCustomMode(false);
+    setRefundCustomDollars("");
+    setRefundPickerOpen(true);
+  }
+  function closeRefundPicker() {
+    setRefundPickerOpen(false);
+    setRefundPreset("full");
+    setRefundCustomMode(false);
+    setRefundCustomDollars("");
+  }
+
   const refundAmountCents = payment
     ? refundCustomMode
       ? Math.max(
@@ -1034,10 +1050,7 @@ function PaymentSection({
       setErrorMsg(result.message ?? "Refund failed");
       return;
     }
-    setRefundPickerOpen(false);
-    setRefundCustomMode(false);
-    setRefundCustomDollars("");
-    setRefundPreset("full");
+    closeRefundPicker();
   }
 
   return (
@@ -1182,7 +1195,7 @@ function PaymentSection({
           type="button"
           className="ss-btn ss-btn-ghost"
           disabled={submitting}
-          onClick={() => setRefundPickerOpen(true)}
+          onClick={openRefundPicker}
         >
           Issue refund
         </button>
@@ -1261,7 +1274,7 @@ function PaymentSection({
             <button
               type="button"
               className="ss-btn ss-btn-ghost"
-              onClick={() => setRefundPickerOpen(false)}
+              onClick={closeRefundPicker}
               disabled={submitting}
             >
               Cancel

--- a/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
+++ b/apps/web/src/app/(app)/schedule/_components/schedule-view.tsx
@@ -969,7 +969,34 @@ function PaymentSection({
     payment?.status === "PARTIALLY_REFUNDED";
   const failed = payment?.status === "FAILED" || payment?.status === "CANCELLED";
   const pending = payment?.status === "PENDING";
-  const canRefund = succeeded && payment !== null;
+  const totalChargedCents = payment
+    ? payment.amountCents + payment.tipCents
+    : 0;
+  const remainingRefundableCents = payment
+    ? totalChargedCents - payment.refundedCents
+    : 0;
+  const canRefund =
+    succeeded && payment !== null && remainingRefundableCents > 0;
+
+  // Refund picker state. Defaults to "full" — issuing the picker without
+  // changing anything refunds the remaining balance, matching the previous
+  // single-button behaviour.
+  const [refundPickerOpen, setRefundPickerOpen] = useState(false);
+  const [refundPreset, setRefundPreset] =
+    useState<RefundPresetKey>("full");
+  const [refundCustomMode, setRefundCustomMode] = useState(false);
+  const [refundCustomDollars, setRefundCustomDollars] = useState<string>("");
+
+  const refundAmountCents = payment
+    ? refundCustomMode
+      ? Math.max(
+          0,
+          Math.round(Number(refundCustomDollars || "0") * 100),
+        )
+      : refundPresetCents(refundPreset, payment, remainingRefundableCents)
+    : 0;
+  const refundAmountValid =
+    refundAmountCents > 0 && refundAmountCents <= remainingRefundableCents;
 
   async function confirmAndPay() {
     setSubmitting(true);
@@ -981,17 +1008,36 @@ function PaymentSection({
   }
 
   async function refund() {
-    if (!payment) return;
-    if (!window.confirm(`Refund ${formatPrice(payment.amountCents + payment.tipCents - payment.refundedCents, payment.currency)} to the customer? This can't be undone from here.`)) {
+    if (!payment || !refundAmountValid) return;
+    const remainingAfter = remainingRefundableCents - refundAmountCents;
+    const amountStr = formatPriceExact(refundAmountCents, payment.currency);
+    const balanceStr = formatPriceExact(remainingAfter, payment.currency);
+    const message =
+      remainingAfter > 0
+        ? `Refund ${amountStr} to the customer? ${balanceStr} will remain refundable. This can't be undone from here.`
+        : `Refund ${amountStr} to the customer? This will fully refund the payment and can't be undone from here.`;
+    if (!window.confirm(message)) {
       return;
     }
     setSubmitting(true);
     setErrorMsg(null);
-    const result = await refundPaymentAction(payment.id);
+    // When refunding the full remaining balance, omit amountCents so the
+    // API takes the default (full remaining). Avoids a rounding race if the
+    // refunded total shifted between render and submit.
+    const amountArg =
+      refundAmountCents === remainingRefundableCents
+        ? undefined
+        : refundAmountCents;
+    const result = await refundPaymentAction(payment.id, amountArg);
     setSubmitting(false);
     if (!result.ok) {
       setErrorMsg(result.message ?? "Refund failed");
+      return;
     }
+    setRefundPickerOpen(false);
+    setRefundCustomMode(false);
+    setRefundCustomDollars("");
+    setRefundPreset("full");
   }
 
   return (
@@ -1018,7 +1064,8 @@ function PaymentSection({
       )}
       {payment && payment.refundedCents > 0 && (
         <div className="ss-detail-payment-meta">
-          {formatPrice(payment.refundedCents, payment.currency)} refunded
+          {formatPrice(payment.refundedCents, payment.currency)} refunded of{" "}
+          {formatPrice(totalChargedCents, payment.currency)}
         </div>
       )}
 
@@ -1130,20 +1177,138 @@ function PaymentSection({
         </div>
       )}
 
-      {canRefund && (
+      {canRefund && !refundPickerOpen && (
         <button
           type="button"
           className="ss-btn ss-btn-ghost"
           disabled={submitting}
-          onClick={refund}
+          onClick={() => setRefundPickerOpen(true)}
         >
-          {submitting ? "Refunding…" : "Issue refund"}
+          Issue refund
         </button>
+      )}
+
+      {canRefund && refundPickerOpen && payment && (
+        <div className="ss-tip-picker">
+          <div className="ss-tip-presets">
+            {REFUND_PRESETS.map((p) => {
+              const presetCents = refundPresetCents(
+                p.key,
+                payment,
+                remainingRefundableCents,
+              );
+              const disabled = presetCents <= 0;
+              return (
+                <button
+                  key={p.key}
+                  type="button"
+                  className={`ss-tip-chip${
+                    !refundCustomMode && refundPreset === p.key ? " is-on" : ""
+                  }`}
+                  disabled={disabled}
+                  onClick={() => {
+                    setRefundCustomMode(false);
+                    setRefundPreset(p.key);
+                  }}
+                >
+                  <span className="ss-tip-chip-label">{p.label}</span>
+                  <span className="ss-tip-chip-amount">
+                    {formatPriceExact(presetCents, payment.currency)}
+                  </span>
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              className={`ss-tip-chip${refundCustomMode ? " is-on" : ""}`}
+              onClick={() => setRefundCustomMode(true)}
+            >
+              <span className="ss-tip-chip-label">Custom</span>
+            </button>
+          </div>
+          {refundCustomMode && (
+            <div className="ss-tip-custom">
+              <span>$</span>
+              <input
+                type="number"
+                inputMode="decimal"
+                min={0}
+                max={remainingRefundableCents / 100}
+                step="0.01"
+                placeholder="0.00"
+                value={refundCustomDollars}
+                onChange={(e) => setRefundCustomDollars(e.target.value)}
+                autoFocus
+              />
+            </div>
+          )}
+          <div className="ss-tip-summary">
+            <span>Refundable balance</span>
+            <span>
+              {formatPriceExact(
+                remainingRefundableCents,
+                payment.currency,
+              )}
+            </span>
+          </div>
+          <div className="ss-tip-summary is-total">
+            <span>Refund</span>
+            <span>
+              {formatPriceExact(refundAmountCents, payment.currency)}
+            </span>
+          </div>
+          <div className="ss-tip-actions">
+            <button
+              type="button"
+              className="ss-btn ss-btn-ghost"
+              onClick={() => setRefundPickerOpen(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="ss-btn ss-btn-primary"
+              onClick={refund}
+              disabled={submitting || !refundAmountValid}
+            >
+              {submitting
+                ? "Refunding…"
+                : `Refund ${formatPriceExact(refundAmountCents, payment.currency)}`}
+            </button>
+          </div>
+        </div>
       )}
 
       {errorMsg && <div className="ss-form-error">{errorMsg}</div>}
     </div>
   );
+}
+
+const REFUND_PRESETS: ReadonlyArray<{
+  key: RefundPresetKey;
+  label: string;
+}> = [
+  { key: "half", label: "50%" },
+  { key: "full", label: "100%" },
+  { key: "tip", label: "Just tip" },
+];
+
+type RefundPresetKey = "half" | "full" | "tip";
+
+// Stripe doesn't track which portion of a refund was "tip" vs "service",
+// so "Just tip" is a UX shortcut for the captured tip amount, capped by
+// what's actually still refundable. Both branches round to whole cents —
+// Stripe rejects fractional cents.
+function refundPresetCents(
+  key: RefundPresetKey,
+  payment: SchedulePayment,
+  remainingCents: number,
+): number {
+  if (remainingCents <= 0) return 0;
+  if (key === "full") return remainingCents;
+  if (key === "half") return Math.round(remainingCents / 2);
+  return Math.min(payment.tipCents, remainingCents);
 }
 
 function PaymentReturnBanner({
@@ -1175,6 +1340,18 @@ function formatPrice(cents: number, currency: string): string {
     style: "currency",
     currency,
     maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+// Refund flow shows cents whenever they're non-zero — operators picking a
+// partial amount need exactness, but whole-dollar presets stay clean.
+function formatPriceExact(cents: number, currency: string): string {
+  const showCents = cents % 100 !== 0;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: showCents ? 2 : 0,
+    maximumFractionDigits: showCents ? 2 : 0,
   }).format(cents / 100);
 }
 


### PR DESCRIPTION
## Summary

- Replace the single "Issue refund" button with an inline picker (preset chips: 50% / 100% / Just tip, plus a custom dollar input).
- Default selection is "100%" so a no-edit confirm refunds the full remaining balance, matching the prior single-button behavior.
- Confirm dialog now spells out the exact amount and the balance that will remain refundable.
- `refundPaymentAction` now plumbs an optional `amountCents` to `POST /payments/:id/refund`. When the picker selects the full remaining balance the action omits `amountCents` so the API still defaults to the remaining balance — avoids a rounding race if the refunded total shifts between render and submit.
- The refunded meta line now reads "$X refunded of $Y" so the remaining balance is visible.
- Adds a local `formatPriceExact` helper used by the refund flow only — partial amounts may have cents, and operators picking an exact amount need to see them.

Closes #31.

## Test plan

- [ ] Open a payment with a SUCCEEDED status — the "Issue refund" button still appears.
- [ ] Click "Issue refund" — picker opens with "100%" selected and the refund total equals the remaining refundable balance.
- [ ] Switch to "50%", "Just tip", and "Custom" — the refund total updates and the primary button label reflects the new amount.
- [ ] Confirm a partial refund — dialog reads e.g. "Refund $20.00 to the customer? $30.00 will remain refundable. This can't be undone from here."
- [ ] Confirm a full-remaining refund — dialog says "This will fully refund the payment".
- [ ] After a partial refund, status flips to PARTIALLY_REFUNDED, the refunded line shows "$X refunded of $Y", and the picker is hidden (API only allows refunds against SUCCEEDED).
- [ ] Custom dollar input rejects values that round above the remaining balance (Refund button disabled).