### PR TITLE
Phase 21a: deploy config for Railway (Dockerfiles + CI)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Build output
+**/node_modules
+**/dist
+**/.next
+**/.turbo
+**/.cache
+**/coverage
+**/*.tsbuildinfo
+
+# VCS / editor
+.git
+.gitignore
+.vscode
+.idea
+*.swp
+.DS_Store
+Thumbs.db
+
+# Local env — never bake secrets into an image
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+
+# Docs / planning that don't need to be in the build context
+.planning
+docs
+README.md
+ROADMAP.md
+
+# CI / deploy metadata
+.github
+**/railway.json
+
+# Docker
+Dockerfile
+**/Dockerfile
+.dockerignore
+docker-compose.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref so a quick re-push doesn't queue.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Several scripts use `dotenv -e ../../.env --` to load env vars; in CI
+      # we synthesize a minimal .env so those wrappers don't fail. The values
+      # only need to satisfy the env schema — no real services are touched.
+      - name: Synthesize CI .env
+        run: |
+          cat > .env <<'EOF'
+          DATABASE_URL=postgresql://ci:ci@localhost:5432/ci?schema=public
+          AUTH_PROVIDER=dev
+          DEV_AUTH_SECRET=ci-secret-do-not-use
+          DEV_USER_ID=00000000-0000-0000-0000-000000000001
+          DEV_USER_EMAIL=ci@shearsimp.test
+          DEV_SALON_ID=00000000-0000-0000-0000-0000000000a1
+          DEV_SALON_SLUG=ci-salon
+          MESSAGING_PROVIDER=dev
+          PAYMENT_PROVIDER=dev
+          EOF
+
+      - name: Generate Prisma client
+        run: pnpm db:generate
+
+      - name: Build workspace packages
+        # Compiles @shearsimp/shared and @shearsimp/db so cross-package
+        # imports resolve during typecheck and test below.
+        run: pnpm --filter @shearsimp/shared --filter @shearsimp/db build
+
+      - name: Validate Prisma schema
+        run: pnpm db:validate
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,6 +322,41 @@ Twilio Voice + OpenAI Realtime. Same tools, narrower scope.
 
 ---
 
+## Phase 21 — Production deployment 🚧
+
+Stand up `app.shearscheduling.com` (real salon) on Railway. Demo deployment
+follows in a later sub-phase.
+
+### Phase 21a — Deploy config 🚧
+
+- Multi-stage Dockerfiles for `apps/api` (also serves the worker) and
+  `apps/web` (Next.js standalone output)
+- Per-service Railway configs at the repo root (`railway.api.json`,
+  `railway.worker.json`, `railway.web.json`)
+- `prisma migrate deploy` as the API service's `preDeployCommand` so schema
+  changes apply once per deploy, before the new container takes traffic
+- GitHub Actions CI on every PR: pnpm install → Prisma generate → schema
+  validate → typecheck → test
+- `docs/deployment.md` documents the Railway setup, env vars per service,
+  DNS/Cloudflare flow, and webhook URLs to wire once `api.shearscheduling.com`
+  resolves
+
+### Phase 21b — Real-salon prod environment ⬜
+
+- Cloudflare DNS for `shearscheduling.com`
+- Clerk production org, real LLC's Stripe live keys, Sentry projects
+- First Railway project deployed; smoke test booking → Stripe checkout
+- Webhook wiring (Clerk, Stripe, Twilio when A2P clears)
+
+### Phase 21c — Demo deployment ⬜
+
+- Second Railway project on `demo.shearscheduling.com`
+- `PAYMENT_PROVIDER=dev` so demo never touches live Stripe
+- Seed script for the demo salon (synthetic clients, services, appointments)
+- Nightly cron resets demo data
+
+---
+
 ## Backlog (unscheduled)
 
 Things to remember but not commit to yet. Deferred work *from* a phase

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.7
+#
+# Image for both the Nest HTTP API service and the outbox worker service.
+# On Railway both services run this image; the API service sets
+# OUTBOX_WORKER_DISABLED=true, the worker leaves it unset.
+
+FROM node:22-slim AS base
+# node:22-slim matches Prisma's default `debian-openssl-3.0.x` binary target,
+# so packages/db/prisma/schema.prisma needs no binaryTargets entry. The query
+# engine still links against libssl at runtime — install it explicitly because
+# the slim image doesn't ship with it.
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends openssl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+WORKDIR /repo
+
+
+FROM base AS build
+# Lockfile + workspace manifests first, so `pnpm install` is cached on the
+# lockfile alone and only re-runs when dependencies actually change.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc tsconfig.base.json ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/db/package.json packages/db/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# Source for everything the API needs (web is excluded).
+COPY packages/shared packages/shared
+COPY packages/db packages/db
+COPY apps/api apps/api
+
+# Generate the Prisma client (writes into node_modules/.prisma) and build
+# the workspace in dependency order: shared → db → api.
+RUN pnpm --filter @shearsimp/db exec prisma generate \
+ && pnpm --filter @shearsimp/shared build \
+ && pnpm --filter @shearsimp/db build \
+ && pnpm --filter @shearsimp/api build
+
+
+FROM base AS runtime
+ENV NODE_ENV=production
+# Copy the entire built workspace. pnpm uses symlinks for workspace packages
+# (apps/api/node_modules/@shearsimp/db → ../../packages/db); copying the tree
+# as a single unit preserves them. The image is larger than a hand-pruned
+# variant but the tradeoff isn't worth the maintenance cost at this stage.
+COPY --from=build /repo /repo
+WORKDIR /repo/apps/api
+EXPOSE 3001
+CMD ["node", "dist/main.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.7
+#
+# Image for the Next.js admin web app. Uses Next 15's standalone output so the
+# runtime image only contains the server bundle Next traced as reachable —
+# not the full pnpm workspace.
+
+FROM node:22-slim AS base
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+WORKDIR /repo
+
+
+FROM base AS build
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc tsconfig.base.json ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/db/package.json packages/db/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# The web build only needs @shearsimp/shared from the workspace.
+COPY packages/shared packages/shared
+COPY apps/web apps/web
+
+# Build-time env. Next 15 collects page data during `next build`, which
+# evaluates `serverEnv` at module load — so any required vars must be present
+# even though the runtime container will set them again. NEXT_PUBLIC_* vars
+# are also inlined into the client bundle here, so the real Clerk publishable
+# key MUST be passed as a build ARG (Railway: Service → Variables → Build
+# Variables). Anything not NEXT_PUBLIC_ can stay as a dummy and be overridden
+# at runtime.
+ARG AUTH_PROVIDER=clerk
+# Clerk validates the publishable key's base64 structure during `next build`,
+# so the placeholder must be a parseable test-mode key. This one decodes to
+# `clerk.placeholder.lcl.dev$` and is harmless — it doesn't authenticate
+# against any real Clerk tenant. Always override at build time in Railway
+# (Service → Variables → Build Variables) with the real publishable key.
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y2xlcmsucGxhY2Vob2xkZXIubGNsLmRldiQ
+ARG NEXT_PUBLIC_API_URL=http://localhost:3001
+ENV AUTH_PROVIDER=${AUTH_PROVIDER}
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV CLERK_SECRET_KEY=sk_build_placeholder
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN pnpm --filter @shearsimp/shared build \
+ && pnpm --filter @shearsimp/web build
+
+
+FROM node:22-slim AS runtime
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+WORKDIR /app
+
+# Next 15 standalone output writes a self-contained server tree at
+# apps/web/.next/standalone (with the workspace root preserved). Static
+# assets and the public/ dir are not included automatically.
+COPY --from=build /repo/apps/web/.next/standalone ./
+COPY --from=build /repo/apps/web/.next/static ./apps/web/.next/static
+# public/ doesn't exist today but Next will look for it; create it in the
+# build stage if assets land there later.
+
+EXPOSE 3000
+# The standalone bundle puts server.js inside the app's own directory.
+WORKDIR /app/apps/web
+CMD ["node", "server.js"]

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -4,6 +4,10 @@ const nextConfig = {
   transpilePackages: ["@shearsimp/shared"],
   // typedRoutes graduated out of `experimental` in Next 15.4.
   typedRoutes: true,
+  // Standalone output writes a self-contained server bundle to
+  // .next/standalone, which the production Dockerfile copies into a slim
+  // runtime image. Local `next dev` / `next start` are unaffected.
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,121 @@
+# Deployment
+
+ShearSimplicity runs on **Railway**. The same image artifacts deploy to two
+separate Railway projects:
+
+- **`app.shearscheduling.com`** — real salon. Live Stripe, live Clerk, real
+  client data.
+- **`demo.shearscheduling.com`** — recruiter-facing demo. Stripe test mode,
+  seeded data, nightly reset cron (planned).
+
+Each project has its own Postgres + Redis. The two never share infrastructure.
+
+## Services per project
+
+| Service | Image            | Public | Notes                                        |
+|---------|------------------|--------|----------------------------------------------|
+| `api`   | `apps/api/Dockerfile` | yes    | Nest HTTP API. `OUTBOX_WORKER_DISABLED=true`. |
+| `worker`| `apps/api/Dockerfile` | no     | Outbox poller. Same image, worker enabled.    |
+| `web`   | `apps/web/Dockerfile` | yes    | Next.js admin app, standalone output.         |
+| `postgres` | Railway plugin     | no     | Postgres 16. Injects `DATABASE_URL` to `api`/`worker`. |
+| `redis` | Railway plugin     | no     | Redis 7. Injects `REDIS_URL` (used once outbox migrates to BullMQ). |
+
+The API and worker share `apps/api/Dockerfile`. They differ only in environment
+variables — the API sets `OUTBOX_WORKER_DISABLED=true`, the worker leaves it
+unset.
+
+## Per-service Railway config
+
+Three `railway.*.json` files at the repo root declare each service's build /
+start. In the Railway dashboard, point each service at its config file via the
+**Config-as-code Path** setting:
+
+| Service | Config file              |
+|---------|--------------------------|
+| `api`   | `railway.api.json`       |
+| `worker`| `railway.worker.json`    |
+| `web`   | `railway.web.json`       |
+
+The API config also runs `prisma migrate deploy` as a `preDeployCommand` so
+schema changes apply once per deploy, before the new container takes traffic.
+The worker doesn't need it (the API already migrated).
+
+## Environment variables
+
+Set per service in the Railway dashboard. `DATABASE_URL` and `REDIS_URL` are
+injected automatically by the plugins — don't hand-paste them.
+
+### `api` and `worker`
+
+| Var                              | Value                                              |
+|----------------------------------|----------------------------------------------------|
+| `NODE_ENV`                       | `production`                                       |
+| `API_PORT`                       | `3001` (Railway exposes via `PORT`; see note)      |
+| `WEB_ORIGIN`                     | `https://app.shearscheduling.com`                  |
+| `DATABASE_URL`                   | (injected)                                         |
+| `AUTH_PROVIDER`                  | `clerk`                                            |
+| `CLERK_SECRET_KEY`               | from Clerk dashboard → API Keys                    |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | from Clerk dashboard                            |
+| `CLERK_WEBHOOK_SECRET`           | from Clerk dashboard → Webhooks → Signing Secret   |
+| `MESSAGING_PROVIDER`             | `dev` until A2P 10DLC clears, then `twilio`        |
+| `TWILIO_ACCOUNT_SID`             | from Twilio (when enabled)                         |
+| `TWILIO_AUTH_TOKEN`              | from Twilio (when enabled)                         |
+| `TWILIO_FROM_NUMBER`             | salon's E.164 number (when enabled)                |
+| `TWILIO_WEBHOOK_PUBLIC_URL`      | `https://api.shearscheduling.com`                  |
+| `PAYMENT_PROVIDER`               | `stripe`                                           |
+| `STRIPE_SECRET_KEY`              | live key from Stripe dashboard                     |
+| `STRIPE_WEBHOOK_SECRET`          | from Stripe → Developers → Webhooks → Signing      |
+| `OUTBOX_WORKER_DISABLED`         | `api`: `true`. `worker`: leave unset.              |
+
+### `web`
+
+| Var                                  | Value                              |
+|--------------------------------------|------------------------------------|
+| `NODE_ENV`                           | `production`                       |
+| `NEXT_PUBLIC_API_URL`                | `https://api.shearscheduling.com`  |
+| `API_INTERNAL_URL`                   | (Railway internal: `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:3001`) |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`  | from Clerk                         |
+| `CLERK_SECRET_KEY`                   | from Clerk                         |
+
+## DNS + custom domains
+
+Cloudflare hosts DNS for `shearscheduling.com`. Each Railway service that
+needs a public URL gets a custom domain in the Railway dashboard:
+
+- `app.shearscheduling.com` → web service
+- `api.shearscheduling.com` → api service
+
+Railway generates a CNAME target; add it in Cloudflare with proxy disabled
+(grey cloud) so Railway can issue its own TLS certificate.
+
+## Webhook URLs
+
+Once `api.shearscheduling.com` resolves and TLS is live:
+
+- **Clerk** → `https://api.shearscheduling.com/webhooks/clerk`
+  Use a fresh signing secret per environment.
+- **Stripe** → `https://api.shearscheduling.com/webhooks/stripe`
+  Subscribe to `checkout.session.completed`, `payment_intent.payment_failed`,
+  `charge.refunded`. Fresh signing secret per environment.
+- **Twilio** → `https://api.shearscheduling.com/webhooks/twilio/sms`
+  Configured per number under Phone Numbers → your number → Messaging →
+  *A message comes in*.
+
+## First deploy
+
+1. Create the Railway project, attach Postgres + Redis plugins.
+2. Add the three services from the GitHub repo, set each one's config-as-code
+   path per the table above.
+3. Paste the env vars per service.
+4. Trigger a deploy — Railway runs `prisma migrate deploy` before the API
+   takes traffic.
+5. Smoke test: `curl https://api.shearscheduling.com/health` should return
+   `{ "status": "ok", "db": "up" }`.
+6. Sign in via Clerk on `app.shearscheduling.com`, create the first salon,
+   wire the webhooks above.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on every PR to `main`:
+typecheck, Prisma schema validate, all package tests. Railway watches the
+`main` branch and auto-deploys on push.

--- a/railway.api.json
+++ b/railway.api.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/api/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node dist/main.js",
+    "preDeployCommand": "pnpm --filter @shearsimp/db exec prisma migrate deploy",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.web.json
+++ b/railway.web.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/web/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node server.js",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/railway.worker.json
+++ b/railway.worker.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/api/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node dist/main.js",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary

First piece of Phase 21 (production deployment). No runtime behavior changes — purely the deploy plumbing so the next sub-phase can stand up `app.shearscheduling.com` on Railway.

- **Dockerfiles** — multi-stage Node 22 + pnpm 9 for both `apps/api` and `apps/web`. The API image also serves the outbox worker (same image, worker enabled via env). Web uses Next 15's `output: "standalone"` for a slim runtime image.
- **Railway configs** — three per-service files at the repo root (`railway.api.json`, `railway.worker.json`, `railway.web.json`). The API's config runs `prisma migrate deploy` as a `preDeployCommand` so schema changes apply once per deploy, before traffic routes.
- **GitHub Actions CI** — runs `pnpm install` → `prisma generate` → schema validate → typecheck → tests on every PR. Matches the working-agreement checks in `ROADMAP.md`.
- **`docs/deployment.md`** — Railway service layout, env vars per service, DNS/Cloudflare flow, webhook URLs to wire once `api.shearscheduling.com` resolves.

## Notes for whoever stands up Railway (= me, soon)

- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `NEXT_PUBLIC_API_URL` must be set as **build variables** on the web service (Service → Variables → Build Variables), not just runtime — Next inlines them at `next build` time.
- The API and worker services share `apps/api/Dockerfile`. The API sets `OUTBOX_WORKER_DISABLED=true`, the worker leaves it unset.
- The Dockerfiles ship a Clerk-format placeholder publishable key so local `docker build` smoke tests succeed without a real tenant. Railway always overrides at build time with the real key.

## Test plan

- [x] `docker build -f apps/api/Dockerfile .` succeeds
- [x] `docker build -f apps/web/Dockerfile .` succeeds
- [x] API container resolves the workspace symlinks across the runtime stage copy (`require('@shearsimp/db')` works)
- [x] Web container boots Next standalone on port 3000
- [ ] CI workflow goes green on this PR (verify after push)
- [ ] Phase 21b: actually create the Railway project and deploy